### PR TITLE
remove ghost mode from browsersync

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -390,7 +390,8 @@ const sync = function (done) {
 	browserSync.init({
 		server: {
 			baseDir: base.dist
-		}
+		},
+    ghostMode: false
 	});
     done();
 };


### PR DESCRIPTION
was wondering why my test window keeps jumping around