### PR TITLE
Add boxes to force gear, attempt two

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1909,9 +1909,7 @@
                                 class="fa fa-question-circle"
                                 data-toggle="tooltip"
                                 title="Force gear slots to a certain affix by typing a few
-                                  characters of the desired affix. You must use the duplicate-stat
-                                  spots (shoulders/boots/gloves, rings, accessories) from left to
-                                  right."
+                                  characters of the desired affix."
                               ></span>
                             </div>
                             <div class="card-body container p-0">
@@ -1943,7 +1941,6 @@
                                   type="text"
                                   maxlength="4"
                                   placeholder="glov"
-                                  disabled
                                 />
                                 <input
                                   class="col-2 col-lg-1 form-control"
@@ -1958,7 +1955,6 @@
                                   type="text"
                                   maxlength="4"
                                   placeholder="boot"
-                                  disabled
                                 />
                                 <input
                                   class="col-2 col-lg-1 form-control"
@@ -1980,7 +1976,6 @@
                                   type="text"
                                   maxlength="4"
                                   placeholder="rng2"
-                                  disabled
                                 />
                                 <input
                                   class="col-2 col-lg-1 form-control"
@@ -1995,7 +1990,6 @@
                                   type="text"
                                   maxlength="4"
                                   placeholder="acc2"
-                                  disabled
                                 />
                                 <input
                                   class="col-2 col-lg-1 form-control"

--- a/src/js/gear-optimizer.js
+++ b/src/js/gear-optimizer.js
@@ -1308,17 +1308,7 @@ const Optimizer = function ($) {
 
             || (!settings.forcedArmor && nextSlot === 6
               && (gear[1] > gear[3] || gear[3] > gear[5]))
-
-          // // Rings/Accs/Weapons
-          // ((nextSlot === 9 || nextSlot === 11 || nextSlot === 14)
-          //   && gear[nextSlot - 2] > gear[nextSlot - 1])
-          // // Shoulders/Gloves/Boots
-          // || (nextSlot === 6 && (gear[1] > gear[3] || gear[3] > gear[5]))
           ) {
-            // let skippedRuns = 1;
-            // for (let i = nextSlot; i < settings.affixesArray.length; i++) {
-            //   skippedRuns *= settings.affixesArray[i].length;
-            // }
             _optimizer.calculationRuns += settings.runsAfterThisSlot[nextSlot];
             continue;
           }
@@ -2367,31 +2357,6 @@ const Optimizer = function ($) {
         break;
     }
   });
-
-  /**
-   * Default-disabled gear force boxes
-   *
-   * The optimizer deduplicates the shoulder/glove/boot triplet and the ring, accessory, and weapon
-   * combos. If forcing one of these items to a specific stat, one must use the leftmost item of
-   * these combos first, otherwise some combinations get skipped.
-   */
-  const duplicateForceIds = [
-    ['shld', 'glov'],
-    ['glov', 'boot'],
-    ['shld', 'boot'],
-    ['rng1', 'rng2'],
-    ['acc1', 'acc2']
-  ];
-
-  for (const [first, second] of duplicateForceIds) {
-    $(Selector.INPUT.FORCE + first).keyup(function () {
-      if ($(this).val()) {
-        $(Selector.INPUT.FORCE + second).prop('disabled', false);
-      } else {
-        $(Selector.INPUT.FORCE + second).val('').prop('disabled', true);
-      }
-    });
-  }
 
   // Calculate button
   $(Selector.START).on(Event.CLICK, function () {


### PR DESCRIPTION
Well, this was rather complicated.

This adds input boxes to force certain gear positions to a certain affix. It:

- makes the selected affix into a 2d array, so the iteration process only iterates on valid affixes during each step
- rewrites `calculationTotal` to take this into account (but not to account for deduplication)
- makes the deduplication increment `calculationRuns` as if it did not skip anything (to account for the previous thing)
- skips the deduplication step if the user has forced one of the items that could have been a duplicate to a certain affix
- gives me a headache. I hope no one ever has to fix or rewrite this code (probably will, though)

I think it works. Probably.