### PR TITLE
Rewrite infusions

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2053,7 +2053,7 @@
               </div>
             </div>
             <p class="last-updated">
-              Last updated: July 15, 2021
+              Last updated: July 16, 2021
               <br />
               Want to open the <a href="https://discretize.eu">main page</a>?
               <br />

--- a/src/js/gear-optimizer.js
+++ b/src/js/gear-optimizer.js
@@ -1456,15 +1456,8 @@ const Optimizer = function ($) {
       for (const stat in gearStats) {
         character.baseAttributes[stat] += gearStats[stat];
       }
-      // $.each(gear, function (index, affix) {
-      //     $.each(Slots[character.settings.weapontype][index].item[Affix[affix].type], function (type, bonus) {
-      //         $.each(Affix[affix].bonuses[type], function (index, stat) {
-      //         for (let stat of Affix[affix].bonuses[type]) {
-      //             character.baseAttributes[stat] = (character.baseAttributes[stat] || 0) + bonus;
-      //         }
-      //     });
-      // });
 
+      // _applyInfusions is aliased to the correct _applyInfusions[mode] function during setup
       _optimizer._applyInfusions(character);
     };
 


### PR DESCRIPTION
This:
- allows for arbitrary infusion choices instead of having to select pairs from a single dropdown menu
- allows a limit on the maximum number of each infusion used (i.e. "I don't want to use more than 6 precision infusions") 
- shows builds with the same attributes in each slot, but different infusions (see: https://discord.com/channels/301270513093967872/842629146857177098/857742939698757652), with a checkbox to not do so as was previously implemented

resolves #62 , resolves #74, resolves #75