### PR TITLE
Performance improvement progress: optimize applyGear and skip unused condi calcs

### DIFF
--- a/src/js/gear-optimizer.js
+++ b/src/js/gear-optimizer.js
@@ -1150,7 +1150,9 @@ let Optimizer = function ($) {
             let {settings} = _optimizer;
 
             try {
-                let cycles = 2000;
+                // pause more frequently to update progress bar/allow cancellation if needed
+                let cycles = Math.min(Math.ceil(_optimizer.calculationTotal * 3 / 5), settings.secondaryInfusion ? 4000 : 8000);
+
                 while (_optimizer.calculationQueue.length && cycles--) {
                     if (STOP_SIGNAL) {
                         throw 0;
@@ -1211,6 +1213,7 @@ let Optimizer = function ($) {
                     let percent = Math.floor(_optimizer.calculationRuns * 100 / _optimizer.calculationTotal);
                     $(Selector.OUTPUT.PROGRESS_BAR).css('width', percent + '%').find(Selector.SPAN).text(percent
                         + '%');
+                    //console.log(`${percent}%: ${_optimizer.calculationRuns}/${_optimizer.calculationTotal}`);
 
                     setTimeout(_optimizer._advanceCalculation.bind(_optimizer), 0);
                 } else {


### PR DESCRIPTION
We're up to ~8x speedup now.

This calculates the stats from gear by keeping a running tally during the generation of the different gear setups, avoiding the need to iterate though it again later.

It adds a flag to updateAttributes that, when in the optimization process, skips steps like calculating condition damage when you don't have any conditions selected.

It also increases the  `cycles` variable, doing more work between UI refreshes, which was consuming a lot of performance in scenarios where there are lots of gear types selected but no infusions.