### PR TITLE
Fix: disable changing profession in easy mode

### DIFF
--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -179,7 +179,9 @@ const Navbar = ({ classes, data, buffPresets, prioritiesPresets }) => {
               }
               onClick={() => {
                 dispatch({ type: 'CANCEL' });
-                dispatch(changeProfession(p.profession));
+                if (expertMode) {
+                  dispatch(changeProfession(p.profession));
+                }
               }}
               variant={p.profession === profession ? 'contained' : 'text'}
               {...bindHover(popupState[index])}


### PR DESCRIPTION
This disables the ability to change to a profession without selecting a template when you're not in advanced mode.