### PR TITLE
remove $.each

### DIFF
--- a/src/js/OptimizerCore.js
+++ b/src/js/OptimizerCore.js
@@ -136,16 +136,16 @@ export function setup (listInput, input) {
   ];
 
   modifiersInput = modifiersInput || [];
-  modifiersInput.forEach(modifiers => {
+  for (const modifiers of modifiersInput) {
     if (!modifiers) {
-      return;
+      continue;
     }
-    Object.entries(modifiers).forEach(([type, modifier]) => {
+    for (const [type, modifier] of Object.entries(modifiers)) {
       if (type && modifier !== undefined) {
         if (type === 'bountiful-maintenance-oil') {
           settings.modifiers[type] = modifier;
         } else {
-          Object.entries(modifier).forEach(([attribute, value]) => {
+          for (const [attribute, value] of Object.entries(modifier)) {
             if (attribute && value) {
               switch (type) {
                 case 'multiplier':
@@ -198,10 +198,10 @@ export function setup (listInput, input) {
                       settings.modifiers['convert'][attribute] = {};
                     }
 
-                    Object.entries(value).forEach(([source, conversion]) => {
+                    for (const [source, conversion] of Object.entries(value)) {
                       settings.modifiers['convert'][attribute][source]
                         = (settings.modifiers['convert'][attribute][source] || 0) + conversion;
-                    });
+                    }
                   } else {
                     throw new Error(
                       'Conversions can only modify primary or secondary attributes, not '
@@ -211,11 +211,11 @@ export function setup (listInput, input) {
                 // no default
               }
             }
-          });
+          }
         }
       }
-    });
-  });
+    }
+  }
   settings.modifiers['multiplier']['Effective Condition Damage']
     *= (1 + addEffectiveConditionDamage);
   settings.modifiers['multiplier']['Effective Power']
@@ -238,9 +238,9 @@ export function setup (listInput, input) {
     const { Power, ...rest } = input.percentDistribution;
     settings.distribution = {};
     settings.distribution['Power'] = Power / 1025;
-    Object.entries(rest).forEach(([condition, value]) => {
+    for (const [condition, value] of Object.entries(rest)) {
       settings.distribution[condition] = value / Condition[condition].baseDamage;
-    });
+    }
   }
 
   /* Infusions */
@@ -363,11 +363,11 @@ export function setup (listInput, input) {
     return possibleAffixes.map(affix => {
       const statTotals = {};
       const bonuses = Object.entries(settings.slots[slotindex].item[Affix[affix].type]);
-      bonuses.forEach(([type, bonus]) => {
+      for (const [type, bonus] of bonuses) {
         for (const stat of Affix[affix].bonuses[type]) {
           statTotals[stat] = (statTotals[stat] || 0) + bonus;
         }
-      });
+      }
       return Object.entries(statTotals);
     });
   });
@@ -823,17 +823,15 @@ function calcStats (_character) {
   _character.attributes = Object.assign({}, _character.baseAttributes);
   const { attributes } = _character;
 
-  _character.settings.modifiers['convert'].forEach(([attribute, conversion]) => {
-    conversion.forEach(([source, percent]) => {
-      attributes[attribute] += roundEven(
-        _character.baseAttributes[source] * percent
-      );
-    });
-  });
+  for (const [attribute, conversion] of _character.settings.modifiers['convert']) {
+    for (const [source, percent] of conversion) {
+      attributes[attribute] += roundEven(_character.baseAttributes[source] * percent);
+    }
+  }
 
-  _character.settings.modifiers['buff'].forEach(([attribute, bonus]) => {
+  for (const [attribute, bonus] of _character.settings.modifiers['buff']) {
     attributes[attribute] = (attributes[attribute] || 0) + bonus;
-  });
+  }
 
   attributes['Boon Duration'] += attributes['Concentration'] / 15;
 }


### PR DESCRIPTION
This replaces `$.each(item, function (key, value) {` with `for (const [key, value] of Object.entries(item)) {`

Then, because why not, it moves the `Object.entries` calls for buffs and conversions out of the loop.

This is apparently a ~30% performance gain.

forEach works just as well (same performance), but I like the loop construct better than callbacks, and this way gives access to `break` while the other one doesn't.