### PR TITLE
add react hooks eslint plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     "ignorePatterns": [
         "gulpfile.js"
     ],
-    "extends": ["standard", "standard-jsx", "standard-react", "prettier"],
+    "extends": ["standard", "standard-jsx", "standard-react", "prettier", "plugin:react-hooks/recommended"],
     "rules": {
         "semi": [
             "error", 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.0.0",
-    "eslint-plugin-react": "^7.21.5"
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react-hooks": "^4.2.0"
   }
 }


### PR DESCRIPTION
apparently standard-react doesn't have the hooks plugin for some reason