### PR TITLE
Reduce flickering/lag on calculate button press

### DIFF
--- a/src/components/GearOptimizer.jsx
+++ b/src/components/GearOptimizer.jsx
@@ -356,9 +356,7 @@ const MainComponent = ({ classes, data }) => {
 
       <ResultTable />
       <Box m={3} />
-      {(status === SUCCESS || status === ABORTED) && (
-        <ResultDetails data={data} buffData={data.buffs.list} />
-      )}
+      <ResultDetails data={data} buffData={data.buffs.list} />
     </div>
   );
 };

--- a/src/state/gearOptimizerSlice.js
+++ b/src/state/gearOptimizerSlice.js
@@ -276,9 +276,6 @@ export const gearOptimizerSlice = createSlice({
       }
 
       state.modifiers = modifiers;
-
-      // clear result details
-      state.control.selectedCharacter = null;
     },
     addTraitModifier: (state, action) => {
       state.traits.modifiers = state.traits.modifiers.concat(action.payload);

--- a/src/state/optimizer/sagas.js
+++ b/src/state/optimizer/sagas.js
@@ -6,6 +6,7 @@ import * as optimizerCore from './optimizerCore';
 import {
   changeControl,
   changeList,
+  changeSelectedCharacter,
   changeSelectedCharacterIfNone,
 } from '../gearOptimizerSlice';
 import { INFUSIONS } from '../../utils/gw2-data';
@@ -14,6 +15,9 @@ import { SUCCESS } from './status';
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function* runCalc() {
+  yield delay(0);
+  yield put(changeSelectedCharacter(null));
+
   const time = Date.now();
   let newList;
 


### PR DESCRIPTION
This reorders the UI updates when you press the calculate button so the status is updated first and it renders that out without lag, then it does the expensive dom updates afterwards.

This is set up such that, if you do a short calculation like a power build, the results table is replaced in-place, while if you do a longer one, it is cleared while the progress bar is going.