### PR TITLE
Refactor: Define base stats; remove random ifs, store uncapped durations

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ var src = {
 		base.src + 'js/vendor/bootstrap/tooltip.js',
 		base.src + 'js/vendor/bootstrap/tab.js',
 		base.assets + dist.js
-	],
+	],	
 	js: [base.src + 'js/discretize.js'],
 	gojs: [base.src + 'js/gear-optimizer.js'],
 	scss: base.src + 'scss/*.scss'
@@ -108,12 +108,12 @@ gulp.task('dl', function() {
 ================================================== */
 gulp.task('img', function(){
 	return gulp.src(src.img)
-		// .pipe(imagemin([
-		// 	imagemin.gifsicle({interlaced: true}),
-		// 	imagemin.jpegtran({progressive: true}),
-		// 	imagemin.optipng({optimizationLevel: 5})
-		// ]))
-		// 	.on('error', swallowError)
+		.pipe(imagemin([
+			imagemin.gifsicle({interlaced: true}),
+			imagemin.jpegtran({progressive: true}),
+			imagemin.optipng({optimizationLevel: 5})
+		]))
+			.on('error', swallowError)
 		.pipe(gulp.dest(dist.img));
 });
 
@@ -149,7 +149,7 @@ gulp.task('html', function(){
 			removeScriptTypeAttributes: true,
 			removeStyleLinkTypeAttributes: true,
 			trimCustomFragments: true,
-			useShortDoctype: true
+			useShortDoctype: true			
 		}))
 			.on('error', swallowError)
 		.pipe(gulp.dest(base.dist));
@@ -188,8 +188,8 @@ gulp.task('gojs', function(){
 			.on('error', swallowError)
 		.pipe(concat(dist.gojs))
 			.on('error', swallowError)
-		// .pipe(uglify())
-		// 	.on('error', swallowError)
+		.pipe(uglify())
+			.on('error', swallowError)
 		.pipe(gulp.dest(base.assets))
 });
 


### PR DESCRIPTION
This refactor:

Defines base stats explicitly as e.g. 1000 toughness, 0 power, etc. This removes the need to constantly check whether base stats exist and the complicated logic involved with doing so. This is done via a `_character.baseAttributes` object that can be simply shallow cloned. This fixes some bugs with having 0 of a stat, and replaces some modifiers with simple `+=` statements.

Resolves #1; resolves #2

Eventually I want to stop deep cloning `character`s completely. A `character` can just be a reference to an immutable `baseCharacter` with all the class/trait/modifier/etc info and a plain old javascript object `gear` with what stat each piece is. This should increase performance and reduce complexity.

---

Stores condition and boon durations and critical chance as uncapped (i.e. can be above 100%), then caps them at 100% when they are actually used. This allows the uncapped values to be shown in the modal menu.

Resolves #31 

---

Applies conversion buffs all at once rather than sequentially by calculating all conversions on a saved version of the attribute totals. This is, as far as I know, more accurate.