### PR TITLE
add unique ids to inserted character objects

### DIFF
--- a/src/js/OptimizerCore.js
+++ b/src/js/OptimizerCore.js
@@ -681,6 +681,7 @@ applyInfusions['SecondaryNoDuplicates'] = function (character) {
   }
 };
 
+let uniqueIDCounter = 0;
 function insertCharacter (character) {
   const { settings } = character;
 
@@ -691,6 +692,8 @@ function insertCharacter (character) {
   ) {
     return;
   }
+
+  character.id = uniqueIDCounter++;
 
   if (list.length === 0) {
     list.push(character);


### PR DESCRIPTION
List items in React need unique IDs so it can shuffle them around, so this just increments a value every time it inserts one into the list.

This will subtly corrupt the React UI after `MAX_SAFE_INTEGER` = 9 quadrillion inserted characters before a page reload, which Wolfram Alpha helpfully tells me would take approximately 1 million years of calculation time to hit during a typical calculation.
