### PR TITLE
add ESLint 6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "no-prototype-builtins": "off",
+        "linebreak-style": "off",
+        "indent": [
+            "error",
+            4,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "comma-spacing": "off",
+        "no-shadow": "off",
+        "space-before-function-paren": "off",
+        "id-length": "off",
+        "dot-notation": "off"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-register": "^6.26.0",
     "browser-sync": "^2.18.13",
     "cssnano": "^3.10.0",
+    "eslint": "^6.8.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^7.0.0",
     "gulp-clean": "^0.3.2",


### PR DESCRIPTION
I tried to add ESLint and a configuration that doesn't change the current style of the gear optimizer js. I assume the react site uses more up to date style(?) so presumably eventually we'll want to update that.

Because I could only get this project to work with Node 8, I could also only get ESLint 6 to work.