### PR TITLE
shuffle affixes

### DIFF
--- a/src/js/gear-optimizer.js
+++ b/src/js/gear-optimizer.js
@@ -1161,6 +1161,22 @@
         }
       }
 
+      // rearrange affixes so you don't always start with e.g. full berserker. Example:
+      // [vipe sini grie] helm
+      // [grie vipe sini] shld
+      // [sini grie vipe] coat
+      // [vipe]           glov (forced to viper)
+      // [grie vipe sini] legs
+      // ...
+      settings.affixesArray = settings.affixesArray.map((affixes, slotindex) => {
+        if (affixes.length === 1) return affixes;
+        return affixes.reduce((newAffixes, affix, i) => {
+          newAffixes[(i + slotindex) % affixes.length] = affix;
+          return newAffixes;
+        }, []);
+      });
+      // console.log(settings.affixesArray.map(item => item.toString()));
+
       // like affixesArray, but each entry is an array of arrays of stats given by that piece with
       // that affix
       // e.g. berserker helm -> [[Power, 63],[Precision, 45],[Ferocity, 45]]


### PR DESCRIPTION
Bit surprised this works, tbh. Don't have a great handle on what's going on mathematically, but basically this just shuffles the affixes around on a per-slot basis, so all the same combinations get evaluated, but it starts from and ends with an even mix of the gear types, and full berserker isn't always at the beginning/full assassin isn't always at the end.

It's a slight/inconsistent performance gain, but what's cool is, it means you usually get your first result a lot faster if you select like 4 affixes.

Had to think about it a bit, but this doesn't break deduplication.

resolves #84