### PR TITLE
experiment: move looping logic out of optimizercore

### DIFF
--- a/src/js/gear-optimizer.js
+++ b/src/js/gear-optimizer.js
@@ -2721,6 +2721,7 @@
     run().catch(e => {
       alert('There was an error in the calculation!\n\n' + e);
       console.log('Caught error in calculation:');
+      lockUI(false);
       throw e;
     });
   });


### PR DESCRIPTION
so I finally read and understood the documentation on js generator *functions and it was too neat not to try out

this uses `yield` in the optimizer loop instead of `await setTimeout 0`, moving the management of the loop outside of the optimizer core

this could enable a resume button that the actual optimizer doesn't know or care about

also I bothered to move insertcharacter to the area with the other dom stuff