### PR TITLE
Fix: affix rearranging breaks everything

### DIFF
--- a/src/js/optimizer-core.js
+++ b/src/js/optimizer-core.js
@@ -396,7 +396,7 @@ export function setup(input) {
       return affixes;
     }
     const result = [];
-    for (const [index, affix] of Object.entries(affixes)) {
+    for (const [index, affix] of affixes.entries()) {
       result[(index + slotindex) % affixes.length] = affix;
     }
     return result;


### PR DESCRIPTION
So, uh, test your code, kids.

This fixes the affix rearranging that I broke while refactoring and apparently forgot to test. I see why people use typescript, now. Pro tip: adding strings and numbers is very bad.

```js
const anArray = [
  'one',
  'two',
  'three'
];

for (const [index, value] of Object.entries(anArray)) {
  console.log(index, typeof index);
}
/*
"0", "string"
"1", "string"
"2", "string"
*/

for (const [index, value] of anArray.entries()) {
  console.log(index, typeof index);
}
/*
0, "number"
1, "number"
2, "number"
*/
```