### PR TITLE
core: mutate list internally

### DIFF
--- a/src/js/OptimizerCore.js
+++ b/src/js/OptimizerCore.js
@@ -47,9 +47,9 @@ let isChanged = true;
  *
  * @returns {Object} settings - parsed settings object
  */
-export function setup (listInput, input) {
+export function setup (input) {
   worstScore = undefined;
-  list = listInput;
+  list = [];
 
   let {
     modifiers: modifiersInput,
@@ -451,7 +451,8 @@ export function * calculate (settings) {
     if ((cycles % 1000 === 0) && Date.now() - iterationTimer > UPDATE_MS) {
       yield {
         isChanged,
-        percent: Math.floor((calculationRuns * 100) / calculationTotal)
+        percent: Math.floor((calculationRuns * 100) / calculationTotal),
+        newList: isChanged ? list.slice() : null
       };
       isChanged = false;
       UPDATE_MS = 55;
@@ -516,7 +517,11 @@ export function * calculate (settings) {
     calculationQueue.push(gear);
     calculationStatsQueue.push(gearStats);
   }
-  return Math.floor((calculationRuns * 100) / calculationTotal);
+  return {
+    isChanged,
+    percent: Math.floor((calculationRuns * 100) / calculationTotal),
+    newList: list.slice()
+  };
 }
 
 function testCharacter (gear, gearStats, settings) {


### PR DESCRIPTION
Instead of having the core take a list as an argument and mutate that list, this makes the core calculate next() function yield a new list object if there have been any changes.

This matches how react expects state changes (as immutable objects), and the non-react codebase's new updateDOM function from #133 doesn't really care either way. (It's effectively a virtual DOM like react anyways.)

Apparently this is a slight performance gain. No idea why. I'll take it.

resolves #158 