### PR TITLE
Performance improvement progress: shallow copy characters

### DIFF
--- a/src/js/gear-optimizer.js
+++ b/src/js/gear-optimizer.js
@@ -1560,7 +1560,12 @@ let Optimizer = function ($) {
     };
 
     let clone = function(character) {
-        return $.extend(true, {}, character);
+        let newBaseAttributes = Object.assign({}, character.baseAttributes);
+        let newInfusions = Object.assign({}, character.infusions);
+        let newGear = Object.assign({}, character.gear);
+
+        // return { ...character, baseAttributes: newBaseAttributes, infusions: newInfusions, gear: newGear};
+        return Object.assign({}, character, {baseAttributes: newBaseAttributes, infusions: newInfusions, gear: newGear});
     };
 
     // Generates the card, that shows up when one clicks on the result.


### PR DESCRIPTION
Previously, the code used jQuery `extend` to repeatedly make deep copies of the `character` object despite almost none of it being changed during the calculation process.

I've reduced the important mutable properties of `character` down to `gear`, `baseAttributes`, and `infusions` - everything else can be stored in `baseCharacter` and be passed by reference, greatly reducing the amount of copying. 

This is more than a 2x speedup in most cases, according to some casual testing.

(to do: refactor further so that it is clear to the developer which pieces of data are immutable)