### PR TITLE
hide new distribution if not selected

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1403,32 +1403,32 @@
                               </div>
                               <hr class="my-4" />
                               <div
-                                class="col-12"
+                                class="row"
+                                id="go-distribution-advanced-toggle"
+                              >
+                                <div class="input col">
+                                  <input
+                                    class="input-checkbox"
+                                    type="checkbox"
+                                    id="go-checkbox-distribution-advanced"
+                                  />
+                                  <label
+                                    class="input-label"
+                                    for="go-checkbox-distribution-advanced"
+                                  >
+                                    Advanced Distribution Mode (experimental)
+                                    <span
+                                      class="fa fa-question-circle"
+                                      data-toggle="tooltip"
+                                      title="Replaces percent distribution. Outputs raw DPS. See gear optimizer channel in Discretize Discord for details."
+                                    ></span>
+                                  </label>
+                                </div>
+                              </div>
+                              <div
+                                class="row"
                                 id="go-distribution-advanced"
                               >
-                                <div class="row">
-
-                                  <div class="input col">
-                                    <input
-                                      class="input-checkbox"
-                                      type="checkbox"
-                                      id="go-checkbox-distribution-advanced"
-                                    />
-                                    <label
-                                      class="input-label"
-                                      for="go-checkbox-distribution-advanced"
-                                    >
-                                      Advanced Distribution Mode (experimental)
-                                      <span
-                                        class="fa fa-question-circle"
-                                        data-toggle="tooltip"
-                                        title="Replaces percent distribution. Outputs raw DPS. See gear optimizer channel in Discretize Discord for details."
-                                      ></span>
-                                    </label>
-                                  </div>
-
-                                  <div class="w-100"></div>
-
                                   <div class="input row col">
                                     <label
                                       class="col-form-label col-6 p-2"
@@ -1544,8 +1544,6 @@
                                       />
                                     </div>
                                   </div>
-
-                                </div>
                               </div>
                             </div>
                           </div>

--- a/src/js/gear-optimizer.js
+++ b/src/js/gear-optimizer.js
@@ -1074,6 +1074,17 @@ import {
     }
   });
 
+  // Advanced distribution show/hide
+  function toggleAdvancedDistribution () {
+    if($('#go-checkbox-distribution-advanced').prop('checked')) {
+      $('#go-distribution-advanced').show();
+    } else {
+      $('#go-distribution-advanced').hide()
+    }
+  }
+  toggleAdvancedDistribution();
+  $('#go-checkbox-distribution-advanced').click(toggleAdvancedDistribution);
+
   // Calculate button
   $(Selector.START).on(Event.CLICK, () => {
     run().catch((error) => {


### PR DESCRIPTION
This hides the advanced distribution section if the checkbox isn't selected.

Quick and dirty, but we're transitioning to new code anyways. Just don't want current users to be confused.