### PR TITLE
Performance: remove styles from frequently updating components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,7 @@
     "no-param-reassign": ["warn", { "props": false }],
 
     "consistent-return": "off",
-    "no-unused-vars": ["warn", { "argsIgnorePattern": "^event$|^e$" }],
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^event$|^e$|^props$" }],
 
     // prettier compat
     "arrow-body-style": "off",

--- a/src/components/baseComponents/ProgressIcon.jsx
+++ b/src/components/baseComponents/ProgressIcon.jsx
@@ -1,17 +1,10 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import EqualizerRoundedIcon from '@material-ui/icons/EqualizerRounded';
-import { withStyles } from '@material-ui/core';
 import { getControl } from '../../state/gearOptimizerSlice';
 import CircularProgressWithLabel from './CircularProgressWithLabel';
 
-const styles = (theme) => ({
-  icon: {
-    fontSize: 40,
-  },
-});
-
-const ProgressIcon = ({ classes }) => {
+const ProgressIcon = (props) => {
   const progress = useSelector(getControl('progress'));
 
   return (
@@ -19,9 +12,9 @@ const ProgressIcon = ({ classes }) => {
       {progress < 100 && progress !== 0 ? (
         <CircularProgressWithLabel variant="determinate" value={progress} />
       ) : (
-        <EqualizerRoundedIcon className={classes.icon}></EqualizerRoundedIcon>
+        <EqualizerRoundedIcon />
       )}
     </>
   );
 };
-export default withStyles(styles)(ProgressIcon);
+export default ProgressIcon;

--- a/src/components/sections/results/ResultTable.jsx
+++ b/src/components/sections/results/ResultTable.jsx
@@ -20,7 +20,7 @@ const styles = (theme) => ({
     borderColor: theme.palette.background.paper,
     border: '1px solid',
   },
-  cell: {
+  pointer: {
     cursor: 'pointer',
   },
   tablehead: {
@@ -53,7 +53,7 @@ const StickyHeadTable = ({ classes }) => {
               ))}
             </TableRow>
           </TableHead>
-          <TableBody>
+          <TableBody className={classes.pointer}>
             {list.map((character) => (
               <ResultTableRow
                 character={character}

--- a/src/components/sections/results/ResultTableRow.jsx
+++ b/src/components/sections/results/ResultTableRow.jsx
@@ -2,20 +2,12 @@ import React from 'react';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import { useDispatch } from 'react-redux';
-import { withStyles } from '@material-ui/core';
 import { changeSelectedCharacter } from '../../../state/gearOptimizerSlice';
 
-const styles = (theme) => ({
-  cell: {
-    cursor: 'pointer',
-  },
-});
-
-const ResultTableRow = React.memo(({ classes, character, selected }) => {
+const ResultTableRow = React.memo(({ character, selected }) => {
   const dispatch = useDispatch();
   return (
     <TableRow
-      className={classes.cell}
       selected={selected}
       style={selected ? { backgroundColor: 'rgba(0, 204, 204, 0.2)' } : null}
       onClick={(e) => dispatch(changeSelectedCharacter(character))}
@@ -32,4 +24,4 @@ const ResultTableRow = React.memo(({ classes, character, selected }) => {
   );
 });
 
-export default withStyles(styles)(ResultTableRow);
+export default ResultTableRow;


### PR DESCRIPTION
This removes the styles HOCs from ProgressIcon and ResultTableRow. Didn't test carefully exactly what the performance gain is but it's a bit.