### PR TITLE
minor build script change to support es6 modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -301,7 +301,7 @@ const js = series(customjs, vendorjs);
 const gojs = function () {
 	return gulp.src(src.gojs)
 		.pipe(babel({
-			presets: [ '@babel/preset-env' ]
+			presets: [['@babel/preset-env', { 'modules': false }]]
 		}))
 			.on('error', swallowError)
 		.pipe(concat(dist.gojs))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": "10"
   },
   "browserslist": [
-    "defaults and supports wasm"
+    "defaults and supports es6-module"
   ],
   "dependencies": {}
 }


### PR DESCRIPTION
just so I don't have to deal with the diff later honestly

no longer supports opera mini, but I can't imagine that worked in the first place