### PR TITLE
Refactor slice into multiple smaller slices

### DIFF
--- a/src/components/GearOptimizer.jsx
+++ b/src/components/GearOptimizer.jsx
@@ -117,7 +117,7 @@ const MainComponent = ({ classes, data }) => {
 
         <ResultTable />
         <Box m={3} />
-        <ResultDetails data={data} buffData={data.buffs.list} />
+        <ResultDetails data={data} />
       </div>
     </div>
   );

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -142,12 +142,13 @@ const Navbar = ({ classes, data, buffPresets, prioritiesPresets, distributionPre
     );
   };
 
-  const handleTemplateSelect = (popup, elem, specialization) => {
+  const handleTemplateSelect = (popup, elem, specialization, profession) => {
     dispatch({ type: 'CANCEL' });
     dispatch(
       setBuildTemplate({
         build: elem,
-        specialization: specialization,
+        specialization,
+        profession,
         buffPreset: JSON.parse(buffPresets.find((pre) => pre.name === elem.boons).value),
         distributionPreset: JSON.parse(
           distributionPresets.find((pre) => pre.name === elem.distribution)?.value || 'null',
@@ -213,7 +214,12 @@ const Navbar = ({ classes, data, buffPresets, prioritiesPresets, distributionPre
                   <MenuItem
                     key={elem.name}
                     onClick={(e) =>
-                      handleTemplateSelect(popupState[index], elem, elem.specialization)
+                      handleTemplateSelect(
+                        popupState[index],
+                        elem,
+                        elem.specialization,
+                        p.profession,
+                      )
                     }
                   >
                     <Profession

--- a/src/components/sections/Affixes.jsx
+++ b/src/components/sections/Affixes.jsx
@@ -3,7 +3,7 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
 import { Item } from 'gw2-ui-bulk';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { changePriority, getPriority } from '../../state/gearOptimizerSlice';
+import { changePriority, getPriority } from '../../state/slices/priorities';
 import { firstUppercase } from '../../utils/usefulFunctions';
 
 const styles = (theme) => ({

--- a/src/components/sections/ar/ARinput.jsx
+++ b/src/components/sections/ar/ARinput.jsx
@@ -2,12 +2,7 @@ import React from 'react';
 import { FormControl, Grid, Input, InputAdornment, InputLabel } from '@material-ui/core';
 import { Attribute, Item } from 'gw2-ui-bulk';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  changeAR,
-  changeOmnipotion,
-  getAR,
-  getOmniPotion,
-} from '../../../state/gearOptimizerSlice';
+import { changeAR, changeOmnipotion, getAR, getOmniPotion } from '../../../state/slices/omnipotion';
 import CheckboxComponent from '../../baseComponents/CheckboxComponent';
 
 const ARinput = () => {

--- a/src/components/sections/buffs/Buffs.jsx
+++ b/src/components/sections/buffs/Buffs.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormControl, FormGroup, FormLabel, Grid, Typography, withStyles } from '@material-ui/core';
 import { Boon, CommonEffect, Condition, Skill, Trait } from 'gw2-ui-bulk';
 import { useDispatch, useSelector } from 'react-redux';
-import { changeBuff, getBuffs } from '../../../state/gearOptimizerSlice';
+import { changeBuff, getBuffs } from '../../../state/slices/buffs';
 import { firstUppercase } from '../../../utils/usefulFunctions';
 import CheckboxComponent from '../../baseComponents/CheckboxComponent';
 

--- a/src/components/sections/buffs/BuffsSection.jsx
+++ b/src/components/sections/buffs/BuffsSection.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { replaceBuffs } from '../../../state/gearOptimizerSlice';
+import { replaceBuffs } from '../../../state/slices/buffs';
 import Presets from '../../baseComponents/Presets';
 import Section from '../../baseComponents/Section';
 import Buffs from './Buffs';

--- a/src/components/sections/controls/Controls.jsx
+++ b/src/components/sections/controls/Controls.jsx
@@ -21,14 +21,14 @@ const ControlsBox = ({ classes, profession, data }) => {
       console.log('calculate');
 
       // pass data from GraphQL
-      dispatch(setModifiers(data));
+      dispatch(setModifiers({ data, profession }));
 
       dispatch(changeControl({ key: 'status', value: RUNNING }));
       dispatch({
         type: 'START',
       });
     },
-    [data, dispatch],
+    [data, dispatch, profession],
   );
 
   const onCancelCalculate = React.useCallback(

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -24,7 +24,7 @@ import {
   getDistributionOld,
   getDistributionVersion,
   getTextBoxes,
-} from '../../../state/gearOptimizerSlice';
+} from '../../../state/slices/distribution';
 
 const styles = (theme) => ({
   textbox: {

--- a/src/components/sections/distribution/DistributionSection.jsx
+++ b/src/components/sections/distribution/DistributionSection.jsx
@@ -10,7 +10,7 @@ import {
   changeAllTextBoxes,
   changeDistributionVersion,
   getDistributionVersion,
-} from '../../../state/gearOptimizerSlice';
+} from '../../../state/slices/distribution';
 import { PROFESSIONS } from '../../../utils/gw2-data';
 import Presets from '../../baseComponents/Presets';
 

--- a/src/components/sections/extramodifiers/ExtraModifiers.jsx
+++ b/src/components/sections/extramodifiers/ExtraModifiers.jsx
@@ -1,7 +1,7 @@
 import { TextField, withStyles } from '@material-ui/core';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { changeExtraModifiers, getExtraModifiers } from '../../../state/gearOptimizerSlice';
+import { changeExtraModifiers, getExtraModifiers } from '../../../state/slices/extraModifiers';
 
 const styles = (theme) => ({
   text: {

--- a/src/components/sections/extras/GW2Select.jsx
+++ b/src/components/sections/extras/GW2Select.jsx
@@ -36,7 +36,7 @@ const styles = (theme) => ({
 const GW2Select = ({ classes, name, label, data }) => {
   const dispatch = useDispatch();
   const bigValue = useSelector(getExtra(name));
-  console.log(bigValue);
+
   const handleChange = (event) => {
     if (event.target.value !== undefined)
       dispatch(changeExtras({ key: event.target.name, value: event.target.value }));

--- a/src/components/sections/extras/GW2Select.jsx
+++ b/src/components/sections/extras/GW2Select.jsx
@@ -12,7 +12,7 @@ import {
 } from '@material-ui/core';
 import { Item } from 'gw2-ui-bulk';
 import { useDispatch, useSelector } from 'react-redux';
-import { changeExtras, getExtra } from '../../../state/gearOptimizerSlice';
+import { changeExtras, getExtra } from '../../../state/slices/extras';
 
 const styles = (theme) => ({
   formControl: {
@@ -36,7 +36,7 @@ const styles = (theme) => ({
 const GW2Select = ({ classes, name, label, data }) => {
   const dispatch = useDispatch();
   const bigValue = useSelector(getExtra(name));
-
+  console.log(bigValue);
   const handleChange = (event) => {
     if (event.target.value !== undefined)
       dispatch(changeExtras({ key: event.target.name, value: event.target.value }));

--- a/src/components/sections/forcedslots/ForcedSlots.jsx
+++ b/src/components/sections/forcedslots/ForcedSlots.jsx
@@ -3,7 +3,8 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
 import { Item } from 'gw2-ui-bulk';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { changeForcedSlot, getGeneric, getPriority } from '../../../state/gearOptimizerSlice';
+import { changeForcedSlot, getForcedSlots } from '../../../state/slices/forcedSlots';
+import { getPriority } from '../../../state/slices/priorities';
 import { GEAR_SLOTS } from '../../../utils/gw2-data';
 import { firstUppercase } from '../../../utils/usefulFunctions';
 import { AFFIXES } from '../Affixes';
@@ -24,7 +25,7 @@ const styles = (theme) => ({
 
 const ForcedSlots = ({ classes }) => {
   const dispatch = useDispatch();
-  const forcedSlots = useSelector(getGeneric('forcedSlots'));
+  const forcedSlots = useSelector(getForcedSlots);
   const dualWielded = useSelector(getPriority('weaponType'));
 
   let SLOTS = GEAR_SLOTS;

--- a/src/components/sections/infusions/Infusions.jsx
+++ b/src/components/sections/infusions/Infusions.jsx
@@ -10,7 +10,7 @@ import {
 import { Item } from 'gw2-ui-bulk';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { changeInfusions, getInfusions } from '../../../state/gearOptimizerSlice';
+import { changeInfusions, getInfusions } from '../../../state/slices/infusions';
 import { INFUSIONS } from '../../../utils/gw2-data';
 
 const styles = (theme) => ({

--- a/src/components/sections/priorities/Priorities.jsx
+++ b/src/components/sections/priorities/Priorities.jsx
@@ -12,7 +12,7 @@ import {
 import { Attribute } from 'gw2-ui-bulk';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { changePriority, getPriority } from '../../../state/gearOptimizerSlice';
+import { changePriority, getPriority } from '../../../state/slices/priorities';
 import HelperIcon from '../../baseComponents/HelperIcon';
 import Affixes from '../Affixes';
 

--- a/src/components/sections/priorities/PrioritiesSection.jsx
+++ b/src/components/sections/priorities/PrioritiesSection.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { changePriority } from '../../../state/gearOptimizerSlice';
+import { changePriority } from '../../../state/slices/priorities';
 import Section from '../../baseComponents/Section';
 import Presets from '../../baseComponents/Presets';
 import Priorities from './Priorities';

--- a/src/components/sections/results/ResultDetails.jsx
+++ b/src/components/sections/results/ResultDetails.jsx
@@ -3,8 +3,6 @@ import { getImage } from 'gatsby-plugin-image';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import {
-  getExtra,
-  getExtras,
   getModifiers,
   getPriority,
   getProfession,
@@ -12,6 +10,7 @@ import {
   getTraitLines,
 } from '../../../state/gearOptimizerSlice';
 import { updateAttributes } from '../../../state/optimizer/optimizerCore';
+import { getExtra, getExtras, getExtrasModifiers } from '../../../state/slices/extras';
 import { Classes, Defense, INFUSIONS, PROFESSIONS } from '../../../utils/gw2-data';
 import { firstUppercase } from '../../../utils/usefulFunctions';
 import Character from '../../gw2/Character';
@@ -30,8 +29,9 @@ const ResultDetails = ({ classes, data, buffData }) => {
   const sigil1 = useSelector(getExtra('Sigil1'));
   const sigil2 = useSelector(getExtra('Sigil2'));
   const priority = useSelector(getPriority('weaponType'));
-  const modifiers = useSelector(getModifiers);
   const traits = useSelector(getTraitLines);
+
+  const modifiers = useSelector(getModifiers);
 
   const charRaw = useSelector(getSelectedCharacter);
   if (!charRaw) {

--- a/src/components/sections/results/ResultDetails.jsx
+++ b/src/components/sections/results/ResultDetails.jsx
@@ -23,7 +23,7 @@ import SpecialDurations from './SpecialDurations';
 
 const styles = (theme) => ({});
 
-const ResultDetails = ({ classes, data, buffData }) => {
+const ResultDetails = ({ classes, data }) => {
   const profession = useSelector(getProfession);
   const sigil1 = useSelector(getExtra('Sigil1'));
   const sigil2 = useSelector(getExtra('Sigil2'));
@@ -196,7 +196,7 @@ const ResultDetails = ({ classes, data, buffData }) => {
         <Grid item xs={12} sm={6} md={4}></Grid>
       </Grid>
 
-      <AppliedModifiers data={modifiers} buffData={buffData} />
+      <AppliedModifiers data={modifiers} buffData={data.buffs.list} />
     </div>
   );
 };

--- a/src/components/sections/results/ResultDetails.jsx
+++ b/src/components/sections/results/ResultDetails.jsx
@@ -4,13 +4,13 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import {
   getModifiers,
-  getPriority,
   getProfession,
   getSelectedCharacter,
-  getTraitLines,
 } from '../../../state/gearOptimizerSlice';
 import { updateAttributes } from '../../../state/optimizer/optimizerCore';
-import { getExtra, getExtras, getExtrasModifiers } from '../../../state/slices/extras';
+import { getExtra } from '../../../state/slices/extras';
+import { getPriority } from '../../../state/slices/priorities';
+import { getTraitLines } from '../../../state/slices/traits';
 import { Classes, Defense, INFUSIONS, PROFESSIONS } from '../../../utils/gw2-data';
 import { firstUppercase } from '../../../utils/usefulFunctions';
 import Character from '../../gw2/Character';
@@ -24,15 +24,15 @@ import SpecialDurations from './SpecialDurations';
 const styles = (theme) => ({});
 
 const ResultDetails = ({ classes, data, buffData }) => {
-  const extras = useSelector(getExtras);
   const profession = useSelector(getProfession);
   const sigil1 = useSelector(getExtra('Sigil1'));
   const sigil2 = useSelector(getExtra('Sigil2'));
+  const runeStringId = useSelector(getExtra('Runes'));
+
   const priority = useSelector(getPriority('weaponType'));
   const traits = useSelector(getTraitLines);
 
   const modifiers = useSelector(getModifiers);
-
   const charRaw = useSelector(getSelectedCharacter);
   if (!charRaw) {
     return null;
@@ -112,10 +112,10 @@ const ResultDetails = ({ classes, data, buffData }) => {
     };
   }
 
-  const rune = extras.Runes
-    ? data.runes.list.flatMap((r) => r.items).find((r) => r.id === extras.Runes)
+  const rune = runeStringId
+    ? data.runes.list.flatMap((r) => r.items).find((r) => r.id === runeStringId)
     : '';
-  const runeName = extras.Runes ? rune.text.split(' ')[rune.text.split(' ').length - 1] : '';
+  const runeName = runeStringId ? rune.text.split(' ')[rune.text.split(' ').length - 1] : '';
 
   // find the right image for the selected elite specialization
   const { eliteSpecializations } = PROFESSIONS.find(

--- a/src/components/sections/results/ResultDetails.jsx
+++ b/src/components/sections/results/ResultDetails.jsx
@@ -1,7 +1,7 @@
 import { Grid, Typography, withStyles } from '@material-ui/core';
 import { getImage } from 'gatsby-plugin-image';
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useStore } from 'react-redux';
 import {
   getModifiers,
   getProfession,
@@ -21,9 +21,8 @@ import OutputDistribution from './OutputDistribution';
 import OutputInfusions from './OutputInfusions';
 import SpecialDurations from './SpecialDurations';
 
-const styles = (theme) => ({});
-
-const ResultDetails = ({ classes, data }) => {
+const ResultDetails = ({ data }) => {
+  const store = useStore();
   const profession = useSelector(getProfession);
   const sigil1 = useSelector(getExtra('Sigil1'));
   const sigil2 = useSelector(getExtra('Sigil2'));
@@ -32,7 +31,8 @@ const ResultDetails = ({ classes, data }) => {
   const priority = useSelector(getPriority('weaponType'));
   const traits = useSelector(getTraitLines);
 
-  const modifiers = useSelector(getModifiers);
+  // its good enough to query this value once since modifiers remain the same accross all characters
+  const modifiers = getModifiers(store.getState());
   const charRaw = useSelector(getSelectedCharacter);
   if (!charRaw) {
     return null;
@@ -201,4 +201,4 @@ const ResultDetails = ({ classes, data }) => {
   );
 };
 
-export default React.memo(withStyles(styles)(ResultDetails));
+export default React.memo(ResultDetails);

--- a/src/components/sections/results/ResultTableHeaderRow.jsx
+++ b/src/components/sections/results/ResultTableHeaderRow.jsx
@@ -4,7 +4,8 @@ import TableRow from '@material-ui/core/TableRow';
 import { Item } from 'gw2-ui-bulk';
 import { useSelector } from 'react-redux';
 import { Slots } from '../../../utils/gw2-data';
-import { getPriority, getInfusions } from '../../../state/gearOptimizerSlice';
+import { getPriority } from '../../../state/slices/priorities';
+import { getInfusions } from '../../../state/slices/infusions';
 
 const ResultTableHeaderRow = ({ classes }) => {
   const wield = useSelector(getPriority('weaponType'));

--- a/src/components/sections/skills/Skills.jsx
+++ b/src/components/sections/skills/Skills.jsx
@@ -2,7 +2,7 @@ import { Typography, withStyles } from '@material-ui/core';
 import { Skill } from 'gw2-ui-bulk';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { addSkill, getSkills, removeSkill } from '../../../state/gearOptimizerSlice';
+import { addSkill, getSkills, removeSkill } from '../../../state/slices/skills';
 import CheckboxComponent from '../../baseComponents/CheckboxComponent';
 
 const styles = (theme) => ({
@@ -27,7 +27,7 @@ const Skills = ({ classes, data }) => {
 
   const onChange = (skill) => (e) => {
     if (e.target.checked) {
-      dispatch(addSkill({ value: skill.id }));
+      dispatch(addSkill(skill.id));
     } else {
       dispatch(removeSkill(skill.id));
     }

--- a/src/components/sections/traits/Traits.jsx
+++ b/src/components/sections/traits/Traits.jsx
@@ -21,7 +21,7 @@ import {
   removeTraitModifier,
   removeTraitModifierWithGW2id,
   removeTraitModifierWithSource,
-} from '../../../state/gearOptimizerSlice';
+} from '../../../state/slices/traits';
 import CheckboxComponent from '../../baseComponents/CheckboxComponent';
 
 const styles = (theme) => ({

--- a/src/state/createStore.js
+++ b/src/state/createStore.js
@@ -5,7 +5,9 @@ import { applyMiddleware, combineReducers, compose, createStore as reduxCreateSt
 import createSagaMiddleware from 'redux-saga';
 
 import createWebStorage from 'redux-persist/lib/storage/createWebStorage';
-import gearOptimizerReducer from './gearOptimizerSlice';
+
+import mainReducer from './gearOptimizerSlice';
+import { extrasSlice } from './slices/extras';
 import gearOptimizerSaga from './optimizer/sagas';
 
 const createNoopStorage = () => {
@@ -32,7 +34,8 @@ const persistConfig = {
 
 const reducers = combineReducers({
   gw2UiStore: gw2UIReducer,
-  gearOptimizer: gearOptimizerReducer,
+  gearOptimizer: mainReducer,
+  extras: extrasSlice.reducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, reducers);

--- a/src/state/createStore.js
+++ b/src/state/createStore.js
@@ -6,9 +6,18 @@ import createSagaMiddleware from 'redux-saga';
 
 import createWebStorage from 'redux-persist/lib/storage/createWebStorage';
 
-import mainReducer from './gearOptimizerSlice';
+import { controlSlice } from './gearOptimizerSlice';
 import { extrasSlice } from './slices/extras';
 import gearOptimizerSaga from './optimizer/sagas';
+import { distributionSlice } from './slices/distribution';
+import { buffsSlice } from './slices/buffs';
+import { infusionsSlice } from './slices/infusions';
+import { traitsSlice } from './slices/traits';
+import { skillsSlice } from './slices/skills';
+import { prioritiesSlice } from './slices/priorities';
+import { extraModifiersSlice } from './slices/extraModifiers';
+import { forcedSlotsSlice } from './slices/forcedSlots';
+import { omnipotionSlice } from './slices/omnipotion';
 
 const createNoopStorage = () => {
   return {
@@ -34,8 +43,17 @@ const persistConfig = {
 
 const reducers = combineReducers({
   gw2UiStore: gw2UIReducer,
-  gearOptimizer: mainReducer,
+  control: controlSlice.reducer,
   extras: extrasSlice.reducer,
+  distribution: distributionSlice.reducer,
+  buffs: buffsSlice.reducer,
+  infusions: infusionsSlice.reducer,
+  traits: traitsSlice.reducer,
+  skills: skillsSlice.reducer,
+  priorities: prioritiesSlice.reducer,
+  extraModifiers: extraModifiersSlice.reducer,
+  forcedSlots: forcedSlotsSlice.reducer,
+  omnipotion: omnipotionSlice.reducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, reducers);

--- a/src/state/gearOptimizerSlice.js
+++ b/src/state/gearOptimizerSlice.js
@@ -23,13 +23,6 @@ const INITIALSTATE = {
     modifiers: [],
   },
   skills: [],
-  extras: {
-    Runes: '',
-    Sigil1: '',
-    Sigil2: '',
-    Enhancement: '',
-    Nourishment: '',
-  },
   extraModifiers: {
     error: '',
     extraModifiers: [],
@@ -266,31 +259,10 @@ export const gearOptimizerSlice = createSlice({
       // passed data from GraphQL
       const data = action.payload;
 
-      const { extras, buffs, skills, traits, extraModifiers, profession } = state;
+      const { buffs, skills, traits, extraModifiers, profession } = state;
 
       // all selected modifiers will be collected in this array
       const modifiers = [];
-
-      // Applies runes, sigils, food modifiers
-      const extrasData = [
-        { id: 'Runes', list: data.runes.list },
-        { id: 'Sigil1', list: data.sigils.list },
-        { id: 'Sigil2', list: data.sigils.list },
-        { id: 'Enhancement', list: data.enhancement.list },
-        { id: 'Nourishment', list: data.nourishment.list },
-      ];
-
-      extrasData
-        .filter((extra) => extras[extra.id] !== '')
-        .filter((extra) => extras[extra.id] !== undefined)
-        .forEach((extra) => {
-          modifiers.push({
-            id: extras[extra.id],
-            modifiers: extra.list.flatMap((d) => d.items).find((a) => a.id === extras[extra.id])
-              .modifiers,
-            source: extra.id,
-          });
-        });
 
       // Apply "buffs" modifiers
       data.buffs.list
@@ -360,9 +332,6 @@ export const gearOptimizerSlice = createSlice({
     removeTraitModifierWithSource: (state, action) => {
       state.traits.modifiers = state.traits.modifiers.filter((m) => m.source !== action.payload);
     },
-    changeExtras: (state, action) => {
-      state.extras[action.payload.key] = action.payload.value;
-    },
     changeControl: (state, action) => {
       state.control[action.payload.key] = action.payload.value;
     },
@@ -411,14 +380,15 @@ export const getDistributionOld = (state) => state.gearOptimizer.distribution.va
 export const getDistributionNew = (state) => state.gearOptimizer.distribution.values2;
 export const getTextBoxes = (state) => state.gearOptimizer.distribution.textBoxes;
 export const getSkills = (state) => state.gearOptimizer.skills;
-export const getModifiers = (state) => state.gearOptimizer.modifiers;
+export const getModifiers = (state) => [
+  ...state.gearOptimizer.modifiers,
+  ...state.extras.modifiers,
+];
 export const getTraitModifiers = (state) => state.gearOptimizer.traits.modifiers;
-export const getExtra = (key) => (state) => state.gearOptimizer.extras[key];
 export const getControl = (key) => (state) => state.gearOptimizer.control[key];
 export const getBuffs = (state) => state.gearOptimizer.buffs;
 export const getInfusions = (state) => state.gearOptimizer.infusions;
 export const getPriority = (key) => (state) => state.gearOptimizer.priorities[key];
-export const getExtras = (state) => state.gearOptimizer.extras;
 export const getList = (state) => state.gearOptimizer.control.list;
 export const getOmniPotion = (state) => state.gearOptimizer.omnipotion;
 export const getSelectedCharacter = (state) => state.gearOptimizer.control.selectedCharacter;
@@ -444,7 +414,6 @@ export const {
   removeModifier,
   removeTraitModifierWithGW2id,
   removeModifierWithSource,
-  changeExtras,
   changeExtraModifiers,
   changeControl,
   changeBuff,

--- a/src/state/gearOptimizerSlice.js
+++ b/src/state/gearOptimizerSlice.js
@@ -1,125 +1,24 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { WAITING } from './optimizer/status';
-import { Omnipotion } from '../utils/gw2-data';
 import { firstUppercase } from '../utils/usefulFunctions';
 
-const INITIALSTATE = {
-  control: {
+export const controlSlice = createSlice({
+  name: 'control',
+  initialState: {
     expertMode: true,
     list: [],
     progress: 0,
     selectedCharacter: null,
     selectedTemplate: '',
     status: WAITING,
+    profession: '',
   },
-  profession: '',
-  traits: {
-    lines: ['', '', ''],
-    selected: [
-      [0, 0, 0],
-      [0, 0, 0],
-      [0, 0, 0],
-    ],
-    modifiers: [],
-  },
-  skills: [],
-  extraModifiers: {
-    error: '',
-    extraModifiers: [],
-    textBox: '',
-  },
-  buffs: {
-    might: false,
-    fury: false,
-    protection: false,
-    vulnerability: false,
-    bannerOfStrength: false,
-    bannerOfDiscipline: false,
-    bannerOfTactics: false,
-    bannerOfDefense: false,
-    spotter: false,
-    frostSpirit: false,
-    empowerAllies: false,
-    pinpointDistribution: false,
-    assassinsPresence: false,
-    facetOfNature: false,
-    riteDwarf: false,
-    strengthInNumbers: false,
-    baneSignet: false,
-    signetOfJudgment: false,
-    signetOfMercy: false,
-    signetOfWrath: false,
-    exposed: false,
-    lightArmor: false,
-  },
-  infusions: {
-    primaryInfusion: '',
-    secondaryInfusion: '',
-    primaryMaxInfusions: '',
-    secondaryMaxInfusions: '',
-  },
-  forcedSlots: [null, null, null, null, null, null, null, null, null, null, null, null, null],
-  ar: 162,
-  omnipotion: true,
-  priorities: {
-    optimizeFor: 'Damage',
-    weaponType: 'Dual wield',
-    minBoonDuration: '',
-    minHealingPower: '',
-    minToughness: '',
-    maxToughness: '',
-    affixes: [],
-  },
-  distribution: {
-    version: 2,
-    values1: {
-      Power: 100,
-      Burning: 0,
-      Bleeding: 0,
-      Poisoned: 0,
-      Torment: 0,
-      Confusion: 0,
-    },
-    values2: {
-      Power: 3000,
-      Burning: 0,
-      Bleeding: 0,
-      Poisoned: 0,
-      Torment: 0,
-      Confusion: 0,
-    },
-    textBoxes: {
-      Power: '3000',
-      Burning: '0',
-      Bleeding: '0',
-      Poisoned: '0',
-      Torment: '0',
-      Confusion: '0',
-    },
-  },
-  modifiers: [],
-};
-
-export const gearOptimizerSlice = createSlice({
-  name: 'go',
-  initialState: INITIALSTATE,
   reducers: {
     changeProfession: (state, action) => {
       if (state.profession !== action.payload) {
         state.profession = action.payload;
 
         // reset
-        state.modifiers = [];
-        state.traits = {
-          lines: ['', '', ''],
-
-          selected: [
-            [0, 0, 0],
-            [0, 0, 0],
-            [0, 0, 0],
-          ],
-          modifiers: [],
-        };
         state.control = {
           ...state.control,
           list: [],
@@ -129,7 +28,6 @@ export const gearOptimizerSlice = createSlice({
           selectedSpecialization: firstUppercase(action.payload),
           status: WAITING,
         };
-        state.skills = [];
       }
     },
     changeExpertMode: (state, action) => {
@@ -137,299 +35,77 @@ export const gearOptimizerSlice = createSlice({
         // just change expertMode to true
         return {
           ...state,
-          control: {
-            ...state.control,
-            expertMode: action.payload,
-          },
+          expertMode: action.payload,
         };
       }
       // wipe state and force usr to select a template
       return {
-        ...INITIALSTATE,
-        control: {
-          expertMode: action.payload,
-          list: [],
-          progress: 0,
-          selectedCharacter: null,
-          status: WAITING,
-        },
-        ar: state.ar,
-        omnipotion: state.omnipotion,
+        ...state,
+        expertMode: action.payload,
+        list: [],
+        progress: 0,
+        selectedCharacter: null,
+        status: WAITING,
       };
-    },
-    changeAR: (state, action) => {
-      state.ar = action.payload;
-    },
-    changeTraitLine: (state, action) => {
-      state.traits.lines[action.payload.index] = action.payload.value;
-    },
-    changeTraits: (state, action) => {
-      state.traits.selected[action.payload.index] = action.payload.selected;
-    },
-    changeGeneric: (state, action) => {
-      state[action.payload.toChange] = action.payload.value;
-    },
-    changeDistributionVersion: (state, action) => {
-      state.distribution.version = action.payload;
-    },
-    changeDistributionNew: (state, action) => {
-      state.distribution = {
-        ...state.distribution,
-        values2: { ...state.distribution.values2, [action.payload.index]: action.payload.value },
-      };
-    },
-    changeTextBoxes: (state, action) => {
-      state.distribution = {
-        ...state.distribution,
-        textBoxes: {
-          ...state.distribution.textBoxes,
-          [action.payload.index]: action.payload.value,
-        },
-      };
-    },
-    changeAllTextBoxes: (state, action) => {
-      state.distribution.textBoxes = action.payload;
-    },
-    changeExtraModifiers: (state, action) => {
-      state.extraModifiers[action.payload.key] = action.payload.value;
-    },
-    changeAllDistributionsOld: (state, action) => {
-      state.distribution.values1 = action.payload;
-    },
-    changeAllDistributionsNew: (state, action) => {
-      state.distribution.values2 = action.payload;
-    },
-    addSkill: (state, action) => {
-      state.skills = state.skills.concat(action.payload.value);
-    },
-    removeSkill: (state, action) => {
-      state.skills = state.skills.filter((v) => v !== action.payload);
-    },
-    changeForcedSlot: (state, action) => {
-      state.forcedSlots[action.payload.index] = action.payload.value;
-    },
-    addModifier: (state, action) => {
-      state.modifiers = state.modifiers.concat(action.payload);
     },
     setBuildTemplate: (state, action) => {
-      const data = action.payload;
-
-      // enable the buff template
-      const { buffs } = state;
-      const buffsNew = {};
-      [...Object.keys(buffs)].forEach((key) => {
-        buffsNew[key] = false;
-        if (key in data.buffPreset) buffsNew[key] = data.buffPreset[key];
-      });
-
-      const traitState = JSON.parse(data.build.traits);
-
-      let { distribution } = state;
-      if (data.distributionPreset) {
-        distribution = {
-          version: 2,
-          values1: data.distributionPreset.values1,
-          values2: data.distributionPreset.values2,
-          textBoxes: data.distributionPreset.values2,
-        };
-      }
+      const { build, specialization, profession } = action.payload;
 
       return {
         ...state,
-        ...traitState,
-        modifiers: [],
-        control: {
-          ...state.control,
-          list: [],
-          progress: 0,
-          selectedCharacter: null,
-          selectedTemplate: data.build.name,
-          selectedSpecialization: data.specialization,
-          status: WAITING,
-        },
-        buffs: buffsNew,
-        priorities: {
-          ...state.priorities,
-          ...data.prioritiesPreset,
-        },
-        distribution,
+        list: [],
+        progress: 0,
+        selectedCharacter: null,
+        selectedTemplate: build.name,
+        selectedSpecialization: specialization,
+        status: WAITING,
+        profession,
       };
     },
     setModifiers: (state, action) => {
-      // passed data from GraphQL
-      const data = action.payload;
-
-      const { buffs, skills, traits, extraModifiers, profession } = state;
-
-      // all selected modifiers will be collected in this array
-      const modifiers = [];
-
-      // Apply "buffs" modifiers
-      data.buffs.list
-        .flatMap((d) => d.items)
-        .filter((elem) => buffs[elem.id])
-        .forEach((elem) =>
-          modifiers.push({ id: elem.id, modifiers: elem.modifiers, gw2_id: elem.gw2_id }),
-        );
-
-      // map id to modifier. We dont store modifier values in the state!
-      const allSkillsAndTraits = data[profession.toLowerCase()].edges[0].node.list.flatMap(
-        (el) => el.items,
-      );
-      const matchedTraitModifiers = traits.modifiers.map((traitModifier) =>
-        allSkillsAndTraits.filter((t) => t !== null).find((trait) => trait.id === traitModifier.id),
-      );
-      const matchedSkillModifiers = skills.map((skill) =>
-        allSkillsAndTraits.filter((t) => t !== null).find((s) => s.id === skill),
-      );
-      modifiers.push(...matchedTraitModifiers);
-      modifiers.push(...matchedSkillModifiers);
-
-      // Apply AR and omnipotion
-      if (state.ar) {
-        modifiers.push({
-          id: 'agony-resistance',
-          modifiers: JSON.stringify({
-            flat: {
-              'Agony Resistance': state.ar,
-            },
-          }),
-        });
-      }
-      if (state.omnipotion) {
-        modifiers.push({
-          id: 'omnipotion',
-          modifiers: JSON.stringify(Omnipotion),
-        });
-      }
-
-      // Apply extra (manual) modifiers
-      if (extraModifiers.extraModifiers.length > 0) {
-        modifiers.push(
-          ...JSON.parse(extraModifiers.extraModifiers).map((modi, index) => {
-            return { id: `extraModifier${index}`, modifiers: JSON.stringify(modi) };
-          }),
-        );
-      }
-
-      state.modifiers = modifiers;
-    },
-    addTraitModifier: (state, action) => {
-      state.traits.modifiers = state.traits.modifiers.concat(action.payload);
-    },
-    removeModifier: (state, action) => {
-      state.modifiers = state.modifiers.filter((m) => m.id !== action.payload);
-    },
-    removeTraitModifier: (state, action) => {
-      state.traits.modifiers = state.traits.modifiers.filter((m) => m.id !== action.payload);
-    },
-    removeTraitModifierWithGW2id: (state, action) => {
-      state.traits.modifiers = state.traits.modifiers.filter((m) => m.gw2_id !== action.payload);
-    },
-    removeModifierWithSource: (state, action) => {
-      state.modifiers = state.modifiers.filter((m) => m.source !== action.payload);
-    },
-    removeTraitModifierWithSource: (state, action) => {
-      state.traits.modifiers = state.traits.modifiers.filter((m) => m.source !== action.payload);
+      return state;
     },
     changeControl: (state, action) => {
-      state.control[action.payload.key] = action.payload.value;
-    },
-    changeBuff: (state, action) => {
-      state.buffs[action.payload.key] = action.payload.value;
-    },
-    replaceBuffs: (state, action) => {
-      state.buffs = Object.fromEntries(
-        Object.keys(state.buffs).map((key) => [key, Boolean(action.payload[key])]),
-      );
-    },
-    changeInfusions: (state, action) => {
-      state.infusions[action.payload.key] = action.payload.value;
-    },
-    changePriority: (state, action) => {
-      state.priorities[action.payload.key] = action.payload.value;
+      state[action.payload.key] = action.payload.value;
     },
     changeList: (state, action) => {
-      state.control.list = action.payload;
-    },
-    changeOmnipotion: (state, action) => {
-      state.omnipotion = action.payload;
-    },
-    changeState: (state, action) => {
-      return { ...state, ...action.payload };
+      state.list = action.payload;
     },
     changeSelectedCharacter: (state, action) => {
-      state.control.selectedCharacter = action.payload;
+      state.selectedCharacter = action.payload;
     },
     changeSelectedCharacterIfNone: (state, action) => {
-      if (!state.control.selectedCharacter) {
-        state.control.selectedCharacter = action.payload;
+      if (!state.selectedCharacter) {
+        state.selectedCharacter = action.payload;
       }
     },
   },
 });
 
-export const getProfession = (state) => state.gearOptimizer.profession;
-export const getAR = (state) => state.gearOptimizer.ar;
-export const getTraitLines = (state) => state.gearOptimizer.traits.lines;
-export const getTraits = (state) => state.gearOptimizer.traits.selected;
-export const getGeneric = (key) => (state) => state.gearOptimizer[key];
-export const getExtraModifiers = (key) => (state) => state.gearOptimizer.extraModifiers[key];
-export const getDistributionVersion = (state) => state.gearOptimizer.distribution.version;
-export const getDistributionOld = (state) => state.gearOptimizer.distribution.values1;
-export const getDistributionNew = (state) => state.gearOptimizer.distribution.values2;
-export const getTextBoxes = (state) => state.gearOptimizer.distribution.textBoxes;
-export const getSkills = (state) => state.gearOptimizer.skills;
 export const getModifiers = (state) => [
-  ...state.gearOptimizer.modifiers,
   ...state.extras.modifiers,
+  ...state.buffs.modifiers,
+  ...state.extraModifiers.modifiers,
+  ...state.omnipotion.modifiers,
+  ...state.skills.modifiers,
+  ...state.traits.modifiers,
 ];
-export const getTraitModifiers = (state) => state.gearOptimizer.traits.modifiers;
-export const getControl = (key) => (state) => state.gearOptimizer.control[key];
-export const getBuffs = (state) => state.gearOptimizer.buffs;
-export const getInfusions = (state) => state.gearOptimizer.infusions;
-export const getPriority = (key) => (state) => state.gearOptimizer.priorities[key];
-export const getList = (state) => state.gearOptimizer.control.list;
-export const getOmniPotion = (state) => state.gearOptimizer.omnipotion;
-export const getSelectedCharacter = (state) => state.gearOptimizer.control.selectedCharacter;
+
+export const getProfession = (state) => state.control.profession;
+export const getControl = (key) => (state) => state.control[key];
+export const getList = (state) => state.control.list;
+export const getSelectedCharacter = (state) => state.control.selectedCharacter;
 
 export const {
   reset,
   changeProfession,
   changeExpertMode,
-  changeAR,
-  changeTraitLine,
-  changeTraits,
-  changeGeneric,
-  changeDistributionVersion,
-  changeDistributionNew,
-  changeTextBoxes,
-  changeAllTextBoxes,
-  changeAllDistributionsOld,
-  changeAllDistributionsNew,
-  addSkill,
-  removeSkill,
-  changeForcedSlot,
-  addModifier,
-  removeModifier,
-  removeTraitModifierWithGW2id,
-  removeModifierWithSource,
-  changeExtraModifiers,
   changeControl,
-  changeBuff,
-  replaceBuffs,
-  changeInfusions,
-  changePriority,
   changeList,
-  addTraitModifier,
-  removeTraitModifier,
-  removeTraitModifierWithSource,
   setModifiers,
   setBuildTemplate,
-  changeOmnipotion,
-  changeState,
   changeSelectedCharacter,
   changeSelectedCharacterIfNone,
-} = gearOptimizerSlice.actions;
+} = controlSlice.actions;
 
-export default gearOptimizerSlice.reducer;
+export default controlSlice.reducer;

--- a/src/state/optimizer/sagas.js
+++ b/src/state/optimizer/sagas.js
@@ -68,9 +68,15 @@ function* runCalc() {
         maxToughness,
         affixes,
       },
-      modifiers,
+      modifiers: modifiersMain,
       distribution: { version, values1, values2 },
     } = state.gearOptimizer;
+    const { modifiers: modifiersExtras } = state.extras;
+
+    // need to reassemble modifiers of all slices here
+    const modifiers = [];
+    modifiers.push(...modifiersMain);
+    modifiers.push(...modifiersExtras);
 
     const parseTextNumber = (text, defaultValue) => {
       const parsed = Number.parseInt(text, 10);

--- a/src/state/optimizer/sagas.js
+++ b/src/state/optimizer/sagas.js
@@ -9,6 +9,7 @@ import {
   changeSelectedCharacter,
   changeSelectedCharacterIfNone,
   getList,
+  getModifiers,
 } from '../gearOptimizerSlice';
 import { INFUSIONS } from '../../utils/gw2-data';
 import { SUCCESS, WAITING } from './status';
@@ -48,17 +49,17 @@ function* runCalc() {
     state = yield select();
 
     console.groupCollapsed('Debug/Template Data:');
-    printTemplate(state.gearOptimizer);
+    printTemplate(state);
 
     const {
-      profession,
+      control: { profession },
       infusions: {
         primaryInfusion,
         secondaryInfusion,
         primaryMaxInfusions: primaryMaxInfusionsInput,
         secondaryMaxInfusions: secondaryMaxInfusionsInput,
       },
-      forcedSlots,
+      forcedSlots: { slots },
       priorities: {
         optimizeFor,
         weaponType,
@@ -68,15 +69,10 @@ function* runCalc() {
         maxToughness,
         affixes,
       },
-      modifiers: modifiersMain,
       distribution: { version, values1, values2 },
-    } = state.gearOptimizer;
-    const { modifiers: modifiersExtras } = state.extras;
+    } = state;
 
-    // need to reassemble modifiers of all slices here
-    const modifiers = [];
-    modifiers.push(...modifiersMain);
-    modifiers.push(...modifiersExtras);
+    const modifiers = getModifiers(state);
 
     const parseTextNumber = (text, defaultValue) => {
       const parsed = Number.parseInt(text, 10);
@@ -94,7 +90,7 @@ function* runCalc() {
       profession: profession.toLowerCase(),
       weapontype: weaponType,
       affixes: affixes.map((affix) => affix.toLowerCase().replace(/^\w/, (c) => c.toUpperCase())),
-      forcedAffixes: forcedSlots,
+      forcedAffixes: slots,
       rankby: optimizeFor,
       minBoonDuration,
       minHealingPower,

--- a/src/state/slices/buffs.js
+++ b/src/state/slices/buffs.js
@@ -66,7 +66,7 @@ export const buffsSlice = createSlice({
       // Apply "buffs" modifiers
       data.buffs.list
         .flatMap((d) => d.items)
-        .filter((elem) => state[elem.id])
+        .filter((elem) => state.buffs[elem.id])
         .forEach((elem) =>
           modifiers.push({ id: elem.id, modifiers: elem.modifiers, gw2_id: elem.gw2_id }),
         );

--- a/src/state/slices/buffs.js
+++ b/src/state/slices/buffs.js
@@ -1,0 +1,81 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { setBuildTemplate, setModifiers } from '../gearOptimizerSlice';
+
+export const buffsSlice = createSlice({
+  name: 'buffs',
+  initialState: {
+    buffs: {
+      might: false,
+      fury: false,
+      protection: false,
+      vulnerability: false,
+      bannerOfStrength: false,
+      bannerOfDiscipline: false,
+      bannerOfTactics: false,
+      bannerOfDefense: false,
+      spotter: false,
+      frostSpirit: false,
+      empowerAllies: false,
+      pinpointDistribution: false,
+      assassinsPresence: false,
+      facetOfNature: false,
+      riteDwarf: false,
+      strengthInNumbers: false,
+      baneSignet: false,
+      signetOfJudgment: false,
+      signetOfMercy: false,
+      signetOfWrath: false,
+      exposed: false,
+      lightArmor: false,
+    },
+    modifiers: [],
+  },
+  reducers: {
+    changeBuff: (state, action) => {
+      state.buffs[action.payload.key] = action.payload.value;
+    },
+    replaceBuffs: (state, action) => {
+      return {
+        ...state,
+        buffs: {
+          ...Object.fromEntries(
+            Object.keys(state.buffs).map((key) => [key, Boolean(action.payload[key])]),
+          ),
+        },
+      };
+    },
+  },
+  extraReducers: {
+    [setBuildTemplate]: (state, action) => {
+      const { buffPreset } = action.payload;
+
+      const buffs = {};
+      [...Object.keys(state.buffs)].forEach((key) => {
+        buffs[key] = false;
+        if (key in buffPreset) buffs[key] = buffPreset[key];
+      });
+
+      return { ...state, buffs };
+    },
+    [setModifiers]: (state, action) => {
+      const { data } = action.payload;
+
+      // all selected modifiers will be collected in this array
+      const modifiers = [];
+
+      // Apply "buffs" modifiers
+      data.buffs.list
+        .flatMap((d) => d.items)
+        .filter((elem) => state[elem.id])
+        .forEach((elem) =>
+          modifiers.push({ id: elem.id, modifiers: elem.modifiers, gw2_id: elem.gw2_id }),
+        );
+
+      state.modifiers = modifiers;
+    },
+  },
+});
+
+export const getBuffs = (state) => state.buffs.buffs;
+
+export const { changeBuff, replaceBuffs } = buffsSlice.actions;

--- a/src/state/slices/distribution.js
+++ b/src/state/slices/distribution.js
@@ -1,0 +1,92 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { setBuildTemplate } from '../gearOptimizerSlice';
+
+export const distributionSlice = createSlice({
+  name: 'distribution',
+  initialState: {
+    version: 2,
+    values1: {
+      Power: 100,
+      Burning: 0,
+      Bleeding: 0,
+      Poisoned: 0,
+      Torment: 0,
+      Confusion: 0,
+    },
+    values2: {
+      Power: 3000,
+      Burning: 0,
+      Bleeding: 0,
+      Poisoned: 0,
+      Torment: 0,
+      Confusion: 0,
+    },
+    textBoxes: {
+      Power: '3000',
+      Burning: '0',
+      Bleeding: '0',
+      Poisoned: '0',
+      Torment: '0',
+      Confusion: '0',
+    },
+  },
+  reducers: {
+    changeDistributionVersion: (state, action) => {
+      state.version = action.payload;
+    },
+    changeDistributionNew: (state, action) => {
+      return {
+        ...state,
+        values2: { ...state.values2, [action.payload.index]: action.payload.value },
+      };
+    },
+    changeTextBoxes: (state, action) => {
+      return {
+        ...state,
+        textBoxes: {
+          ...state.textBoxes,
+          [action.payload.index]: action.payload.value,
+        },
+      };
+    },
+    changeAllTextBoxes: (state, action) => {
+      state.textBoxes = action.payload;
+    },
+    changeAllDistributionsOld: (state, action) => {
+      state.values1 = action.payload;
+    },
+    changeAllDistributionsNew: (state, action) => {
+      state.values2 = action.payload;
+    },
+  },
+  extraReducers: {
+    [setBuildTemplate]: (state, action) => {
+      const { distributionPreset } = action.payload;
+
+      if (distributionPreset) {
+        return {
+          ...state,
+          version: 2,
+          values1: distributionPreset.values1,
+          values2: distributionPreset.values2,
+          textBoxes: distributionPreset.values2,
+        };
+      }
+      return state;
+    },
+  },
+});
+
+export const getDistributionVersion = (state) => state.distribution.version;
+export const getDistributionOld = (state) => state.distribution.values1;
+export const getDistributionNew = (state) => state.distribution.values2;
+export const getTextBoxes = (state) => state.distribution.textBoxes;
+
+export const {
+  changeDistributionVersion,
+  changeDistributionNew,
+  changeTextBoxes,
+  changeAllTextBoxes,
+  changeAllDistributionsOld,
+  changeAllDistributionsNew,
+} = distributionSlice.actions;

--- a/src/state/slices/extraModifiers.js
+++ b/src/state/slices/extraModifiers.js
@@ -1,0 +1,38 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { setModifiers } from '../gearOptimizerSlice';
+
+export const extraModifiersSlice = createSlice({
+  name: 'extraModifiers',
+  initialState: {
+    error: '',
+    extraModifiers: [],
+    textBox: '',
+    modifiers: [],
+  },
+  reducers: {
+    changeExtraModifiers: (state, action) => {
+      state.extraModifiers[action.payload.key] = action.payload.value;
+    },
+  },
+  extraReducers: {
+    [setModifiers]: (state, action) => {
+      // all selected modifiers will be collected in this array
+      const modifiers = [];
+      const { extraModifiers } = state;
+
+      // Apply extra (manual) modifiers
+      if (extraModifiers.length > 0) {
+        modifiers.push(
+          ...JSON.parse(extraModifiers).map((modi, index) => {
+            return { id: `extraModifier${index}`, modifiers: JSON.stringify(modi) };
+          }),
+        );
+      }
+      state.modifiers = modifiers;
+    },
+  },
+});
+
+export const getExtraModifiers = (key) => (state) => state.extraModifiers[key];
+
+export const { changeExtraModifiers } = extraModifiersSlice.actions;

--- a/src/state/slices/extras.js
+++ b/src/state/slices/extras.js
@@ -1,0 +1,60 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { setBuildTemplate, setModifiers } from '../gearOptimizerSlice';
+
+export const extrasSlice = createSlice({
+  name: 'extras',
+  initialState: {
+    Runes: '',
+    Sigil1: '',
+    Sigil2: '',
+    Enhancement: '',
+    Nourishment: '',
+    modifiers: [],
+  },
+  reducers: {
+    changeExtras: (state, action) => {
+      state[action.payload.key] = action.payload.value;
+    },
+  },
+  extraReducers: {
+    [setBuildTemplate]: (state, action) => {
+      const templateState = JSON.parse(action.payload.build.traits);
+      return { ...state, ...templateState.extras };
+    },
+    [setModifiers]: (state, action) => {
+      const data = action.payload;
+
+      // all selected modifiers will be collected in this array
+      const modifiers = [];
+
+      // Applies runes, sigils, food modifiers
+      const extrasData = [
+        { id: 'Runes', list: data.runes.list },
+        { id: 'Sigil1', list: data.sigils.list },
+        { id: 'Sigil2', list: data.sigils.list },
+        { id: 'Enhancement', list: data.enhancement.list },
+        { id: 'Nourishment', list: data.nourishment.list },
+      ];
+
+      extrasData
+        .filter((extra) => state[extra.id] !== '')
+        .filter((extra) => state[extra.id] !== undefined)
+        .forEach((extra) => {
+          modifiers.push({
+            id: state[extra.id],
+            modifiers: extra.list.flatMap((d) => d.items).find((a) => a.id === state[extra.id])
+              .modifiers,
+            source: extra.id,
+          });
+        });
+
+      state.modifiers = modifiers;
+    },
+  },
+});
+
+export const getExtra = (key) => (state) => state.extras[key];
+export const getExtras = (state) => state.extras;
+export const getExtrasModifiers = (state) => state.extras.modifiers;
+
+export const { changeExtras } = extrasSlice.actions;

--- a/src/state/slices/extras.js
+++ b/src/state/slices/extras.js
@@ -22,7 +22,7 @@ export const extrasSlice = createSlice({
       return { ...state, ...templateState.extras };
     },
     [setModifiers]: (state, action) => {
-      const data = action.payload;
+      const { data } = action.payload;
 
       // all selected modifiers will be collected in this array
       const modifiers = [];

--- a/src/state/slices/forcedSlots.js
+++ b/src/state/slices/forcedSlots.js
@@ -1,0 +1,17 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const forcedSlotsSlice = createSlice({
+  name: 'forcedSlots',
+  initialState: {
+    slots: [null, null, null, null, null, null, null, null, null, null, null, null, null],
+  },
+  reducers: {
+    changeForcedSlot: (state, action) => {
+      state.slots[action.payload.index] = action.payload.value;
+    },
+  },
+});
+
+export const getForcedSlots = (state) => state.forcedSlots.slots;
+
+export const { changeForcedSlot } = forcedSlotsSlice.actions;

--- a/src/state/slices/infusions.js
+++ b/src/state/slices/infusions.js
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const infusionsSlice = createSlice({
+  name: 'infusions',
+  initialState: {
+    primaryInfusion: '',
+    secondaryInfusion: '',
+    primaryMaxInfusions: '',
+    secondaryMaxInfusions: '',
+  },
+  reducers: {
+    changeInfusions: (state, action) => {
+      state[action.payload.key] = action.payload.value;
+    },
+  },
+});
+
+export const getInfusions = (state) => state.infusions;
+
+export const { changeInfusions } = infusionsSlice.actions;

--- a/src/state/slices/omnipotion.js
+++ b/src/state/slices/omnipotion.js
@@ -1,0 +1,55 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { Omnipotion } from '../../utils/gw2-data';
+import { changeExpertMode, setBuildTemplate, setModifiers } from '../gearOptimizerSlice';
+
+export const omnipotionSlice = createSlice({
+  name: 'omnipotion',
+  initialState: {
+    enable: true,
+    ar: 162,
+    modifiers: [],
+  },
+  reducers: {
+    changeAR: (state, action) => {
+      state.ar = action.payload;
+    },
+    changeOmnipotion: (state, action) => {
+      state.enable = action.payload;
+    },
+  },
+  extraReducers: {
+    [setBuildTemplate]: (state, action) => {
+      const templateState = JSON.parse(action.payload.build.traits);
+      return { ...state, ...templateState.extras };
+    },
+    [setModifiers]: (state, action) => {
+      // all selected modifiers will be collected in this array
+      const modifiers = [];
+
+      // Apply AR and omnipotion
+      if (state.ar) {
+        modifiers.push({
+          id: 'agony-resistance',
+          modifiers: JSON.stringify({
+            flat: {
+              'Agony Resistance': state.ar,
+            },
+          }),
+        });
+      }
+      if (state.omnipotion) {
+        modifiers.push({
+          id: 'omnipotion',
+          modifiers: JSON.stringify(Omnipotion),
+        });
+      }
+
+      state.modifiers = modifiers;
+    },
+  },
+});
+
+export const getAR = (state) => state.omnipotion.ar;
+export const getOmniPotion = (state) => state.omnipotion.enable;
+
+export const { changeAR, changeOmnipotion } = omnipotionSlice.actions;

--- a/src/state/slices/omnipotion.js
+++ b/src/state/slices/omnipotion.js
@@ -18,10 +18,6 @@ export const omnipotionSlice = createSlice({
     },
   },
   extraReducers: {
-    [setBuildTemplate]: (state, action) => {
-      const templateState = JSON.parse(action.payload.build.traits);
-      return { ...state, ...templateState.extras };
-    },
     [setModifiers]: (state, action) => {
       // all selected modifiers will be collected in this array
       const modifiers = [];
@@ -37,7 +33,7 @@ export const omnipotionSlice = createSlice({
           }),
         });
       }
-      if (state.omnipotion) {
+      if (state.enable) {
         modifiers.push({
           id: 'omnipotion',
           modifiers: JSON.stringify(Omnipotion),

--- a/src/state/slices/priorities.js
+++ b/src/state/slices/priorities.js
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { setBuildTemplate, setModifiers } from '../gearOptimizerSlice';
+
+export const prioritiesSlice = createSlice({
+  name: 'priorities',
+  initialState: {
+    optimizeFor: 'Damage',
+    weaponType: 'Dual wield',
+    minBoonDuration: '',
+    minHealingPower: '',
+    minToughness: '',
+    maxToughness: '',
+    affixes: [],
+  },
+  reducers: {
+    changePriority: (state, action) => {
+      state[action.payload.key] = action.payload.value;
+    },
+  },
+  extraReducers: {
+    [setBuildTemplate]: (state, action) => {
+      const { prioritiesPreset } = action.payload;
+      return { ...state, ...prioritiesPreset };
+    },
+  },
+});
+
+export const getPriority = (key) => (state) => state.priorities[key];
+
+export const { changePriority } = prioritiesSlice.actions;

--- a/src/state/slices/skills.js
+++ b/src/state/slices/skills.js
@@ -1,0 +1,58 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { changeProfession, setBuildTemplate, setModifiers } from '../gearOptimizerSlice';
+
+export const skillsSlice = createSlice({
+  name: 'skills',
+  initialState: {
+    skills: [],
+    modifiers: [],
+  },
+  reducers: {
+    addSkill: (state, action) => {
+      return { ...state, skills: state.skills.concat(action.payload) };
+    },
+    removeSkill: (state, action) => {
+      return { ...state, skills: state.skills.filter((v) => v !== action.payload) };
+    },
+  },
+  extraReducers: {
+    [changeProfession]: (state, action) => {
+      if (state.profession !== action.payload) {
+        return {
+          ...state,
+          skills: [],
+          modifiers: [],
+        };
+      }
+    },
+    [setBuildTemplate]: (state, action) => {
+      const { build } = action.payload;
+
+      const traitState = JSON.parse(build.traits);
+      return { ...state, skills: traitState.skills };
+    },
+    [setModifiers]: (state, action) => {
+      // passed data from GraphQL
+      const { data, profession } = action.payload;
+
+      // all selected modifiers will be collected in this array
+      const modifiers = [];
+
+      // map id to modifier. We dont store modifier values in the state!
+      const allSkillsAndTraits = data[profession.toLowerCase()].edges[0].node.list.flatMap(
+        (el) => el.items,
+      );
+      const matchedSkillModifiers = state.skills.map((skill) =>
+        allSkillsAndTraits.filter((t) => t !== null).find((s) => s.id === skill),
+      );
+
+      modifiers.push(...matchedSkillModifiers);
+
+      state.modifiers = modifiers;
+    },
+  },
+});
+
+export const getSkills = (state) => state.skills.skills;
+
+export const { addSkill, removeSkill } = skillsSlice.actions;

--- a/src/state/slices/traits.js
+++ b/src/state/slices/traits.js
@@ -1,0 +1,89 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { changeProfession, setBuildTemplate, setModifiers } from '../gearOptimizerSlice';
+
+export const traitsSlice = createSlice({
+  name: 'traits',
+  initialState: {
+    lines: ['', '', ''],
+    selected: [
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ],
+    modifiers: [],
+  },
+  reducers: {
+    changeTraitLine: (state, action) => {
+      state.lines[action.payload.index] = action.payload.value;
+    },
+    changeTraits: (state, action) => {
+      state.selected[action.payload.index] = action.payload.selected;
+    },
+    addTraitModifier: (state, action) => {
+      state.modifiers = state.modifiers.concat(action.payload);
+    },
+    removeTraitModifier: (state, action) => {
+      state.modifiers = state.modifiers.filter((m) => m.id !== action.payload);
+    },
+    removeTraitModifierWithGW2id: (state, action) => {
+      state.modifiers = state.modifiers.filter((m) => m.gw2_id !== action.payload);
+    },
+    removeTraitModifierWithSource: (state, action) => {
+      state.modifiers = state.modifiers.filter((m) => m.source !== action.payload);
+    },
+  },
+  extraReducers: {
+    [changeProfession]: (state, action) => {
+      if (state.profession !== action.payload) {
+        return {
+          ...state,
+          lines: ['', '', ''],
+          selected: [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+          ],
+          modifiers: [],
+        };
+      }
+    },
+    [setBuildTemplate]: (state, action) => {
+      const { build } = action.payload;
+
+      const traitState = JSON.parse(build.traits);
+      return { ...state, ...traitState.traits };
+    },
+    [setModifiers]: (state, action) => {
+      // passed data from GraphQL
+      const { data, profession } = action.payload;
+
+      // all selected modifiers will be collected in this array
+      const modifiers = [];
+
+      // map id to modifier. We dont store modifier values in the state!
+      const allSkillsAndTraits = data[profession.toLowerCase()].edges[0].node.list.flatMap(
+        (el) => el.items,
+      );
+      const matchedTraitModifiers = state.modifiers.map((traitModifier) =>
+        allSkillsAndTraits.filter((t) => t !== null).find((trait) => trait.id === traitModifier.id),
+      );
+
+      modifiers.push(...matchedTraitModifiers);
+
+      state.modifiers = modifiers;
+    },
+  },
+});
+
+export const getTraitLines = (state) => state.traits.lines;
+export const getTraits = (state) => state.traits.selected;
+export const getTraitModifiers = (state) => state.traits.modifiers;
+
+export const {
+  changeTraitLine,
+  changeTraits,
+  addTraitModifier,
+  removeTraitModifier,
+  removeTraitModifierWithGW2id,
+  removeTraitModifierWithSource,
+} = traitsSlice.actions;


### PR DESCRIPTION
This PR splits up the monolithic gearOptimizerSlice into many smaller slices. Every subsection has its own slice. The control object is now the former gearOptimizerSlice. Merged some values like `profession` into control.