### PR TITLE
Format+lint all the things

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,6 @@
     "prefer-arrow-callback": "off",
 
     // temp
-    "import/prefer-default-export": "off",
-
     "react/prop-types": "off",
     "react/self-closing-comp": "off",
     "react/jsx-props-no-spreading": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,6 @@
     // temp
     "react/prop-types": "off",
     "react/jsx-props-no-spreading": "off",
-    "react/destructuring-assignment": "off",
     "no-restricted-imports": [
       "error",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "no-continue": "off",
     "no-param-reassign": ["warn", { "props": false }],
     "consistent-return": "off",
-    "no-unused-vars": ["warn", { "argsIgnorePattern": "^event$|^e$|^props$" }],
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^event$|^e$|^props$|^theme$|^action$" }],
     "react/state-in-constructor": "off",
 
     // temp

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,6 @@
   "extends": ["react-app", "airbnb/whitespace", "airbnb/hooks", "prettier"],
   "rules": {
     "no-restricted-syntax": "off",
-    "no-use-before-define": "off",
     "no-plusplus": "off",
     "func-names": "off",
     "no-continue": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "no-continue": "off",
     "no-param-reassign": ["warn", { "props": false }],
     "consistent-return": "off",
-    "no-unused-vars": ["warn", { "argsIgnorePattern": "^event$|^e$|^props$|^theme$|^action$" }],
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^event$|^e$|^props$|^theme$|^action$|^_" }],
     "react/state-in-constructor": "off",
 
     // temp

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     "func-names": "off",
     "no-continue": "off",
     "no-param-reassign": ["warn", { "props": false }],
+    "react/state-in-constructor": "off",
 
     "consistent-return": "off",
     "no-unused-vars": ["warn", { "argsIgnorePattern": "^event$|^e$|^props$" }],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,6 @@
 
     // temp
     "react/prop-types": "off",
-    "react/self-closing-comp": "off",
     "react/jsx-props-no-spreading": "off",
     "react/destructuring-assignment": "off",
     "no-restricted-imports": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,6 @@
     "prefer-arrow-callback": "off",
 
     // temp
-    "one-var": "off",
-
     "import/prefer-default-export": "off",
 
     "react/prop-types": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,23 +7,24 @@
   "ignorePatterns": ["gulpfile.js"],
   "extends": ["react-app", "airbnb/whitespace", "airbnb/hooks", "prettier"],
   "rules": {
+    // disabled or reduced
     "no-restricted-syntax": "off",
     "no-plusplus": "off",
     "func-names": "off",
     "no-continue": "off",
     "no-param-reassign": ["warn", { "props": false }],
-    "react/state-in-constructor": "off",
-
     "consistent-return": "off",
     "no-unused-vars": ["warn", { "argsIgnorePattern": "^event$|^e$|^props$" }],
+    "react/state-in-constructor": "off",
+
+    // temp
+    "react/prop-types": "off",
+    "react/jsx-props-no-spreading": "off",
 
     // prettier compat
     "arrow-body-style": "off",
     "prefer-arrow-callback": "off",
 
-    // temp
-    "react/prop-types": "off",
-    "react/jsx-props-no-spreading": "off",
     "no-restricted-imports": [
       "error",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,6 @@
     "prefer-arrow-callback": "off",
 
     // temp
-    "object-shorthand": "off",
     "one-var": "off",
 
     "import/prefer-default-export": "off",

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 /* eslint-disable react/jsx-filename-extension */
 
 import React from 'react';
@@ -14,7 +15,6 @@ import createStore from './src/state/createStore';
 
 const { store, persistor } = createStore();
 
-// eslint-disable-next-line import/prefer-default-export
 export const wrapRootElement = ({ element }) => (
   <Provider store={store}>
     {/* TODO fix redux-persist breaking template swapping <PersistGate loading={<Spinner />} persistor={persistor}> */}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 /* eslint-disable react/jsx-filename-extension */
 
 import React from 'react';
@@ -9,7 +10,6 @@ import { Spinner } from 'gw2-ui-bulk';
 import getPageContext from './src/utils/getPageContext';
 import createStore from './src/state/createStore';
 
-// eslint-disable-next-line import/prefer-default-export
 export const replaceRenderer = ({ bodyComponent, replaceBodyHTMLString, setHeadComponents }) => {
   const { store, persistor } = createStore();
   const { sheetsRegistry } = getPageContext();

--- a/src/assets/data/buffs.yaml
+++ b/src/assets/data/buffs.yaml
@@ -145,10 +145,7 @@ list:
         type: 'Trait'
         extraCSS: 'text-guardian'
 
-  - section: >-
-      <span class="text-guardian">
-        Guardian - Perfect Inscriptions (Assuming 100% uptime!)
-      </span>
+  - section: Guardian - Perfect Inscriptions (100% uptime)
     items:
       - id: baneSignet
         text: 'Bane Signet'

--- a/src/assets/data/buffs.yaml
+++ b/src/assets/data/buffs.yaml
@@ -1,6 +1,6 @@
 GraphQL ID: Buffs
 list:
-  - section: "Boons"
+  - section: 'Boons'
     items:
       - id: might
         text: >-
@@ -12,7 +12,7 @@ list:
             "buff": { "Power": 750, "Condition Damage": 750 }
           }
         default-enabled: true
-        type: "Boon"
+        type: 'Boon'
 
       - id: fury
         text: >-
@@ -23,7 +23,7 @@ list:
             "flat": { "Critical Chance": 20 }
           }
         default-enabled: true
-        type: "Boon"
+        type: 'Boon'
 
       - id: protection
         text: >-
@@ -33,7 +33,7 @@ list:
           {
             "multiplier": { "Effective Health": 0.33 }
           }
-        type: "Boon"
+        type: 'Boon'
 
       - id: vulnerability
         text: >-
@@ -45,105 +45,105 @@ list:
             "multiplier": { "target: Effective Power": 0.25, "target: Effective Condition Damage": 0.25 }
           }
         default-enabled: true
-        type: "Condition"
+        type: 'Condition'
 
-  - section: "Warrior buffs"
+  - section: 'Warrior buffs'
     items:
       - id: bannerOfStrength
-        text: "Banner of Strength"
+        text: 'Banner of Strength'
         modifiers: >-
           {
             "buff": { "Power": 100, "Condition Damage": 100 }
           }
         gw2-id: 14405
-        type: "Skill"
+        type: 'Skill'
         default-enabled: true
-        extraCSS: "text-warrior"
+        extraCSS: 'text-warrior'
 
       - id: bannerOfDiscipline
-        text: "Banner of Discipline"
+        text: 'Banner of Discipline'
         modifiers: >-
           {
             "buff": { "Precision": 100, "Ferocity": 100 }
           }
         gw2-id: 14407
-        type: "Skill"
+        type: 'Skill'
         default-enabled: true
-        extraCSS: "text-warrior"
+        extraCSS: 'text-warrior'
 
       - id: bannerOfTactics
-        text: "Banner of Tactics"
+        text: 'Banner of Tactics'
         modifiers: >-
           {
             "buff": { "Healing Power": 100},
             "flat": { "Boon Duration": 10 }
           }
         gw2-id: 14408
-        type: "Skill"
-        extraCSS: "text-warrior"
+        type: 'Skill'
+        extraCSS: 'text-warrior'
 
       - id: bannerOfDefense
-        text: "Banner of Defense"
+        text: 'Banner of Defense'
         modifiers: >-
           {
             "buff": { "Toughness": 100, "Vitality": 100 }
           }
         gw2-id: 14528
-        type: "Skill"
-        extraCSS: "text-warrior"
+        type: 'Skill'
+        extraCSS: 'text-warrior'
 
       - id: empowerAllies
-        text: "Empower Allies"
+        text: 'Empower Allies'
         modifiers: >-
           {
             "buff": { "Power": 100 }
           }
         gw2-id: 1482
-        type: "Trait"
-        extraCSS: "text-warrior"
+        type: 'Trait'
+        extraCSS: 'text-warrior'
 
-  - section: "Other buffs"
+  - section: 'Other buffs'
     items:
       - id: spotter
-        text: "Spotter"
+        text: 'Spotter'
         modifiers: >-
           {
             "buff": { "Precision": 100 }
           }
         gw2-id: 1016
-        type: "Trait"
-        extraCSS: "text-ranger"
+        type: 'Trait'
+        extraCSS: 'text-ranger'
 
       - id: frostSpirit
-        text: "Frost Spirit"
+        text: 'Frost Spirit'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.05 }
           }
         gw2-id: 12497
-        type: "Skill"
+        type: 'Skill'
         default-enabled: true
-        extraCSS: "text-ranger"
+        extraCSS: 'text-ranger'
 
       - id: pinpointDistribution
-        text: "Pinpoint Distribution"
+        text: 'Pinpoint Distribution'
         modifiers: >-
           {
             "buff": { "Condition Damage": 100 }
           }
         gw2-id: 1984
-        type: "Trait"
-        extraCSS: "text-engineer"
+        type: 'Trait'
+        extraCSS: 'text-engineer'
 
       - id: strengthInNumbers
-        text: "Strength in Numbers"
+        text: 'Strength in Numbers'
         modifiers: >-
           {
             "buff": { "Toughness": 100 }
           }
         gw2-id: 584
-        type: "Trait"
-        extraCSS: "text-guardian"
+        type: 'Trait'
+        extraCSS: 'text-guardian'
 
   - section: >-
       <span class="text-guardian">
@@ -151,48 +151,48 @@ list:
       </span>
     items:
       - id: baneSignet
-        text: "Bane Signet"
+        text: 'Bane Signet'
         modifiers: >-
           {
             "buff": { "Power": 216 }
           }
         gw2-id: 9093
-        type: "Skill"
+        type: 'Skill'
         default-enabled: true
-        extraCSS: "text-guardian"
+        extraCSS: 'text-guardian'
 
       - id: signetOfJudgment
-        text: "Signet of Judgement"
+        text: 'Signet of Judgement'
         modifiers: >-
           {
             "multiplier": { "Effective Health": 0.12 }
           }
         gw2-id: 9150
-        type: "Skill"
-        extraCSS: "text-guardian"
+        type: 'Skill'
+        extraCSS: 'text-guardian'
 
       - id: signetOfMercy
-        text: "Signet of Mercy"
+        text: 'Signet of Mercy'
         modifiers: >-
           {
             "flat": { "Boon Duration": 10 }
           }
         gw2-id: 9163
-        type: "Skill"
+        type: 'Skill'
 
-        extraCSS: "text-guardian"
+        extraCSS: 'text-guardian'
 
       - id: signetOfWrath
-        text: "Signet of Wrath"
+        text: 'Signet of Wrath'
         modifiers: >-
           {
             "buff": { "Condition Damage": 216 }
           }
         gw2-id: 9151
-        type: "Skill"
-        extraCSS: "text-guardian"
+        type: 'Skill'
+        extraCSS: 'text-guardian'
 
-  - section: "Revenant buffs"
+  - section: 'Revenant buffs'
     items:
       - id: assassinsPresence
         text: "Assassin's Presence"
@@ -201,31 +201,31 @@ list:
             "buff": { "Ferocity": 150 }
           }
         gw2-id: 1786
-        type: "Trait"
+        type: 'Trait'
         default-enabled: true
-        extraCSS: "text-revenant"
+        extraCSS: 'text-revenant'
 
       - id: facetOfNature
-        text: "Facet of Nature—Dragon"
+        text: 'Facet of Nature—Dragon'
         modifiers: >-
           {
             "flat": { "Boon Duration": 20 }
           }
         gw2-id: 29371
-        type: "Skill"
-        extraCSS: "text-revenant"
+        type: 'Skill'
+        extraCSS: 'text-revenant'
 
       - id: riteDwarf
-        text: "Rite of the Great Dwarf"
+        text: 'Rite of the Great Dwarf'
         modifiers: >-
           {
             "multiplier": { "Effective Health": 0.5 }
           }
         gw2-id: 27975
-        type: "Skill"
-        extraCSS: "text-revenant"
+        type: 'Skill'
+        extraCSS: 'text-revenant'
 
-  - section: "Effects"
+  - section: 'Effects'
     items:
       - id: exposed
         text: >-
@@ -236,7 +236,7 @@ list:
           {
             "multiplier": { "target: Effective Power": 0.3, "target: Effective Condition Damage": 1.0 }
           }
-        type: "CommonEffect"
+        type: 'CommonEffect'
 
       - id: lightArmor
         text: >-
@@ -246,4 +246,4 @@ list:
           {
             "multiplier": { "Effective Power": 0.359685864 }
           }
-        type: "Text"
+        type: 'Text'

--- a/src/assets/data/elementalist.yaml
+++ b/src/assets/data/elementalist.yaml
@@ -3,73 +3,73 @@ list:
   - section: Skills
     items:
       - id: signet-of-fire
-        text: "Signet of Fire"
+        text: 'Signet of Fire'
         modifiers: >-
           {
             "buff": { "Precision": 180 }
           }
         gw2-id: 5542
-        type: "skills"
+        type: 'skills'
 
       - id: signet-of-earth
-        text: "Signet of Earth"
+        text: 'Signet of Earth'
         modifiers: >-
           {
             "buff": { "Toughness": 180 }
           }
         gw2-id: 5571
-        type: "skills"
+        type: 'skills'
 
       - id: flame-axe
-        text: "Flame Axe"
-        subText: "when equipped"
+        text: 'Flame Axe'
+        subText: 'when equipped'
         modifiers: >-
           {
             "buff": { "Power": 180, "Condition Damage": 180 }
           }
         gw2-id: 5540
-        type: "skills"
+        type: 'skills'
 
       - id: earth-shield
-        text: "Earth Shield"
-        subText: "when equipped"
+        text: 'Earth Shield'
+        subText: 'when equipped'
         modifiers: >-
           {
             "buff": { "Vitality": 180, "Toughness": 180 }
           }
         gw2-id: 5546
-        type: "skills"
+        type: 'skills'
 
       - id: fiery-greatsword
-        text: "Fiery Greatsword"
-        subText: "when equipped"
+        text: 'Fiery Greatsword'
+        subText: 'when equipped'
         modifiers: >-
           {
             "buff": { "Power": 260, "Condition Damage": 180 }
           }
         gw2-id: 5516
-        type: "skills"
+        type: 'skills'
 
       - id: lightning-hammer
-        text: "Lightning Hammer"
-        subText: "when equipped"
+        text: 'Lightning Hammer'
+        subText: 'when equipped'
         modifiers: >-
           {
             "buff": { "Precision": 180, "Ferocity": 75 }
           }
         gw2-id: 5624
-        type: "skills"
+        type: 'skills'
 
       - id: frost-bow
-        text: "Frost Bow"
-        subText: "when equipped"
+        text: 'Frost Bow'
+        subText: 'when equipped'
         modifiers: >-
           {
             "buff": { "Healing Power": 180 },
             "flat": { "Condition Duration": 20 }
           }
         gw2-id: 5567
-        type: "skills"
+        type: 'skills'
 
   - section: Fire
     id: 31
@@ -84,38 +84,38 @@ list:
             "buff": { "Power": 150 }
           }
         gw2-id: 320
-        type: "traits"
+        type: 'traits'
 
       - id: burning-precision
-        text: "Burning Precision"
+        text: 'Burning Precision'
         modifiers: >-
           {
             "flat": { "Burning Duration": 20 }
           }
         gw2-id: 296
-        type: "traits"
+        type: 'traits'
 
       - id: burning-rage
-        text: "Burning Rage"
+        text: 'Burning Rage'
         modifiers: >-
           {
             "buff": { "Condition Damage": 180 }
           }
         gw2-id: 325
-        type: "traits"
+        type: 'traits'
 
       - id: power-overwhelming
-        text: "Power Overwhelming"
-        subText: "perma"
+        text: 'Power Overwhelming'
+        subText: 'perma'
         modifiers: >-
           {
             "buff": { "Power": 150 }
           }
         gw2-id: 334
-        type: "traits"
+        type: 'traits'
 
       - id: power-overwhelming-2
-        text: "Power Overwhelming"
+        text: 'Power Overwhelming'
         subText: >-
           (100% in fire - tick both)
         modifiers: >-
@@ -123,7 +123,7 @@ list:
             "buff": { "Power": 150 }
           }
         gw2-id: 334
-        type: "traits"
+        type: 'traits'
 
       - id: pyromancers-training
         text: "Pyromancer's Training"
@@ -133,48 +133,48 @@ list:
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 319
-        type: "traits"
+        type: 'traits'
 
   - section: Air
     id: 41
     items:
       - id: ferocious-winds
-        text: "Ferocious Winds"
+        text: 'Ferocious Winds'
         modifiers: >-
           {
             "convert": { "Ferocity": { "Precision": 0.07 } }
           }
         gw2-id: 232
-        type: "traits"
+        type: 'traits'
 
       - id: raging-storm
-        text: "Raging Storm"
+        text: 'Raging Storm'
         modifiers: >-
           {
             "buff": { "Ferocity": 180 }
           }
         gw2-id: 214
-        type: "traits"
+        type: 'traits'
 
       - id: stormsoul
-        text: "Stormsoul"
+        text: 'Stormsoul'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 1502
-        type: "traits"
+        type: 'traits'
 
       - id: aeromancers-training
         text: "Aeromancer's Training"
-        subText: "perma"
+        subText: 'perma'
         minor: true
         modifiers: >-
           {
             "buff": { "Ferocity": 150 }
           }
         gw2-id: 223
-        type: "traits"
+        type: 'traits'
 
       - id: aeromancers-training-2
         text: "Aeromancer's Training"
@@ -186,33 +186,33 @@ list:
             "buff": { "Ferocity": 150 }
           }
         gw2-id: 223
-        type: "traits"
+        type: 'traits'
 
       - id: bolt-to-the-heart
-        text: "Bolt to the Heart"
-        subText: "50% uptime"
+        text: 'Bolt to the Heart'
+        subText: '50% uptime'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 226
-        type: "traits"
+        type: 'traits'
 
       - id: fresh-air
-        text: "Fresh Air"
-        subText: "100% uptime"
+        text: 'Fresh Air'
+        subText: '100% uptime'
         modifiers: >-
           {
             "buff": { "Ferocity": 250 }
           }
         gw2-id: 1503
-        type: "traits"
+        type: 'traits'
 
   - section: Earth
     id: 26
     items:
       - id: stone-flesh
-        text: "Stone Flesh"
+        text: 'Stone Flesh'
         minor: true
         subText: >-
           (100% in earth)
@@ -221,26 +221,26 @@ list:
             "multiplier": { "Effective Health": 0.07 }
           }
         gw2-id: 278
-        type: "traits"
+        type: 'traits'
 
       - id: serrated-stones
-        text: "Serrated Stones"
+        text: 'Serrated Stones'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.05 },
             "flat": { "Bleeding Duration": 20 }
           }
         gw2-id: 1507
-        type: "traits"
+        type: 'traits'
 
       - id: strength-of-stone
-        text: "Strength of Stone"
+        text: 'Strength of Stone'
         modifiers: >-
           {
             "convert": { "Condition Damage": { "Toughness": 0.1 } }
           }
         gw2-id: 275
-        type: "traits"
+        type: 'traits'
 
       - id: geomancers-defense
         text: "Geomancer's Defense"
@@ -250,22 +250,22 @@ list:
             "multiplier": { "Effective Health": 0.1 }
           }
         gw2-id: 280
-        type: "traits"
+        type: 'traits'
 
   - section: Water
     id: 17
     items:
       - id: piercing-blades
-        text: "Piercing Shards"
+        text: 'Piercing Shards'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 363
-        type: "traits"
+        type: 'traits'
 
       - id: piercing-blades-2
-        text: "Piercing Shards"
+        text: 'Piercing Shards'
         subText: >-
           100% in water - tick both
         modifiers: >-
@@ -273,16 +273,16 @@ list:
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 363
-        type: "traits"
+        type: 'traits'
 
       - id: flow-like-water
-        text: "Flow like Water"
+        text: 'Flow like Water'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 349
-        type: "traits"
+        type: 'traits'
 
       - id: aquamancers-training
         text: "Aquamancer's Training"
@@ -292,138 +292,138 @@ list:
           }
         minor: true
         gw2-id: 1676
-        type: "traits"
+        type: 'traits'
 
   - section: Arcane
     id: 37
     items:
       - id: elemental-enchantment
-        text: "Elemental Enchantment"
+        text: 'Elemental Enchantment'
         modifiers: >-
           {
             "buff": { "Concentration": 180 }
           }
         minor: true
         gw2-id: 2004
-        type: "traits"
+        type: 'traits'
 
       - id: elemental-surge
-        text: "Elemental Surge (100% uptime)"
+        text: 'Elemental Surge (100% uptime)'
         modifiers: >-
           {
             "flat": { "Ferocity": 150 }
           }
         gw2-id: 263
-        type: "traits"
+        type: 'traits'
 
       - id: bountiful-power
-        text: "Bountiful Power"
-        subText: "6x"
+        text: 'Bountiful Power'
+        subText: '6x'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.12 }
           }
         gw2-id: 1511
-        type: "traits"
+        type: 'traits'
 
       - id: bountiful-power-9
-        text: "Bountiful Power"
-        subText: "9x"
+        text: 'Bountiful Power'
+        subText: '9x'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.18 }
           }
         gw2-id: 1511
-        type: "traits"
+        type: 'traits'
 
   - section: Tempest
     id: 48
     items:
       - id: gathered-focus
-        text: "Gathered Focus"
+        text: 'Gathered Focus'
         modifiers: >-
           {
             "buff": { "Concentration": 240 }
           }
         minor: true
         gw2-id: 1938
-        type: "traits"
+        type: 'traits'
 
       - id: hardy-conduit
-        text: "Hardy Conduit"
+        text: 'Hardy Conduit'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Health": 0.1167 }
           }
         gw2-id: 1948
-        type: "traits"
+        type: 'traits'
 
       - id: transcendent-tempest
-        text: "Transcendent Tempest"
+        text: 'Transcendent Tempest'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.07, "add: Effective Condition Damage": 0.07 }
           }
         gw2-id: 1839
-        type: "traits"
+        type: 'traits'
 
   - section: Weaver
     id: 56
     items:
       - id: superior-elements
-        text: "Superior Elements"
-        subText: "100% uptime"
+        text: 'Superior Elements'
+        subText: '100% uptime'
         modifiers: >-
           {
             "flat": { "Critical Chance": 10 }
           }
         gw2-id: 2177
-        type: "traits"
+        type: 'traits'
 
       - id: masters-fortitude
         text: "Master's Fortitude"
-        subText: "With Sword"
+        subText: 'With Sword'
         modifiers: >-
           {
             "flat": { "Vitality": 120 },
             "convert": { "Vitality": { "Power": 0.05, "Condition Damage": 0.05 } }
           }
         gw2-id: 2115
-        type: "traits"
+        type: 'traits'
 
       - id: masters-fortitude-without
         text: "Master's Fortitude"
-        subText: "Without Sword"
+        subText: 'Without Sword'
         modifiers: >-
           {
             "convert": { "Vitality": { "Power": 0.05, "Condition Damage": 0.05 } }
           }
         gw2-id: 2115
-        type: "traits"
+        type: 'traits'
 
       - id: weavers-prowess
         text: "Weaver's Prowess"
-        subText: "100% uptime"
+        subText: '100% uptime'
         modifiers: >-
           {
             "multiplier": { "add: Effective Condition Damage": 0.1 },
             "flat": { "Condition Duration": 20 }
           }
         gw2-id: 2180
-        type: "traits"
+        type: 'traits'
 
       - id: swift-revenge
-        text: "Swift Revenge"
+        text: 'Swift Revenge'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.1 }
           }
         gw2-id: 2061
-        type: "traits"
+        type: 'traits'
 
       - id: elemental-polyphony-fire
-        text: "Elemental Polyphony"
+        text: 'Elemental Polyphony'
         subText: >-
           100% in fire
         minor: true
@@ -432,10 +432,10 @@ list:
             "buff": { "Power": 120 }
           }
         gw2-id: 2081
-        type: "traits"
+        type: 'traits'
 
       - id: elemental-polyphony-air
-        text: "Elemental Polyphony"
+        text: 'Elemental Polyphony'
         subText: >-
           100% in air
         minor: true
@@ -444,14 +444,14 @@ list:
             "buff": { "Ferocity": 120 }
           }
         gw2-id: 2081
-        type: "traits"
+        type: 'traits'
 
       - id: elements-of-rage
-        text: "Elements of Rage"
+        text: 'Elements of Rage'
         modifiers: >-
           {
             "multiplier": { "add: Effective Condition Damage": 0.05 },
             "convert": { "Precision": { "Vitality": 0.13 } }
           }
         gw2-id: 2131
-        type: "traits"
+        type: 'traits'

--- a/src/assets/data/mesmer.yaml
+++ b/src/assets/data/mesmer.yaml
@@ -1,151 +1,151 @@
 GraphQL ID: Mesmer
 list:
-  - section: "Skills"
+  - section: 'Skills'
     items:
       - id: signet-of-domination
-        text: "Signet of Domination"
+        text: 'Signet of Domination'
         modifiers: >-
           {
             "buff": { "Condition Damage": 180 }
           }
         gw2-id: 10232
-        type: "skills"
+        type: 'skills'
 
       - id: signet-of-midnight
-        text: "Signet of Midnight"
+        text: 'Signet of Midnight'
         modifiers: >-
           {
             "buff": { "Expertise": 180 }
           }
         gw2-id: 10234
-        type: "skills"
+        type: 'skills'
 
-  - section: "Domination"
+  - section: 'Domination'
     id: 10
     items:
       - id: fragility
-        text: "Fragility"
+        text: 'Fragility'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.125 }
           }
         gw2-id: 1941
-        type: "traits"
+        type: 'traits'
 
       - id: egotism
-        text: "Egotism"
+        text: 'Egotism'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 713
-        type: "traits"
+        type: 'traits'
 
       - id: vicious-expression
-        text: "Vicious Expression"
+        text: 'Vicious Expression'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.15 }
           }
         gw2-id: 681
-        type: "traits"
+        type: 'traits'
 
-  - section: "Dueling"
+  - section: 'Dueling'
     id: 1
     items:
       - id: fencers-finesse
         text: "Fencer's Finesse"
-        subText: "10x"
+        subText: '10x'
         modifiers: >-
           {
             "buff": { "Ferocity": 150 }
           }
         gw2-id: 708
-        type: "traits"
+        type: 'traits'
 
       - id: superiority-complex
-        text: "Superiority Complex"
-        subText: "50% uptime -> +20% Critical Damage"
+        text: 'Superiority Complex'
+        subText: '50% uptime -> +20% Critical Damage'
         modifiers: >-
           {
             "multiplier": { "Critical Damage": 0.2 }
           }
         gw2-id: 692
-        type: "traits"
+        type: 'traits'
 
-  - section: "Chaos"
+  - section: 'Chaos'
     id: 45
     items:
       - id: illusionary-defense
-        text: "Illusionary Defense"
-        subText: "5x"
+        text: 'Illusionary Defense'
+        subText: '5x'
         modifiers: >-
           {
             "multiplier": { "Effective Health": 0.25 }
           }
         gw2-id: 675
-        type: "traits"
+        type: 'traits'
 
       - id: illusionary-membrane
-        text: "Illusionary Membrane"
+        text: 'Illusionary Membrane'
         minor: true
         modifiers: >-
           {
             "multiplier": { "add: Effective Condition Damage": 0.1 }
           }
         gw2-id: 667
-        type: "traits"
+        type: 'traits'
 
       - id: chaotic-potency
-        text: "Chaotic Potency"
-        subText: "base"
+        text: 'Chaotic Potency'
+        subText: 'base'
         modifiers: >-
           {
             "buff": { "Condition Damage": 120 }
           }
         gw2-id: 669
-        type: "traits"
+        type: 'traits'
 
       - id: chaotic-potency-2
-        text: "Chaotic Potency"
-        subText: "with staff - check both boxes"
+        text: 'Chaotic Potency'
+        subText: 'with staff - check both boxes'
         modifiers: >-
           {
             "buff": { "Condition Damage": 120 }
           }
         gw2-id: 669
-        type: "traits"
+        type: 'traits'
 
       - id: chaotic-persistence
-        text: "Chaotic Persistence"
+        text: 'Chaotic Persistence'
         minor: true
         modifiers: >-
           {
             "buff": { "Concentration": 250, "Expertise": 250 }
           }
         gw2-id: 1865
-        type: "traits"
+        type: 'traits'
 
-  - section: "Inspiration"
+  - section: 'Inspiration'
     id: 23
     items:
       - id: healing-prism
-        text: "Healing Prism"
+        text: 'Healing Prism'
         modifiers: >-
           {
             "convert": { "Healing Power": { "Power": 0.13 } }
           }
         minor: true
         gw2-id: 1915
-        type: "traits"
+        type: 'traits'
 
-  - section: "Illusions"
+  - section: 'Illusions'
     id: 24
     items:
       - id: compounding-power
-        text: "Compounding Power"
-        subText: "5x"
+        text: 'Compounding Power'
+        subText: '5x'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.1 },
@@ -153,21 +153,21 @@ list:
           }
         minor: true
         gw2-id: 723
-        type: "traits"
+        type: 'traits'
 
-  - section: "Chronomancer"
+  - section: 'Chronomancer'
     id: 40
     items:
       - id: danger-time
-        text: "Danger Time"
+        text: 'Danger Time'
         modifiers: >-
           {
             "flat": { "Critical Chance": 15 }
           }
         gw2-id: 2009
-        type: "traits"
+        type: 'traits'
 
-  - section: "Mirage"
+  - section: 'Mirage'
     id: 59
     items:
       - id: nomads-endurance
@@ -178,4 +178,4 @@ list:
           }
         minor: true
         gw2-id: 2069
-        type: "traits"
+        type: 'traits'

--- a/src/assets/data/necromancer.yaml
+++ b/src/assets/data/necromancer.yaml
@@ -1,74 +1,74 @@
 GraphQL ID: Necromancer
 list:
-  - section: "Skills"
+  - section: 'Skills'
     items:
       - id: signet-of-spite
-        text: "Signet of Spite"
+        text: 'Signet of Spite'
         modifiers: >-
           {
             "buff": { "Power": 180 }
           }
         gw2-id: 10622
-        type: "skills"
+        type: 'skills'
 
-  - section: "Spite"
+  - section: 'Spite'
     id: 53
     items:
       - id: spiteful-talisman
-        text: "Spiteful Talisman"
+        text: 'Spiteful Talisman'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 914
-        type: "traits"
+        type: 'traits'
 
       - id: awaken-the-pain
-        text: "Awaken the Pain"
-        subText: "25 might"
+        text: 'Awaken the Pain'
+        subText: '25 might'
         modifiers: >-
           {
             "buff": { "Power": 250, "Condition Damage": -250 }
           }
         gw2-id: 829
-        type: "traits"
+        type: 'traits'
 
       - id: close-to-death
-        text: "Close to Death"
-        subText: "50%"
+        text: 'Close to Death'
+        subText: '50%'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 853
-        type: "traits"
+        type: 'traits'
 
-  - section: "Curses"
+  - section: 'Curses'
     id: 39
     items:
       - id: barbed-precision
-        text: "Barbed Precision"
+        text: 'Barbed Precision'
         minor: true
         modifiers: >-
           {
             "flat": { "Bleeding Duration": 20 }
           }
         gw2-id: 802
-        type: "traits"
+        type: 'traits'
 
       - id: furious-demise
-        text: "Furious Demise"
+        text: 'Furious Demise'
         minor: true
         modifiers: >-
           {
             "flat": { "Precision": 180 }
           }
         gw2-id: 803
-        type: "traits"
+        type: 'traits'
 
       - id: target-the-weak
-        text: "Target the Weak"
-        subText: "10x"
+        text: 'Target the Weak'
+        subText: '10x'
         minor: true
         modifiers: >-
           {
@@ -76,181 +76,181 @@ list:
             "convert": { "Condition Damage": { "Precision": 0.13 } }
           }
         gw2-id: 810
-        type: "traits"
+        type: 'traits'
 
       - id: lingering-curse
-        text: "Lingering Curse"
-        subText: "base only"
+        text: 'Lingering Curse'
+        subText: 'base only'
         modifiers: >-
           {
             "buff": { "Condition Damage": 200 }
           }
         gw2-id: 801
-        type: "traits"
+        type: 'traits'
 
-  - section: "Death Magic"
+  - section: 'Death Magic'
     id: 2
     items:
       - id: carapace
-        text: ""
-        subText: "toughness from carapace, 6x"
+        text: ''
+        subText: 'toughness from carapace, 6x'
         minor: true
         modifiers: >-
           {
             "buff": { "Toughness": 120 }
           }
         gw2-id:
-        type: "traits"
+        type: 'traits'
 
       - id: putrid-defense
-        text: "Putrid Defense"
+        text: 'Putrid Defense'
         modifiers: >-
           {
             "multiplier": { "Poison Damage": 0.15 }
           }
         gw2-id: 857
-        type: "traits"
+        type: 'traits'
 
       - id: deadly-strength-6x
-        text: "Deadly Strength"
-        subText: "6x carapace"
+        text: 'Deadly Strength'
+        subText: '6x carapace'
         modifiers: >-
           {
             "buff": { "Power": 60 }
           }
         gw2-id: 855
-        type: "traits"
+        type: 'traits'
 
       - id: deadly-strength-25x
-        text: "Deadly Strength"
-        subText: "25x carapace"
+        text: 'Deadly Strength'
+        subText: '25x carapace'
         modifiers: >-
           {
             "buff": { "Power": 250 }
           }
         gw2-id: 855
-        type: "traits"
+        type: 'traits'
 
   # - section: "Blood Magic"
   #   id: 19
   #   items:
 
-  - section: "Soul Reaping"
+  - section: 'Soul Reaping'
     id: 50
     items:
       - id: soul-barbs
-        text: "Soul Barbs"
-        subText: "100%"
+        text: 'Soul Barbs'
+        subText: '100%'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.1, "add: Effective Condition Damage": 0.1 }
           }
         gw2-id: 894
-        type: "traits"
+        type: 'traits'
 
       - id: vital-persistence
-        text: "Vital Persistence"
+        text: 'Vital Persistence'
         modifiers: >-
           {
             "flat": { "Vitality": 180 }
           }
         gw2-id: 861
-        type: "traits"
+        type: 'traits'
 
       - id: death-perception
-        text: "Death Perception"
-        subText: "INACCURATE: 100% in shroud"
+        text: 'Death Perception'
+        subText: 'INACCURATE: 100% in shroud'
         modifiers: >-
           {
             "flat": { "Critical Chance": 33 },
             "buff": { "Ferocity": 300 }
           }
         gw2-id: 893
-        type: "traits"
+        type: 'traits'
 
-  - section: "Scourge"
+  - section: 'Scourge'
     id: 60
     items:
       - id: fell-beacon
-        text: "Fell Beacon"
+        text: 'Fell Beacon'
         modifiers: >-
           {
             "convert": { "Expertise": { "Condition Damage": 0.07 } }
           }
         gw2-id: 2074
-        type: "traits"
+        type: 'traits'
 
       - id: sand-sage-2x
-        text: "Sand Sage"
-        subText: "2x"
+        text: 'Sand Sage'
+        subText: '2x'
         minor: true
         modifiers: >-
           {
             "flat": { "Concentration": 150, "Expertise": 150 }
           }
         gw2-id: 2121
-        type: "traits"
+        type: 'traits'
 
       - id: sand-sage-3x
-        text: "Sand Sage"
-        subText: "3x"
+        text: 'Sand Sage'
+        subText: '3x'
         minor: true
         modifiers: >-
           {
             "flat": { "Concentration": 225, "Expertise": 225 }
           }
         gw2-id: 2121
-        type: "traits"
+        type: 'traits'
 
       - id: demonic-lore
-        text: "Demonic Lore"
-        subText: "Torment only"
+        text: 'Demonic Lore'
+        subText: 'Torment only'
         modifiers: >-
           {
             "multiplier": { "Torment Damage": 0.25 }
           }
         gw2-id: 2164
-        type: "traits"
+        type: 'traits'
 
-  - section: "Reaper"
+  - section: 'Reaper'
     id: 34
     items:
       - id: soul-eater
-        text: "Soul Eater"
+        text: 'Soul Eater'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 1969
-        type: "traits"
+        type: 'traits'
 
       - id: decimate-defenses-25x
-        text: "Decimate Defenses"
-        subText: "25x"
+        text: 'Decimate Defenses'
+        subText: '25x'
         modifiers: >-
           {
             "flat": { "Critical Chance": 50 }
           }
         gw2-id: 2031
-        type: "traits"
+        type: 'traits'
 
       - id: cold-shoulder
-        text: "Cold Shoulder"
-        subText: "100%"
+        text: 'Cold Shoulder'
+        subText: '100%'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.15 }
           }
         gw2-id: 2018
-        type: "traits"
+        type: 'traits'
 
       - id: reapers-onslaught
         text: "Reaper's Onslaught"
-        subText: "INACCURATE: 100% in shroud"
+        subText: 'INACCURATE: 100% in shroud'
         modifiers: >-
           {
             "buff": { "Ferocity": 300 }
           }
         gw2-id: 2021
-        type: "traits"
+        type: 'traits'

--- a/src/assets/data/preset-distribution.yaml
+++ b/src/assets/data/preset-distribution.yaml
@@ -1,6 +1,5 @@
 GraphQL ID: presetDistribution
 list:
-
   # button not shown; used for no-op templates
   - name: None
     value: >-
@@ -359,4 +358,3 @@ list:
         "values1": { "Power": 91, "Burning": 4, "Bleeding": 1, "Poisoned": 4, "Torment": 0, "Confusion": 0 },
         "values2": { "Power": 3500, "Burning": 0.5, "Bleeding": 0.4, "Poisoned": 1.8, "Torment": 0, "Confusion": 0 }
       }
-

--- a/src/assets/data/revenant.yaml
+++ b/src/assets/data/revenant.yaml
@@ -2,216 +2,216 @@ GraphQL ID: Revenant
 list:
   - section: 'Skills'
 
-  - section: "Corruption"
+  - section: 'Corruption'
     id: 14
     items:
       - id: acolyte-of-torment
-        text: "Acolyte of Torment"
+        text: 'Acolyte of Torment'
         modifiers: >-
           {
             "multiplier": { "Torment Damage": 0.1 }
           }
         gw2-id: 1793
-        type: "traits"
+        type: 'traits'
 
       - id: seething-malice
-        text: "Seething Malice"
+        text: 'Seething Malice'
         modifiers: >-
           {
             "buff": { "Condition Damage": 120 }
           }
         gw2-id: 1801
-        type: "traits"
+        type: 'traits'
 
       - id: demonic-resistance
-        text: "Demonic Resistance"
+        text: 'Demonic Resistance'
         modifiers: >-
           {
             "multiplier": { "Effective Health": 0.2 }
           }
         gw2-id: 1726
-        type: "traits"
+        type: 'traits'
 
       - id: pact-of-pain
-        text: "Pact of Pain"
+        text: 'Pact of Pain'
         modifiers: >-
           {
             "flat": { "Condition Duration": 15 }
           }
         gw2-id: 1714
-        type: "traits"
+        type: 'traits'
 
       - id: yearning-empowerment
-        text: "Yearning Empowerement"
+        text: 'Yearning Empowerement'
         modifiers: >-
           {
             "flat": { "Condition Duration": 10 }
           }
         gw2-id: 1744
-        type: "traits"
+        type: 'traits'
 
-  - section: "Retribution"
+  - section: 'Retribution'
     id: 9
     items:
       - id: dwarven-battle-training
-        text: "Dwarven Battle Training"
+        text: 'Dwarven Battle Training'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 1740
-        type: "traits"
+        type: 'traits'
 
       - id: determined-resolution
-        text: "Determined Resolution"
+        text: 'Determined Resolution'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Health": 0.1 }
           }
         gw2-id: 1713
-        type: "traits"
+        type: 'traits'
 
       - id: vicious-reprisal
-        text: "Vicious Reprisal"
-        subText: "100%"
+        text: 'Vicious Reprisal'
+        subText: '100%'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.1, "add: Effective Condition Damage": 0.1 }
           }
         gw2-id: 1779
-        type: "traits"
+        type: 'traits'
 
       - id: versed-in-stone
-        text: "Versed in Stone"
+        text: 'Versed in Stone'
         modifiers: >-
           {
             "convert": { "Power": { "Toughness": 0.13 } }
           }
         gw2-id: 1770
-        type: "traits"
+        type: 'traits'
 
-  - section: "Invocation"
+  - section: 'Invocation'
     id: 3
     items:
       - id: rising-tide
-        text: "Rising Tide"
+        text: 'Rising Tide'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.07 }
           }
         gw2-id: 1761
-        type: "traits"
+        type: 'traits'
 
       - id: ferocious-aggression
-        text: "Ferocious Aggression"
+        text: 'Ferocious Aggression'
         minor: true
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.07, "add: Effective Condition Damage": 0.07 }
           }
         gw2-id: 1758
-        type: "traits"
+        type: 'traits'
 
       - id: roiling-mists
-        text: "Roiling Mists"
+        text: 'Roiling Mists'
         modifiers: >-
           {
             "flat": { "Critical Chance": 20 }
           }
         gw2-id: 1719
-        type: "traits"
+        type: 'traits'
 
-  - section: "Devastation"
+  - section: 'Devastation'
     id: 15
     items:
       - id: unsuspecting-strikes
-        text: "Unsuspecting Strikes"
-        subText: "20% uptime -> +4% Damage"
+        text: 'Unsuspecting Strikes'
+        subText: '20% uptime -> +4% Damage'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.04 }
           }
         gw2-id: 1767
-        type: "traits"
+        type: 'traits'
 
       - id: destructive-impulses-dual
-        text: "Destructive Impulses"
-        subText: "Dual wielded"
+        text: 'Destructive Impulses'
+        subText: 'Dual wielded'
         minor: true
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.1, "add: Effective Condition Damage": 0.1 }
           }
         gw2-id: 1724
-        type: "traits"
+        type: 'traits'
 
       - id: destructive-impulses
-        text: "Destructive Impulses"
-        subText: "Two handed"
+        text: 'Destructive Impulses'
+        subText: 'Two handed'
         minor: true
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.05, "add: Effective Condition Damage": 0.05 }
           }
         gw2-id: 1724
-        type: "traits"
+        type: 'traits'
 
       - id: destructive-impulses-mix
-        text: "Destructive Impulses"
-        subText: "50% dual wield, 50% 2h"
+        text: 'Destructive Impulses'
+        subText: '50% dual wield, 50% 2h'
         minor: true
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.075, "add: Effective Condition Damage": 0.075 }
           }
         gw2-id: 1724
-        type: "traits"
+        type: 'traits'
 
       - id: notoriety
-        text: "Notoriety"
-        subText: "25 might"
+        text: 'Notoriety'
+        subText: '25 might'
         modifiers: >-
           {
             "buff": { "Power": 250, "Condition Damage": -250 }
           }
         gw2-id: 1765
-        type: "traits"
+        type: 'traits'
 
       - id: targeted-destruction
-        text: "Targeted Destruction"
-        subText: "25 vulnerability"
+        text: 'Targeted Destruction'
+        subText: '25 vulnerability'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.125 }
           }
         gw2-id: 1792
-        type: "traits"
+        type: 'traits'
 
       - id: swift-termination
-        text: "Swift Termination"
+        text: 'Swift Termination'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 1800
-        type: "traits"
+        type: 'traits'
 
-  - section: "Salvation"
+  - section: 'Salvation'
     id: 12
     items:
       - id: tranquil-balance
-        text: "Tranquil Balance"
+        text: 'Tranquil Balance'
         modifiers: >-
           {
             "multiplier": { "Effective Healing": 0.2 }
           }
         gw2-id: 1822
-        type: "traits"
+        type: 'traits'
 
       - id: life-attunement
-        text: "Life Attunement"
+        text: 'Life Attunement'
         minor: true
         modifiers: >-
           {
@@ -219,22 +219,22 @@ list:
             "convert": { "Concentration": { "Healing Power": 0.07 } }
           }
         gw2-id: 1821
-        type: "traits"
+        type: 'traits'
 
       - id: invoking-harmony
-        text: "Invoking Harmony"
+        text: 'Invoking Harmony'
         modifiers: >-
           {
             "multiplier": { "Effective Healing": 0.2 }
           }
         gw2-id: 1818
-        type: "traits"
+        type: 'traits'
 
-  - section: "Renegade"
+  - section: 'Renegade'
     id: 63
     items:
       - id: ambush-commander
-        text: "Ambush Commander"
+        text: 'Ambush Commander'
         subText: "5x Kalla's Fervor"
         minor: true
         modifiers: >-
@@ -242,42 +242,42 @@ list:
             "multiplier": { "add: Effective Power": 0.1, "add: Effective Condition Damage": 0.1 }
           }
         gw2-id: 2181
-        type: "traits"
+        type: 'traits'
 
       - id: blood-fury
-        text: "Blood Fury"
+        text: 'Blood Fury'
         modifiers: >-
           {
             "flat": { "Bleeding Duration": 25 }
           }
         gw2-id: 2079
-        type: "traits"
+        type: 'traits'
 
       - id: heartpiercer
-        text: "Heartpiercer"
+        text: 'Heartpiercer'
         modifiers: >-
           {
             "multiplier": { "Bleeding Damage": 0.25 }
           }
         gw2-id: 2092
-        type: "traits"
+        type: 'traits'
 
       - id: brutal-momentum
-        text: "Brutal Momentum"
+        text: 'Brutal Momentum'
         minor: true
         modifiers: >-
           {
             "flat": { "Critical Chance": 33 }
           }
         gw2-id: 2142
-        type: "traits"
+        type: 'traits'
 
       - id: lasting-legacy
-        text: "Lasting Legacy"
+        text: 'Lasting Legacy'
         subText: "additional bonus from 5x Kalla's Fervor"
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.05, "add: Effective Condition Damage": 0.05 }
           }
         gw2-id: 2100
-        type: "traits"
+        type: 'traits'

--- a/src/assets/data/runes.yaml
+++ b/src/assets/data/runes.yaml
@@ -11,7 +11,7 @@ list:
             "multiplier": { "Effective Power": 0.05 }
           }
         gw2-id: 24836
-        type: "items"
+        type: 'items'
 
       - id: scholar-without
         text: Superior Rune of the Scholar
@@ -21,94 +21,94 @@ list:
             "flat": { "Power": 175, "Ferocity": 225 }
           }
         gw2-id: 24836
-        type: "items"
+        type: 'items'
 
       - id: eagle
-        text: "Superior Rune of the Eagle"
+        text: 'Superior Rune of the Eagle'
         modifiers: >-
           {
             "flat": { "Precision": 175, "Ferocity": 225 },
             "multiplier": { "Effective Power": 0.05 }
           }
         gw2-id: 24723
-        type: "items"
+        type: 'items'
 
       - id: thief
-        text: "Superior Rune of the Thief"
+        text: 'Superior Rune of the Thief'
         modifiers: >-
           {
             "flat": { "Precision": 300, "Condition Damage": 100 },
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 24818
-        type: "items"
+        type: 'items'
 
       ####
 
       - id: spellbreaker
-        text: "Superior Rune of the Spellbreaker"
+        text: 'Superior Rune of the Spellbreaker'
         modifiers: >-
           {
             "flat": { "Power": 175, "Precision": 100 },
             "multiplier": { "Effective Power": 0.07 }
           }
         gw2-id: 84749
-        type: "items"
+        type: 'items'
 
       - &flame-legion
         id: flame-legion
-        text: "Superior Rune of the Flame Legion"
+        text: 'Superior Rune of the Flame Legion'
         modifiers: >-
           {
             "flat": { "Power": 175, "Burning Duration": 50 },
             "multiplier": { "Effective Power": 0.07 }
           }
         gw2-id: 24797
-        type: "items"
+        type: 'items'
 
       - id: strength
-        text: "Superior Rune of Strength"
+        text: 'Superior Rune of Strength'
         modifiers: >-
           {
             "flat": { "Power": 175, "Might Duration": 50 },
             "multiplier": { "Effective Power": 0.05 }
           }
         gw2-id: 24714
-        type: "items"
+        type: 'items'
 
       - id: ogre
-        text: "Superior Rune of the Ogre"
+        text: 'Superior Rune of the Ogre'
         modifiers: >-
           {
             "flat": { "Power": 175, "Ferocity": 100 },
             "multiplier": { "add: Effective Power": 0.04 }
           }
         gw2-id: 24756
-        type: "items"
+        type: 'items'
 
       - id: chronomancer
-        text: "Superior Rune of the Chronomancer"
+        text: 'Superior Rune of the Chronomancer'
         modifiers: >-
           {
             "flat": { "Power": 175, "Precision": 100 }
           }
         gw2-id: 73399
-        type: "items"
+        type: 'items'
 
   - section: Support Runes
     items:
       - id: pack
-        text: "Superior Rune of the Pack"
+        text: 'Superior Rune of the Pack'
         modifiers: >-
           {
             "flat": { "Power": 175, "Boon Duration": 15 },
             "buff": { "Precision": 125 }
           }
         gw2-id: 24702
-        type: "items"
+        type: 'items'
 
       - id: leadership
-        text: "Superior Rune of Leadership"
+        text: 'Superior Rune of Leadership'
         modifiers: >-
           {
             "flat":
@@ -119,16 +119,16 @@ list:
             }
           }
         gw2-id: 70600
-        type: "items"
+        type: 'items'
 
       - id: firebrand
-        text: "Superior Rune of the Firebrand"
+        text: 'Superior Rune of the Firebrand'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Boon Duration": 10, "Quickness Duration": 30 }
           }
         gw2-id: 83338
-        type: "items"
+        type: 'items'
 
       - id: surging-and-ruby-orb
         text: >-
@@ -138,65 +138,65 @@ list:
             "flat": { "Power": 195, "Precision": 14, "Ferocity": 14, "Boon Duration": 15 }
           }
         gw2-id: 76813
-        type: "items"
+        type: 'items'
 
       - id: surging
-        text: "Superior Rune of Surging"
+        text: 'Superior Rune of Surging'
         modifiers: >-
           {
             "flat": { "Power": 175, "Boon Duration": 15 }
           }
         gw2-id: 76813
-        type: "items"
+        type: 'items'
 
       - id: radiance
-        text: "Superior Rune of Radiance"
+        text: 'Superior Rune of Radiance'
         modifiers: >-
           {
             "flat": { "Vitality": 175, "Boon Duration": 25 }
           }
         gw2-id: 67342
-        type: "items"
+        type: 'items'
 
   - section: Defensive Runes
     items:
       - id: durability
-        text: "Superior Rune of Durability"
+        text: 'Superior Rune of Durability'
         modifiers: >-
           {
             "flat": { "Toughness": 175, "Boon Duration": 15 },
             "multiplier": { "Effective Health": 0.1 }
           }
         gw2-id: 73653
-        type: "items"
+        type: 'items'
 
       - id: sanctuary
-        text: "Superior Rune of Sanctuary"
+        text: 'Superior Rune of Sanctuary'
         modifiers: >-
           {
             "flat": { "Vitality": 175, "Boon Duration": 15 }
           }
         gw2-id: 24857
-        type: "items"
+        type: 'items'
 
       - id: herald
-        text: "Superior Rune of the Herald"
+        text: 'Superior Rune of the Herald'
         modifiers: >-
           {
             "flat": { "Toughness": 175, "Boon Duration": 15 }
           }
         gw2-id: 76100
-        type: "items"
+        type: 'items'
 
       - &rebirth
         id: rebirth
-        text: "Superior Rune of the Rebirth"
+        text: 'Superior Rune of the Rebirth'
         modifiers: >-
           {
             "flat": { "Healing Power": 300, "Boon Duration": 15 }
           }
         gw2-id: 84171
-        type: "items"
+        type: 'items'
 
   - section: Heal Runes
     items:
@@ -209,89 +209,89 @@ list:
             "multiplier": { "Effective Healing": 0.2 }
           }
         gw2-id: 24842
-        type: "items"
+        type: 'items'
 
       - id: water
-        text: "Superior Rune of the Water"
+        text: 'Superior Rune of the Water'
         modifiers: >-
           {
             "flat": { "Healing Power": 175, "Boon Duration": 25 }
           }
         gw2-id: 24839
-        type: "items"
+        type: 'items'
 
       - id: altruism
-        text: "Superior Rune of Altruism"
+        text: 'Superior Rune of Altruism'
         modifiers: >-
           {
             "flat": { "Healing Power": 300, "Boon Duration": 15 }
           }
         gw2-id: 38206
-        type: "items"
+        type: 'items'
 
       - *rebirth
 
   - section: Condition Runes
     items:
       - id: berserker
-        text: "Superior Rune of the Berserker"
+        text: 'Superior Rune of the Berserker'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Power": 100 },
             "multiplier": { "add: Effective Power": 0.05, "add: Effective Condition Damage": 0.05 }
           }
         gw2-id: 71425
-        type: "items"
+        type: 'items'
 
       - id: renegade
-        text: "Superior Rune of the Renegade"
+        text: 'Superior Rune of the Renegade'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Ferocity": 100 },
             "multiplier": { "add: Effective Condition Damage": 0.07 }
           }
         gw2-id: 83502
-        type: "items"
+        type: 'items'
 
       - id: elementalist
-        text: "Superior Rune of the Elementalist"
+        text: 'Superior Rune of the Elementalist'
         modifiers: >-
           {
             "flat": { "Power": 175, "Condition Damage": 225, "Condition Duration": 10 }
           }
         gw2-id: 24800
-        type: "items"
+        type: 'items'
 
       - id: lich
-        text: "Superior Rune of the Lich"
+        text: 'Superior Rune of the Lich'
         modifiers: >-
           {
             "flat": { "Vitality": 175, "Condition Duration": 15 },
             "multiplier": { "add: Effective Condition Damage": 0.04 }
           }
         gw2-id: 24688
-        type: "items"
+        type: 'items'
 
       - id: trapper
-        text: "Superior Rune of the Trapper"
+        text: 'Superior Rune of the Trapper'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Condition Duration": 15 }
           }
         gw2-id: 67339
-        type: "items"
+        type: 'items'
 
       - id: nightmare
-        text: "Superior Rune of the Nightmare"
+        text: 'Superior Rune of the Nightmare'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Condition Duration": 20, "Fear Duration": 10 }
           }
         gw2-id: 24848
-        type: "items"
+        type: 'items'
 
       - id: tempest
-        text: "Superior Rune of the Tempest"
+        text: 'Superior Rune of the Tempest'
         modifiers: >-
           {
             "flat":
@@ -302,26 +302,26 @@ list:
             }
           }
         gw2-id: 76166
-        type: "items"
+        type: 'items'
 
       - id: undead
-        text: "Superior Rune of the Undead"
+        text: 'Superior Rune of the Undead'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Toughness": 225 },
             "convert": { "Condition Damage": { "Toughness": 0.07 } }
           }
         gw2-id: 24757
-        type: "items"
+        type: 'items'
 
       - id: necromancer
-        text: "Superior Rune of the Necromancer"
+        text: 'Superior Rune of the Necromancer'
         modifiers: >-
           {
             "flat": { "Condition Damage": 300, "Vitality": 100, "Fear Duration": 20 }
           }
         gw2-id: 24806
-        type: "items"
+        type: 'items'
 
       - id: soulbeast
         text: Superior Rune of the Soulbeast
@@ -332,56 +332,56 @@ list:
             "convert": { "Condition Damage": { "Power": 0.07 } }
           }
         gw2-id: 83964
-        type: "items"
+        type: 'items'
 
   - section: Specific Condition Runes
     items:
       #### burning
 
       - id: balthazar
-        text: "Superior Rune of Balthazar"
+        text: 'Superior Rune of Balthazar'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Burning Duration": 50 },
             "multiplier": { "Effective Health": 0.1 }
           }
         gw2-id: 24765
-        type: "items"
+        type: 'items'
 
       - *flame-legion
 
       - id: baelfire
-        text: "Superior Rune of the Baelfire"
+        text: 'Superior Rune of the Baelfire'
         modifiers: >-
           {
             "flat": { "Power": 175, "Condition Duration": 10, "Burning Duration": 30 },
             "convert": { "Expertise": { "Power": 0.07 } }
           }
         gw2-id: 24854
-        type: "items"
+        type: 'items'
 
       #### bleeding
 
       - id: krait
-        text: "Superior Rune of the Krait"
+        text: 'Superior Rune of the Krait'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Bleeding Duration": 50 }
           }
         gw2-id: 24762
-        type: "items"
+        type: 'items'
 
       - id: mad-king
-        text: "Superior Rune of the Mad King"
+        text: 'Superior Rune of the Mad King'
         modifiers: >-
           {
             "flat": { "Condition Duration": 5, "Power": 175, "Bleeding Duration": 40 }
           }
         gw2-id: 36044
-        type: "items"
+        type: 'items'
 
       - id: afflicted
-        text: "Superior Rune of the Afflicted"
+        text: 'Superior Rune of the Afflicted'
         modifiers: >-
           {
             "flat":
@@ -393,45 +393,45 @@ list:
             }
           }
         gw2-id: 24687
-        type: "items"
+        type: 'items'
 
       #### poison
 
       - id: thorns
-        text: "Superior Rune of Thorns"
+        text: 'Superior Rune of Thorns'
         modifiers: >-
           {
             "flat": { "Condition Damage": 300, "Poison Duration": 50 }
           }
         gw2-id: 72912
-        type: "items"
+        type: 'items'
 
       #### torment
 
       - id: tormenting
-        text: "Superior Rune of Tormenting"
+        text: 'Superior Rune of Tormenting'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Torment Duration": 50 }
           }
         gw2-id: 44956
-        type: "items"
+        type: 'items'
 
       #### confusion
 
       - id: perplexity
-        text: "Superior Rune of Perplexity"
+        text: 'Superior Rune of Perplexity'
         modifiers: >-
           {
             "flat": { "Condition Damage": 175, "Confusion Duration": 50 }
           }
         gw2-id: 44957
-        type: "items"
+        type: 'items'
 
   - section: Hybrid Runes
     items:
       - id: traveler
-        text: "Superior Rune of the Traveler"
+        text: 'Superior Rune of the Traveler'
         modifiers: >-
           {
             "flat":
@@ -443,10 +443,10 @@ list:
             }
           }
         gw2-id: 24691
-        type: "items"
+        type: 'items'
 
       - id: divinity
-        text: "Superior Rune of Divinity"
+        text: 'Superior Rune of Divinity'
         modifiers: >-
           {
             "flat":
@@ -457,10 +457,10 @@ list:
             "multiplier": { "Effective Health": 0.1 }
           }
         gw2-id: 24732
-        type: "items"
+        type: 'items'
 
       - id: revenant
-        text: "Superior Rune of the Revenant"
+        text: 'Superior Rune of the Revenant'
         modifiers: >-
           {
             "flat":
@@ -470,10 +470,10 @@ list:
             }
           }
         gw2-id: 69370
-        type: "items"
+        type: 'items'
 
       - id: exuberance
-        text: "Superior Rune of Exuberance"
+        text: 'Superior Rune of Exuberance'
         modifiers: >-
           {
             "flat": { "Vitality": 175 },
@@ -485,4 +485,4 @@ list:
             }
           }
         gw2-id: 44951
-        type: "items"
+        type: 'items'

--- a/src/assets/data/thief.yaml
+++ b/src/assets/data/thief.yaml
@@ -1,244 +1,244 @@
 GraphQL ID: Thief
 list:
-  - section: "Skills"
+  - section: 'Skills'
     items:
       - id: assassins-signet
         text: "Assassin's Signet"
-        subText: "passive"
+        subText: 'passive'
         modifiers: >-
           {
             "buff": { "Power": 180 }
           }
         gw2-id: 13046
-        type: "skills"
+        type: 'skills'
 
       - id: assassins-signet-active
         text: "Assassin's Signet"
-        subText: "while active"
+        subText: 'while active'
         modifiers: >-
           {
             "buff": { "Power": 540 }
           }
         gw2-id: 13046
-        type: "skills"
+        type: 'skills'
 
       - id: signet-of-agility
-        text: "Signet of Agility"
+        text: 'Signet of Agility'
         modifiers: >-
           {
             "buff": { "Precision": 180 }
           }
         gw2-id: 13062
-        type: "skills"
+        type: 'skills'
 
-  - section: "Deadly Arts"
+  - section: 'Deadly Arts'
     id: 28
     items:
       - id: dagger-training-base
-        text: "Dagger Training"
-        subText: "base"
+        text: 'Dagger Training'
+        subText: 'base'
         modifiers: >-
           {
             "flat": { "Power": 80 }
           }
         gw2-id: 1245
-        type: "traits"
+        type: 'traits'
 
       - id: dagger-training-dagger
-        text: "Dagger Training"
-        subText: "with dagger"
+        text: 'Dagger Training'
+        subText: 'with dagger'
         modifiers: >-
           {
             "flat": { "Power": 80 }
           }
         gw2-id: 1245
-        type: "traits"
+        type: 'traits'
 
       - id: deadly-ambition
-        text: "Deadly Ambition"
+        text: 'Deadly Ambition'
         modifiers: >-
           {
             "buff": { "Condition Damage": 120 }
           }
         gw2-id: 1164
-        type: "traits"
+        type: 'traits'
 
       - id: revealed-training-base
-        text: "Revealed Training"
-        subText: "base"
+        text: 'Revealed Training'
+        subText: 'base'
         modifiers: >-
           {
             "buff": { "Power": 80 }
           }
         gw2-id: 1704
-        type: "traits"
+        type: 'traits'
 
       - id: revealed-training-revealed
-        text: "Revealed Training"
-        subText: "100% revealed - also check base"
+        text: 'Revealed Training'
+        subText: '100% revealed - also check base'
         modifiers: >-
           {
             "buff": { "Power": 120 }
           }
         gw2-id: 1704
-        type: "traits"
+        type: 'traits'
 
       - id: exposed-weakness
-        text: "Exposed Weakness"
-        subText: "10 conditions"
+        text: 'Exposed Weakness'
+        subText: '10 conditions'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.2 }
           }
         gw2-id: 1257
-        type: "traits"
+        type: 'traits'
 
       - id: potent-poison
-        text: "Potent Poison"
+        text: 'Potent Poison'
         modifiers: >-
           {
             "multiplier": { "Poison Damage": 0.33 },
             "flat": { "Poison Duration": 33 }
           }
         gw2-id: 1291
-        type: "traits"
+        type: 'traits'
 
       - id: executioner
-        text: "Executioner"
-        subText: "50%"
+        text: 'Executioner'
+        subText: '50%'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 1269
-        type: "traits"
+        type: 'traits'
 
-  - section: "Critical Strikes"
+  - section: 'Critical Strikes'
     id: 35
     items:
       - id: keen-observer
-        text: "Keen Observer"
-        subText: "100%"
+        text: 'Keen Observer'
+        subText: '100%'
         minor: true
         modifiers: >-
           {
             "flat": { "Critical Chance": 10 }
           }
         gw2-id: 1281
-        type: "traits"
+        type: 'traits'
 
       - id: twin-fangs-scholar
-        text: "Twin Fangs"
-        subText: "100% scholar (check both)"
+        text: 'Twin Fangs'
+        subText: '100% scholar (check both)'
         modifiers: >-
           {
             "multiplier": { "Critical Damage": 0.07 }
           }
         gw2-id: 1268
-        type: "traits"
+        type: 'traits'
 
       - id: twin-fangs-flank
-        text: "Twin Fangs"
-        subText: "100% flanking (check both)"
+        text: 'Twin Fangs'
+        subText: '100% flanking (check both)'
         modifiers: >-
           {
             "flat": { "Critical Chance": 7 }
           }
         gw2-id: 1268
-        type: "traits"
+        type: 'traits'
 
       - id: practiced-tolerance
-        text: "Practiced Tolerance"
+        text: 'Practiced Tolerance'
         modifiers: >-
           {
             "convert": { "Ferocity": { "Precision": 0.07 } }
           }
         gw2-id: 1272
-        type: "traits"
+        type: 'traits'
 
       - id: ferocious-strikes
-        text: "Ferocious Strikes"
-        subText: "50% above 50%, average"
+        text: 'Ferocious Strikes'
+        subText: '50% above 50%, average'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Critical Damage": 0.05 }
           }
         gw2-id: 1282
-        type: "traits"
+        type: 'traits'
 
       - id: ferocious-strikes-always
-        text: "Ferocious Strikes"
-        subText: "always above 50%"
+        text: 'Ferocious Strikes'
+        subText: 'always above 50%'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Critical Damage": 0.1 }
           }
         gw2-id: 1282
-        type: "traits"
+        type: 'traits'
 
       - id: no-quarter
-        text: "No Quarter"
+        text: 'No Quarter'
         modifiers: >-
           {
             "flat": { "Ferocity": 250 }
           }
         gw2-id: 1904
-        type: "traits"
+        type: 'traits'
 
   # - section: "Shadow Arts"
   #   id: 20
   #   items:
 
-  - section: "Acrobatics"
+  - section: 'Acrobatics'
     id: 54
     items:
       - id: endless-stamina
-        text: "Endless Stamina"
+        text: 'Endless Stamina'
         minor: true
         modifiers: >-
           {
             "buff": { "Concentration": 240 }
           }
         gw2-id: 1242
-        type: "traits"
+        type: 'traits'
 
-  - section: "Trickery"
+  - section: 'Trickery'
     id: 44
     items:
       - id: preparedness
-        text: "Preparedness"
+        text: 'Preparedness'
         minor: true
         modifiers: >-
           {
             "flat": { "Expertise": 150 }
           }
         gw2-id: 1232
-        type: "traits"
+        type: 'traits'
 
       - id: lead-attacks
-        text: "Lead Attacks"
-        subText: "15x"
+        text: 'Lead Attacks'
+        subText: '15x'
         minor: true
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.15, "add: Effective Condition Damage": 0.15 }
           }
         gw2-id: 1157
-        type: "traits"
+        type: 'traits'
 
       - id: deadly-ambush
-        text: "Deadly Ambush"
+        text: 'Deadly Ambush'
         modifiers: >-
           {
             "multiplier": { "Bleeding Damage": 0.25 }
           }
         gw2-id: 1706
-        type: "traits"
+        type: 'traits'
 
-  - section: "Daredevil"
+  - section: 'Daredevil'
     id: 7
     items:
       - id: marauders-resilience
@@ -249,132 +249,132 @@ list:
             "multiplier": { "Effective Health": 0.1 }
           }
         gw2-id: 1933
-        type: "traits"
+        type: 'traits'
 
       - id: weakening-strikes
-        text: "Weakening Strikes"
-        subText: "100%"
+        text: 'Weakening Strikes'
+        subText: '100%'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.07, "Effective Health": 0.1 }
           }
         gw2-id: 1887
-        type: "traits"
+        type: 'traits'
 
       - id: staff-master-base
-        text: "Staff Master"
-        subText: "base"
+        text: 'Staff Master'
+        subText: 'base'
         modifiers: >-
           {
             "flat": { "Power": 120 }
           }
         gw2-id: 1884
-        type: "traits"
+        type: 'traits'
 
       - id: staff-master-staff
-        text: "Staff Master"
-        subText: "with staff (check both)"
+        text: 'Staff Master'
+        subText: 'with staff (check both)'
         modifiers: >-
           {
             "flat": { "Power": 120 }
           }
         gw2-id: 1884
-        type: "traits"
+        type: 'traits'
 
       - id: havoc-specialist
-        text: "Havoc Specialist"
-        subText: "3x"
+        text: 'Havoc Specialist'
+        subText: '3x'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.15 }
           }
         gw2-id: 1893
-        type: "traits"
+        type: 'traits'
 
       - id: bounding-dodger
-        text: "Bounding Dodger"
-        subText: "100% uptime"
+        text: 'Bounding Dodger'
+        subText: '100% uptime'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.1 }
           }
         gw2-id: 2047
-        type: "traits"
+        type: 'traits'
 
       - id: lotus-training
-        text: "Lotus Training"
-        subText: "100% uptime"
+        text: 'Lotus Training'
+        subText: '100% uptime'
         modifiers: >-
           {
             "multiplier": { "add: Effective Condition Damage": 0.15 }
           }
         gw2-id: 1833
-        type: "traits"
+        type: 'traits'
 
-  - section: "Deadeye"
+  - section: 'Deadeye'
     id: 58
     items:
       - id: silent-scope-base
-        text: "Silent Scope"
-        subText: "base"
+        text: 'Silent Scope'
+        subText: 'base'
         modifiers: >-
           {
             "flat": { "Precision": 120 }
           }
         gw2-id: 2118
-        type: "traits"
+        type: 'traits'
 
       - id: silent-scope-rifle
-        text: "Silent Scope"
-        subText: "with rifle (check both)"
+        text: 'Silent Scope'
+        subText: 'with rifle (check both)'
         modifiers: >-
           {
             "flat": { "Precision": 120 }
           }
         gw2-id: 2118
-        type: "traits"
+        type: 'traits'
 
       - id: premeditation-6
-        text: "Premeditation"
-        subText: "6x"
+        text: 'Premeditation'
+        subText: '6x'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.06 },
             "buff": { "Concentration": 180 }
           }
         gw2-id: 2160
-        type: "traits"
+        type: 'traits'
 
       - id: premeditation-9
-        text: "Premeditation"
-        subText: "9x"
+        text: 'Premeditation'
+        subText: '9x'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.09 },
             "buff": { "Concentration": 180 }
           }
         gw2-id: 2160
-        type: "traits"
+        type: 'traits'
 
       - id: iron-sight
-        text: "Iron Sight"
+        text: 'Iron Sight'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1, "Effective Health": 0.1 }
           }
         gw2-id: 2084
-        type: "traits"
+        type: 'traits'
 
       - id: be-quick-or-be-killed
-        text: "Be Quick or Be Killed"
+        text: 'Be Quick or Be Killed'
         modifiers: >-
           {
             "buff": { "Power": 200, "Precision": 200 }
           }
         gw2-id: 2093
-        type: "traits"
+        type: 'traits'
 
   # - section: ""
   #   id:

--- a/src/assets/data/utility.yaml
+++ b/src/assets/data/utility.yaml
@@ -1,251 +1,251 @@
 GraphQL ID: Utility
 list:
-  - section: "Power Utilities"
+  - section: 'Power Utilities'
     items:
       - id: slaying-potion
-        text: "Slaying Potion"
+        text: 'Slaying Potion'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1, "Effective Health": 0.1 }
           }
         gw2-id: 50082
-        type: "items"
+        type: 'items'
 
       - id: furious-sharpening-stone
-        text: "Furious Sharpening Stone"
+        text: 'Furious Sharpening Stone'
         modifiers: >-
           {
             "convert": { "Power": { "Precision": 0.03 }, "Ferocity": { "Precision": 0.03 } }
           }
         gw2-id: 67530
-        type: "items"
+        type: 'items'
 
       - id: superior-sharpening-stone
-        text: "Superior Sharpening Stone"
+        text: 'Superior Sharpening Stone'
         modifiers: >-
           {
             "convert": { "Power": { "Precision": 0.03, "Ferocity": 0.06 } }
           }
         gw2-id: 9443
-        type: "items"
+        type: 'items'
 
       - id: toxic-sharpening-stone
-        text: "Toxic Sharpening Stone"
+        text: 'Toxic Sharpening Stone'
         modifiers: >-
           {
             "convert": { "Power": { "Condition Damage": 0.06, "Expertise": 0.08 } }
           }
         gw2-id: 48915
-        type: "items"
+        type: 'items'
 
       - id: magnanimous-sharpening-stone
-        text: "Magnanimous Sharpening Stone"
+        text: 'Magnanimous Sharpening Stone'
         modifiers: >-
           {
             "convert": { "Power": { "Vitality": 0.03, "Toughness": 0.03 } }
           }
         gw2-id: 81034
-        type: "items"
+        type: 'items'
 
       - id: bountiful-sharpening-stone
-        text: "Bountiful Sharpening Stone"
+        text: 'Bountiful Sharpening Stone'
         modifiers: >-
           {
             "convert": { "Power": { "Healing Power": 0.06, "Concentration": 0.08 } }
           }
         gw2-id: 67531
-        type: "items"
+        type: 'items'
 
-  - section: "Support Utilities"
+  - section: 'Support Utilities'
     items:
       - id: potent-lucent-oil
-        text: "Potent Lucent Oil"
+        text: 'Potent Lucent Oil'
         modifiers: >-
           {
             "convert": { "Concentration": { "Power": 0.03, "Precision": 0.03 } }
           }
         gw2-id: 89203
-        type: "items"
+        type: 'items'
 
       - id: toxic-maintenance-oil
-        text: "Toxic Maintenance Oil"
+        text: 'Toxic Maintenance Oil'
         modifiers: >-
           {
             "convert": { "Concentration": { "Power": 0.03, "Condition Damage": 0.06 } }
           }
         gw2-id: 48916
-        type: "items"
+        type: 'items'
 
       - id: enhanced-lucent-oil
-        text: "Enhanced Lucent Oil"
+        text: 'Enhanced Lucent Oil'
         modifiers: >-
           {
             "convert": { "Concentration": { "Precision": 0.03, "Condition Damage": 0.06 } }
           }
         gw2-id: 89157
-        type: "items"
+        type: 'items'
 
       - id: furious-maintenance-oil
-        text: "Furious Maintenance Oil"
+        text: 'Furious Maintenance Oil'
         modifiers: >-
           {
             "convert": { "Concentration": { "Precision": 0.03 }, "Healing Power": { "Precision": 0.03 } }
           }
         gw2-id: 67529
-        type: "items"
+        type: 'items'
 
       - id: magnanimous-maintenance-oil
-        text: "Magnanimous Maintenance Oil"
+        text: 'Magnanimous Maintenance Oil'
         modifiers: >-
           {
             "convert": { "Concentration": { "Vitality": 0.03, "Toughness": 0.03 } }
           }
         gw2-id: 81157
-        type: "items"
+        type: 'items'
 
       - id: master-maintenance-oil
-        text: "Master Maintenance Oil"
+        text: 'Master Maintenance Oil'
         modifiers: >-
           {
             "convert": { "Concentration": { "Precision": 0.03, "Healing Power": 0.06 } }
           }
         gw2-id: 9461
-        type: "items"
+        type: 'items'
 
       - id: corsair-maintenance-oil
-        text: "Corsair Maintenance Oil"
+        text: 'Corsair Maintenance Oil'
         modifiers: >-
           {
             "convert": { "Concentration": { "Toughness": 0.03 }, "Expertise": { "Toughness": 0.03 } }
           }
         gw2-id: 86016
-        type: "items"
+        type: 'items'
 
-  - section: "Heal Utilities"
+  - section: 'Heal Utilities'
     items:
       - id: bountiful-maintenance-oil
-        text: "Bountiful Maintenance Oil"
+        text: 'Bountiful Maintenance Oil'
         modifiers: >-
           {
             "bountiful-maintenance-oil": true
           }
         gw2-id: 67528
-        type: "items"
+        type: 'items'
 
-  - section: "Condition Utilities"
+  - section: 'Condition Utilities'
     items:
       - id: toxic-focusing-crystal
-        text: "Toxic Focusing Crystal"
+        text: 'Toxic Focusing Crystal'
         modifiers: >-
           {
             "convert": { "Condition Damage": { "Power": 0.03, "Precision": 0.03 } }
           }
         gw2-id: 48917
-        type: "items"
+        type: 'items'
 
       - id: furious-tuning-crystal
-        text: "Furious Tuning Crystal"
+        text: 'Furious Tuning Crystal'
         modifiers: >-
           {
             "convert": { "Condition Damage": { "Precision": 0.03 }, "Expertise": { "Precision": 0.03 } }
           }
         gw2-id: 67524
-        type: "items"
+        type: 'items'
 
       - id: master-tuning-crystal
-        text: "Master Tuning Crystal"
+        text: 'Master Tuning Crystal'
         modifiers: >-
           {
             "convert": { "Condition Damage": { "Precision": 0.03, "Expertise": 0.08 } }
           }
         gw2-id: 9476
-        type: "items"
+        type: 'items'
 
       - id: magnanimous-tuning-crystal
-        text: "Magnanimous Tuning Crystal"
+        text: 'Magnanimous Tuning Crystal'
         modifiers: >-
           {
             "convert": { "Condition Damage": { "Vitality": 0.03, "Toughness": 0.03 } }
           }
         gw2-id: 81079
-        type: "items"
+        type: 'items'
 
       - id: bountiful-tuning-crystal
-        text: "Bountiful Tuning Crystal"
+        text: 'Bountiful Tuning Crystal'
         modifiers: >-
           {
             "convert": { "Condition Damage": { "Healing Power": 0.06, "Concentration": 0.08 } }
           }
         gw2-id: 67522
-        type: "items"
+        type: 'items'
 
-  - section: "SAB Utilities"
+  - section: 'SAB Utilities'
     items:
       - id: holographic-super-apple
-        text: "Holographic Super Apple"
+        text: 'Holographic Super Apple'
         modifiers: >-
           {
             "convert":
             { "Condition Damage": { "Concentration": 0.08 }, "Concentration": { "Precision": 0.03 } }
           }
         gw2-id: 87336
-        type: "items"
+        type: 'items'
 
       - id: holographic-super-drumstick
-        text: "Holographic Super Drumstick"
+        text: 'Holographic Super Drumstick'
         modifiers: >-
           {
             "convert":
             { "Healing Power": { "Concentration": 0.08 }, "Concentration": { "Precision": 0.03 } }
           }
         gw2-id: 87329
-        type: "items"
+        type: 'items'
 
       - id: holographic-super-cheese
-        text: "Holographic Super Cheese"
+        text: 'Holographic Super Cheese'
         modifiers: >-
           {
             "convert": { "Power": { "Concentration": 0.08 }, "Concentration": { "Precision": 0.03 } }
           }
         gw2-id: 87358
-        type: "items"
+        type: 'items'
 
-  - section: "Writs"
+  - section: 'Writs'
     items:
       - id: writ-of-masterful-accuracy
-        text: "Writ of Masterful Accuracy"
+        text: 'Writ of Masterful Accuracy'
         modifiers: >-
           {
             "flat": { "Precision": 200 }
           }
         gw2-id: 76833
-        type: "items"
+        type: 'items'
 
       - id: writ-of-masterful-malice
-        text: "Writ of Masterful Malice"
+        text: 'Writ of Masterful Malice'
         modifiers: >-
           {
             "flat": { "Condition Damage": 200 }
           }
         gw2-id: 72510
-        type: "items"
+        type: 'items'
 
       - id: writ-of-masterful-strength
-        text: "Writ of Masterful Strength"
+        text: 'Writ of Masterful Strength'
         modifiers: >-
           {
             "flat": { "Power": 200 }
           }
         gw2-id: 73191
-        type: "items"
+        type: 'items'
 
-  - section: "Misc"
+  - section: 'Misc'
     items:
       - id: potion-of-karka-toughness
-        text: "Potion Of Karka Toughness"
+        text: 'Potion Of Karka Toughness'
         modifiers: >-
           {
             "flat": { "Toughness": 150 }
           }
         gw2-id: 42428
-        type: "items"
+        type: 'items'

--- a/src/assets/data/warrior.yaml
+++ b/src/assets/data/warrior.yaml
@@ -1,293 +1,293 @@
 GraphQL ID: Warrior
 list:
-  - section: "Skills"
+  - section: 'Skills'
     items:
       - id: signet-of-might
-        text: "Signet of Might"
+        text: 'Signet of Might'
         modifiers: >-
           {
             "buff": { "Power": 180 }
           }
         gw2-id: 14404
-        type: "skills"
+        type: 'skills'
 
       - id: signet-of-fury
-        text: "Signet of Fury"
+        text: 'Signet of Fury'
         modifiers: >-
           {
             "buff": { "Precision": 180 }
           }
         gw2-id: 14410
-        type: "skills"
+        type: 'skills'
 
       - id: dolyak-signet
-        text: "Dolyak Signet"
+        text: 'Dolyak Signet'
         modifiers: >-
           {
             "buff": { "Toughness": 180 }
           }
         gw2-id: 14413
-        type: "skills"
+        type: 'skills'
 
-  - section: "Strength"
+  - section: 'Strength'
     id: 4
     items:
       - id: peak-performance
-        text: "Peak Performance"
-        subText: "passive"
+        text: 'Peak Performance'
+        subText: 'passive'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.05 }
           }
         gw2-id: 1444
-        type: "traits"
+        type: 'traits'
 
       - id: peak-performance-2
-        text: "Peak Performance"
-        subText: "active, 100% uptime - check both boxes"
+        text: 'Peak Performance'
+        subText: 'active, 100% uptime - check both boxes'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.1 }
           }
         gw2-id: 1444
-        type: "traits"
+        type: 'traits'
 
       - id: forceful-greatsword
-        text: "Forceful Greatsword"
-        subText: "base"
+        text: 'Forceful Greatsword'
+        subText: 'base'
         modifiers: >-
           {
             "buff": { "Power": 120 }
           }
         gw2-id: 1338
-        type: "traits"
+        type: 'traits'
 
       - id: forceful-greatsword-2
-        text: "Forceful Greatsword"
-        subText: "with greatsword/spear - check both boxes"
+        text: 'Forceful Greatsword'
+        subText: 'with greatsword/spear - check both boxes'
         modifiers: >-
           {
             "buff": { "Power": 120 }
           }
         gw2-id: 1338
-        type: "traits"
+        type: 'traits'
 
       - id: great-fortitude
-        text: "Great Fortitude"
+        text: 'Great Fortitude'
         modifiers: >-
           {
             "convert": { "Vitality": { "Power": 0.1 }, "Ferocity": { "Power": 0.1 } }
           }
         gw2-id: 1449
-        type: "traits"
+        type: 'traits'
 
       - id: pinnacle-of-strength
-        text: "Pinnacle Of Strength"
+        text: 'Pinnacle Of Strength'
         minor: true
         modifiers: >-
           {
             "buff": { "Power": 250 }
           }
         gw2-id: 1453
-        type: "traits"
+        type: 'traits'
 
       - id: berserkers-power
         text: "Berserker's Power"
-        subText: "100% 3x"
+        subText: '100% 3x'
         modifiers: >-
           {
             "multiplier": { "add: Effective Power": 0.21 }
           }
         gw2-id: 1437
-        type: "traits"
+        type: 'traits'
 
-  - section: "Arms"
+  - section: 'Arms'
     id: 36
     items:
       - id: wounding-precision
-        text: "Wounding Precision"
+        text: 'Wounding Precision'
         modifiers: >-
           {
             "convert": { "Expertise": { "Precision": 0.07 } }
           }
         gw2-id: 1455
-        type: "traits"
+        type: 'traits'
 
       - id: signet-mastery
-        text: "Signet Mastery"
-        subText: "5x"
+        text: 'Signet Mastery'
+        subText: '5x'
         modifiers: >-
           {
             "flat": { "Ferocity": 500 }
           }
         gw2-id: 1344
-        type: "traits"
+        type: 'traits'
 
       - id: deep-strikes
-        text: "Deep Strikes"
+        text: 'Deep Strikes'
         minor: true
         modifiers: >-
           {
             "buff": { "Condition Damage": 180 }
           }
         gw2-id: 1343
-        type: "traits"
+        type: 'traits'
 
       - id: blade-master
-        text: "Blademaster"
-        subText: "base"
+        text: 'Blademaster'
+        subText: 'base'
         modifiers: >-
           {
             "buff": { "Expertise": 120 }
           }
         gw2-id: 1333
-        type: "traits"
+        type: 'traits'
 
       - id: blade-master-2
-        text: "Blademaster"
-        subText: "with sword 50% - check both boxes"
+        text: 'Blademaster'
+        subText: 'with sword 50% - check both boxes'
         modifiers: >-
           {
             "buff": { "Condition Damage": 60 }
           }
         gw2-id: 1333
-        type: "traits"
+        type: 'traits'
 
       - id: bloodlust
-        text: "Bloodlust"
+        text: 'Bloodlust'
         minor: true
         modifiers: >-
           {
             "flat": { "Bleeding Duration": 33 }
           }
         gw2-id: 1337
-        type: "traits"
+        type: 'traits'
 
       - id: furious
-        text: "Furious"
-        subText: "25x"
+        text: 'Furious'
+        subText: '25x'
         modifiers: >-
           {
             "buff": { "Condition Damage": 250 }
           }
         gw2-id: 1346
-        type: "traits"
+        type: 'traits'
 
-  - section: "Defense"
+  - section: 'Defense'
     id: 22
     items:
       - id: thick-skin
-        text: "Thick Skin"
+        text: 'Thick Skin'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Health": 0.05 }
           }
         gw2-id: 1350
-        type: "traits"
+        type: 'traits'
 
       - id: cull-the-weak
-        text: "Cull the Weak"
+        text: 'Cull the Weak'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 1372
-        type: "traits"
+        type: 'traits'
 
       - id: armored-attack
-        text: "Armored Attack"
+        text: 'Armored Attack'
         modifiers: >-
           {
             "convert": { "Power": { "Toughness": 0.1 } }
           }
         gw2-id: 1379
-        type: "traits"
+        type: 'traits'
 
       - id: hardened-armor
-        text: "Hardened Armor"
+        text: 'Hardened Armor'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Health": 0.1 }
           }
         gw2-id: 1380
-        type: "traits"
+        type: 'traits'
 
-  - section: "Tactics"
+  - section: 'Tactics'
     id: 11
     items:
       - id: leg-specialist
-        text: "Leg Specialist"
+        text: 'Leg Specialist'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 1469
-        type: "traits"
+        type: 'traits'
 
       - id: roaring-reveille
-        text: "Roaring Reveille"
+        text: 'Roaring Reveille'
         modifiers: >-
           {
             "buff": { "Concentration": 120 }
           }
         gw2-id: 1471
-        type: "traits"
+        type: 'traits'
 
       - id: empowered-6
-        text: "Empowered"
-        subText: "6x"
+        text: 'Empowered'
+        subText: '6x'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.06 }
           }
         gw2-id: 1485
-        type: "traits"
+        type: 'traits'
 
       - id: empowered-9
-        text: "Empowered"
-        subText: "9x"
+        text: 'Empowered'
+        subText: '9x'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.09 }
           }
         gw2-id: 1485
-        type: "traits"
+        type: 'traits'
 
       - id: empowered-11
-        text: "Empowered"
-        subText: "11x"
+        text: 'Empowered'
+        subText: '11x'
         minor: true
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.11 }
           }
         gw2-id: 1485
-        type: "traits"
+        type: 'traits'
 
       - id: warriors-cunning
         text: "Warrior's Cunning"
-        subText: "20% uptime -> +5% Damage"
+        subText: '20% uptime -> +5% Damage'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.05 }
           }
         gw2-id: 1486
-        type: "traits"
+        type: 'traits'
 
       - id: vigorous-shouts
-        text: "Vigorous Shouts"
+        text: 'Vigorous Shouts'
         modifiers: >-
           {
             "convert": { "Healing Power": { "Power": 0.13 } }
           }
         gw2-id: 1470
-        type: "traits"
+        type: 'traits'
 
-  - section: "Discipline"
+  - section: 'Discipline'
     id: 51
     items:
       - id: warriors-sprint
@@ -297,140 +297,140 @@ list:
             "multiplier": { "add: Effective Power": 0.1 }
           }
         gw2-id: 1413
-        type: "traits"
+        type: 'traits'
 
       - id: double-standards
-        text: "Doubled Standards"
-        subText: "+50 Pwr/Prc/Fer/Con"
+        text: 'Doubled Standards'
+        subText: '+50 Pwr/Prc/Fer/Con'
         modifiers: >-
           {
             "buff": { "Power": 50, "Precision": 50, "Ferocity": 50, "Condition Damage": 50 }
           }
         gw2-id: 1484
-        type: "traits"
+        type: 'traits'
 
       - id: axe-mastery-one
-        text: "Axe Mastery"
-        subText: "without axe"
+        text: 'Axe Mastery'
+        subText: 'without axe'
         modifiers: >-
           {
             "buff": { "Ferocity": 120 }
           }
         gw2-id: 1369
-        type: "traits"
+        type: 'traits'
 
       - id: axe-mastery-two
-        text: "Axe Mastery"
-        subText: "with axe - check both boxes"
+        text: 'Axe Mastery'
+        subText: 'with axe - check both boxes'
         modifiers: >-
           {
             "buff": { "Ferocity": 120 }
           }
         gw2-id: 1369
-        type: "traits"
+        type: 'traits'
 
-  - section: "Berserker"
+  - section: 'Berserker'
     id: 18
     items:
       - id: blood-reaction-no
-        text: "Blood Reaction"
-        subText: "with 0% berserker mode"
+        text: 'Blood Reaction'
+        subText: 'with 0% berserker mode'
         modifiers: >-
           {
             "convert": { "Ferocity": { "Precision": 0.07 } }
           }
         gw2-id: 2011
-        type: "traits"
+        type: 'traits'
 
       - id: blood-reaction-with
-        text: "Blood Reaction"
-        subText: "with 100% berserker mode"
+        text: 'Blood Reaction'
+        subText: 'with 100% berserker mode'
         modifiers: >-
           {
             "convert": { "Ferocity": { "Precision": 0.14 } }
           }
         gw2-id: 2011
-        type: "traits"
+        type: 'traits'
 
       - id: heat-the-soul
-        text: "Heat the Soul"
-        subText: "without torch"
+        text: 'Heat the Soul'
+        subText: 'without torch'
         modifiers: >-
           {
             "buff": { "Condition Damage": 120 }
           }
         gw2-id: 2042
-        type: "traits"
+        type: 'traits'
 
       - id: heat-the-soul-with
-        text: "Heat the Soul"
-        subText: "with torch 50% - check both boxes"
+        text: 'Heat the Soul'
+        subText: 'with torch 50% - check both boxes'
         modifiers: >-
           {
             "buff": { "Condition Damage": 60 }
           }
         gw2-id: 2042
-        type: "traits"
+        type: 'traits'
 
       - id: fatal-frenzy
-        text: "Fatal Frenzy"
+        text: 'Fatal Frenzy'
         minor: true
         modifiers: >-
           {
             "buff": { "Power": 300, "Condition Damage": 300, "Toughness": -300 }
           }
         gw2-id: 2046
-        type: "traits"
+        type: 'traits'
 
       - id: bloody-roar
-        text: "Bloody Roar"
+        text: 'Bloody Roar'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.2 }
           }
         gw2-id: 1928
-        type: "traits"
+        type: 'traits'
 
       - id: king-of-fires
-        text: "King of Fires"
+        text: 'King of Fires'
         modifiers: >-
           {
             "flat": { "Burning Duration": 33 }
           }
         gw2-id: 2038
-        type: "traits"
+        type: 'traits'
 
       - id: eternal-champion
-        text: "Eternal Champion"
+        text: 'Eternal Champion'
         modifiers: >-
           {
             "buff": { "Toughness": 300 }
           }
         gw2-id: 2043
-        type: "traits"
+        type: 'traits'
 
-  - section: "Spellbreaker"
+  - section: 'Spellbreaker'
     id: 61
     items:
       - id: pure-strike-boonless
-        text: "Pure Strike"
-        subText: "Against boonless"
+        text: 'Pure Strike'
+        subText: 'Against boonless'
         modifiers: >-
           {
             "multiplier": { "Critical Damage": 0.14 }
           }
         gw2-id: 2107
-        type: "traits"
+        type: 'traits'
 
       - id: sun-and-moon-style
-        text: "Sun and Moon Style"
-        subText: "100% onhand dagger; no boons"
+        text: 'Sun and Moon Style'
+        subText: '100% onhand dagger; no boons'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.1 }
           }
         gw2-id: 2095
-        type: "traits"
+        type: 'traits'
 
       - id: attackers-insight
         text: "Attacker's Insight"
@@ -440,14 +440,14 @@ list:
             "buff": { "Ferocity": 250, "Power": 250, "Precision": 250 }
           }
         gw2-id: 2130
-        type: "traits"
+        type: 'traits'
 
       - id: magebane-tether
-        text: "Magebane Tether"
-        subText: "75% uptime -> +7.5% Damage"
+        text: 'Magebane Tether'
+        subText: '75% uptime -> +7.5% Damage'
         modifiers: >-
           {
             "multiplier": { "Effective Power": 0.075 }
           }
         gw2-id: 2060
-        type: "traits"
+        type: 'traits'

--- a/src/components/baseComponents/CheckboxComponent.jsx
+++ b/src/components/baseComponents/CheckboxComponent.jsx
@@ -1,5 +1,5 @@
-import { Checkbox, FormControlLabel } from "@material-ui/core";
-import React from "react";
+import { Checkbox, FormControlLabel } from '@material-ui/core';
+import React from 'react';
 
 const CheckboxComponent = ({ checked, value, label, onChange, ...rest }) => (
   <FormControlLabel

--- a/src/components/baseComponents/CircularProgressWithLabel.jsx
+++ b/src/components/baseComponents/CircularProgressWithLabel.jsx
@@ -4,6 +4,7 @@ import Typography from '@material-ui/core/Typography';
 import React from 'react';
 
 function CircularProgressWithLabel(props) {
+  const { value } = props;
   return (
     <Box position="relative" display="inline-flex">
       <CircularProgress variant="determinate" {...props} />
@@ -17,9 +18,7 @@ function CircularProgressWithLabel(props) {
         alignItems="center"
         justifyContent="center"
       >
-        <Typography variant="caption" color="textSecondary">{`${Math.round(
-          props.value,
-        )}%`}</Typography>
+        <Typography variant="caption" color="textSecondary">{`${Math.round(value)}%`}</Typography>
       </Box>
     </Box>
   );

--- a/src/components/baseComponents/Layout.jsx
+++ b/src/components/baseComponents/Layout.jsx
@@ -27,7 +27,7 @@ const styles = (theme) => ({
 });
 
 class Layout extends Component {
-  state = { open: false };
+  // state = { open: false };
 
   render = () => {
     const { classes, children, ContainerProps, disableContainer = false } = this.props;

--- a/src/components/baseComponents/LinearProgressWithLabel.jsx
+++ b/src/components/baseComponents/LinearProgressWithLabel.jsx
@@ -1,7 +1,7 @@
 import { Box, LinearProgress, Typography } from '@material-ui/core';
 import React from 'react';
 
-export function LinearProgressWithLabel(props) {
+function LinearProgressWithLabel(props) {
   return (
     <Box display="flex" alignItems="center">
       <Box width="100%" mr={1}>
@@ -15,3 +15,5 @@ export function LinearProgressWithLabel(props) {
     </Box>
   );
 }
+
+export default LinearProgressWithLabel;

--- a/src/components/baseComponents/LinearProgressWithLabel.jsx
+++ b/src/components/baseComponents/LinearProgressWithLabel.jsx
@@ -2,15 +2,14 @@ import { Box, LinearProgress, Typography } from '@material-ui/core';
 import React from 'react';
 
 function LinearProgressWithLabel(props) {
+  const { value } = props;
   return (
     <Box display="flex" alignItems="center">
       <Box width="100%" mr={1}>
         <LinearProgress variant="determinate" {...props} />
       </Box>
       <Box minWidth={35}>
-        <Typography variant="body2" color="textSecondary">{`${Math.round(
-          props.value,
-        )}%`}</Typography>
+        <Typography variant="body2" color="textSecondary">{`${Math.round(value)}%`}</Typography>
       </Box>
     </Box>
   );

--- a/src/components/baseComponents/Section.jsx
+++ b/src/components/baseComponents/Section.jsx
@@ -27,15 +27,15 @@ const styles = (theme) => ({
   },
 });
 
-const SectionInfo = (props) => (
+const SectionInfo = ({ title, children }) => (
   <>
-    <Typography variant="h5">{props.title}</Typography>
-    {props.children && (
+    <Typography variant="h5">{title}</Typography>
+    {children && (
       <Typography variant="caption">
         <Paper variant="outlined">
           <Box p={1}>
             <LiveHelpIcon />
-            <div>{props.children}</div>
+            <div>{children}</div>
           </Box>
         </Paper>
       </Typography>

--- a/src/components/gw2/BackAndTrinkets.jsx
+++ b/src/components/gw2/BackAndTrinkets.jsx
@@ -26,6 +26,7 @@ const styles = (theme) => ({
 });
 
 const Weapons = ({ classes, ...rest }) => {
+  /* eslint-disable no-unused-vars */
   const {
     backItemId,
     backItemStatsId,
@@ -56,6 +57,7 @@ const Weapons = ({ classes, ...rest }) => {
     ring2Infusion3Id,
     ring2Affix,
   } = resolveBackAndTrinkets(rest);
+  /* eslint-enable no-unused-vars */
 
   return (
     <Grid container spacing={3}>

--- a/src/components/gw2/Weapons.jsx
+++ b/src/components/gw2/Weapons.jsx
@@ -35,6 +35,7 @@ const styles = (theme) => ({
   },
 });
 
+/* eslint-disable no-unused-vars */
 const Weapons = ({
   classes,
   weapon1MainId,
@@ -68,6 +69,7 @@ const Weapons = ({
   weapon2OffSigil,
   weapon2OffInfusionId,
 }) => (
+  /* eslint-enable no-unused-vars */
   <>
     <List disablePadding>
       <ListItem disableGutters className={classes.listItem}>

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -142,6 +142,7 @@ const Navbar = ({ classes, data, buffPresets, prioritiesPresets, distributionPre
     );
   };
 
+  // eslint-disable-next-line no-shadow
   const handleTemplateSelect = (popup, elem, specialization, profession) => {
     dispatch({ type: 'CANCEL' });
     dispatch(

--- a/src/components/sections/Affixes.jsx
+++ b/src/components/sections/Affixes.jsx
@@ -76,7 +76,7 @@ const Affixes = ({ classes }) => {
       options={AFFIXES}
       getOptionLabel={(option) => firstUppercase(option)}
       value={affixes}
-      onChange={(event, value) => dispatch(changePriority({ key: 'affixes', value: value }))}
+      onChange={(event, value) => dispatch(changePriority({ key: 'affixes', value }))}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/src/components/sections/buffs/Buffs.jsx
+++ b/src/components/sections/buffs/Buffs.jsx
@@ -42,9 +42,7 @@ const Buffs = ({ classes, data }) => {
       {data.map((section) => (
         <Grid key={section.section} item xs={12} sm={6} md={4}>
           <FormControl component="fieldset" className={classes.formControl}>
-            <FormLabel component="legend">
-              <div dangerouslySetInnerHTML={{ __html: section.section }} />
-            </FormLabel>
+            <FormLabel component="legend">{section.section}</FormLabel>
             <FormGroup>
               {section.items.map((buff) => {
                 let Component;

--- a/src/components/sections/buffs/Buffs.jsx
+++ b/src/components/sections/buffs/Buffs.jsx
@@ -30,11 +30,11 @@ const Buffs = ({ classes, data }) => {
 
   // Dynamic component creation for buffs from a string
   const components = {
-    Boon: Boon,
-    Trait: Trait,
-    Skill: Skill,
-    CommonEffect: CommonEffect,
-    Condition: Condition,
+    Boon,
+    Trait,
+    Skill,
+    CommonEffect,
+    Condition,
   };
 
   return (

--- a/src/components/sections/buffs/Buffs.jsx
+++ b/src/components/sections/buffs/Buffs.jsx
@@ -43,7 +43,7 @@ const Buffs = ({ classes, data }) => {
         <Grid key={section.section} item xs={12} sm={6} md={4}>
           <FormControl component="fieldset" className={classes.formControl}>
             <FormLabel component="legend">
-              <div dangerouslySetInnerHTML={{ __html: section.section }}></div>
+              <div dangerouslySetInnerHTML={{ __html: section.section }} />
             </FormLabel>
             <FormGroup>
               {section.items.map((buff) => {

--- a/src/components/sections/buffs/Buffs.jsx
+++ b/src/components/sections/buffs/Buffs.jsx
@@ -47,7 +47,8 @@ const Buffs = ({ classes, data }) => {
             </FormLabel>
             <FormGroup>
               {section.items.map((buff) => {
-                let Component, name;
+                let Component;
+                let name;
 
                 switch (buff.type) {
                   case 'Text':

--- a/src/components/sections/controls/Controls.jsx
+++ b/src/components/sections/controls/Controls.jsx
@@ -65,7 +65,7 @@ const ControlsBox = ({ classes, profession, data }) => {
           onClick={onCancelCalculate}
           disabled={status !== RUNNING}
         >
-          <Cancel className={classNames(classes.icon)}></Cancel>
+          <Cancel className={classNames(classes.icon)} />
           <Typography style={{ marginLeft: 8 }}>Abort</Typography>
         </Button>
       </Box>

--- a/src/components/sections/controls/Controls.jsx
+++ b/src/components/sections/controls/Controls.jsx
@@ -42,6 +42,20 @@ const ControlsBox = ({ classes, profession, data }) => {
     [dispatch],
   );
 
+  let icon;
+
+  switch (status) {
+    case SUCCESS:
+      icon = <DoneAllIcon fontSize="small" classes={{ root: classes.chipIcon }} />;
+      break;
+    case WAITING:
+    case RUNNING:
+      icon = <HourglassEmptyIcon fontSize="small" classes={{ root: classes.chipIcon }} />;
+      break;
+    default:
+      icon = null;
+  }
+
   return (
     <Box display="flex" flexWrap="wrap">
       <Box>
@@ -73,12 +87,7 @@ const ControlsBox = ({ classes, profession, data }) => {
         <Chip
           label={
             <>
-              Status: {firstUppercase(status)}{' '}
-              {status === SUCCESS ? (
-                <DoneAllIcon fontSize="small" classes={{ root: classes.chipIcon }} />
-              ) : status === WAITING || status === RUNNING ? (
-                <HourglassEmptyIcon fontSize="small" classes={{ root: classes.chipIcon }} />
-              ) : null}
+              Status: {firstUppercase(status)} {icon}
             </>
           }
           color={status !== ABORTED ? 'primary' : 'secondary'}

--- a/src/components/sections/controls/CopyTemplateButton.jsx
+++ b/src/components/sections/controls/CopyTemplateButton.jsx
@@ -6,14 +6,7 @@ import { useSelector } from 'react-redux';
 import { getProfession } from '../../../state/gearOptimizerSlice';
 import { Classes } from '../../../utils/gw2-data';
 
-export const CopyTemplateButton = ({
-  extras: extrasIds,
-  data,
-  infusions,
-  weight,
-  runeId,
-  runeName,
-}) => {
+const CopyTemplateButton = ({ extras: extrasIds, data, infusions, weight, runeId, runeName }) => {
   const [open, setOpen] = React.useState(false);
   const [w11, setw11] = React.useState('');
   const [w12, setw12] = React.useState('');
@@ -101,3 +94,5 @@ export const CopyTemplateButton = ({
     </>
   );
 };
+
+export default CopyTemplateButton;

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -162,10 +162,10 @@ const DamageDistribution = ({ classes }) => {
     const { value } = e.target;
     if (value.match('^[-+]?[0-9]*.?[0-9]+([eE][-+]?[0-9]+)?$')) {
       // only update the actual slider when the number entered is a valid string. The regex matches for integer or floats.
-      dispatch(changeDistributionNew({ index: key, value: value }));
+      dispatch(changeDistributionNew({ index: key, value }));
     }
 
-    dispatch(changeTextBoxes({ index: key, value: value }));
+    dispatch(changeTextBoxes({ index: key, value }));
   };
   const SlidersNew = () => {
     return DISTRIBUTION_NAMES.map((d, index) => (

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import { Attribute, Condition } from 'gw2-ui-bulk';
 import debounce from 'lodash.debounce';
 import Nouislider from 'nouislider-react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import 'nouislider/distribute/nouislider.css';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';

--- a/src/components/sections/extras/GW2Select.jsx
+++ b/src/components/sections/extras/GW2Select.jsx
@@ -61,7 +61,7 @@ const GW2Select = ({ classes, name, label, data }) => {
               disableLink
               text={item.text.replace('Superior ', '')}
               className={classes.item}
-            ></Item>
+            />
           );
         }}
       >

--- a/src/components/sections/forcedslots/ForcedSlots.jsx
+++ b/src/components/sections/forcedslots/ForcedSlots.jsx
@@ -34,7 +34,7 @@ const ForcedSlots = ({ classes }) => {
   }
 
   const handleChange = (index) => (event, newInput) => {
-    dispatch(changeForcedSlot({ index: index, value: newInput }));
+    dispatch(changeForcedSlot({ index, value: newInput }));
   };
 
   const input2 = (name, index, offset) => {

--- a/src/components/sections/priorities/Priorities.jsx
+++ b/src/components/sections/priorities/Priorities.jsx
@@ -40,7 +40,7 @@ const styles = (theme) => ({
 
 const OPTIMIZATION_GOALS = ['Damage', 'Survivability', 'Healing'];
 
-const Priorities = ({ classes, presets }) => {
+const Priorities = ({ classes }) => {
   const dispatch = useDispatch();
   const optimizeFor = useSelector(getPriority('optimizeFor'));
   const weaponType = useSelector(getPriority('weaponType'));

--- a/src/components/sections/priorities/Priorities.jsx
+++ b/src/components/sections/priorities/Priorities.jsx
@@ -101,12 +101,12 @@ const Priorities = ({ classes, presets }) => {
               value="Dual wield"
               control={<Radio color="primary" />}
               label="Dual wielded"
-            ></FormControlLabel>
+            />
             <FormControlLabel
               value="Two-handed"
               control={<Radio color="primary" />}
               label="Two-handed"
-            ></FormControlLabel>
+            />
           </RadioGroup>
         </FormControl>
       </Grid>

--- a/src/components/sections/priorities/Priorities.jsx
+++ b/src/components/sections/priorities/Priorities.jsx
@@ -75,7 +75,7 @@ const Priorities = ({ classes, presets }) => {
                 key={goal}
                 value={goal}
                 control={<Radio color="primary" />}
-                label={goal === 'Survivability' ? 'Survivability (WIP)': goal}
+                label={goal === 'Survivability' ? 'Survivability (WIP)' : goal}
               />
             ))}
           </RadioGroup>

--- a/src/components/sections/results/AppliedModifiers.jsx
+++ b/src/components/sections/results/AppliedModifiers.jsx
@@ -10,7 +10,7 @@ import {
   withStyles,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { Boon, CommonEffect, Condition, Skill, Trait } from 'gw2-ui-bulk';
+// import { Boon, CommonEffect, Condition, Skill, Trait } from 'gw2-ui-bulk';
 import React from 'react';
 
 const styles = (theme) => ({
@@ -24,13 +24,13 @@ const styles = (theme) => ({
 });
 
 // Dynamic component creation for buffs from a string
-const components = {
-  Boon,
-  Trait,
-  Skill,
-  CommonEffect,
-  Condition,
-};
+// const components = {
+//   Boon,
+//   Trait,
+//   Skill,
+//   CommonEffect,
+//   Condition,
+// };
 
 const AffixesStats = ({ classes, data, buffData }) => {
   const allBuffs = buffData.flatMap((d) => d.items);

--- a/src/components/sections/results/AppliedModifiers.jsx
+++ b/src/components/sections/results/AppliedModifiers.jsx
@@ -25,11 +25,11 @@ const styles = (theme) => ({
 
 // Dynamic component creation for buffs from a string
 const components = {
-  Boon: Boon,
-  Trait: Trait,
-  Skill: Skill,
-  CommonEffect: CommonEffect,
-  Condition: Condition,
+  Boon,
+  Trait,
+  Skill,
+  CommonEffect,
+  Condition,
 };
 
 const AffixesStats = ({ classes, data, buffData }) => {

--- a/src/components/sections/results/ResultDetails.jsx
+++ b/src/components/sections/results/ResultDetails.jsx
@@ -14,7 +14,7 @@ import { getTraitLines } from '../../../state/slices/traits';
 import { Classes, Defense, INFUSIONS, PROFESSIONS } from '../../../utils/gw2-data';
 import { firstUppercase } from '../../../utils/usefulFunctions';
 import Character from '../../gw2/Character';
-import { CopyTemplateButton } from '../controls/CopyTemplateButton';
+import CopyTemplateButton from '../controls/CopyTemplateButton';
 import AffixesStats from './AffixesStats';
 import AppliedModifiers from './AppliedModifiers';
 import Indicators from './Indicators';

--- a/src/components/sections/results/ResultDetails.jsx
+++ b/src/components/sections/results/ResultDetails.jsx
@@ -94,7 +94,10 @@ const ResultDetails = ({ data }) => {
   const runeName = runeStringId ? rune.text.split(' ')[rune.text.split(' ').length - 1] : '';
 
   // Calculate the props for the weapons component
-  let wea1, wea2, weapData;
+  let wea1;
+  let wea2;
+  let weapData;
+
   if (priority === 'Dual wield') {
     wea1 = classData.mainHand.find((d) => d.type === 'one-handed');
     [wea2] = classData.offHand;

--- a/src/components/sections/results/ResultDetails.jsx
+++ b/src/components/sections/results/ResultDetails.jsx
@@ -202,7 +202,7 @@ const ResultDetails = ({ data }) => {
             title="Damage loss from -5 of attribute"
           />
         </Grid>
-        <Grid item xs={12} sm={6} md={4}></Grid>
+        <Grid item xs={12} sm={6} md={4} />
       </Grid>
 
       <AppliedModifiers data={modifiers} buffData={data.buffs.list} />

--- a/src/components/sections/results/ResultTable.jsx
+++ b/src/components/sections/results/ResultTable.jsx
@@ -5,10 +5,7 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import {
-  getList,
-  getSelectedCharacter,
-} from '../../../state/gearOptimizerSlice';
+import { getList, getSelectedCharacter } from '../../../state/gearOptimizerSlice';
 import ResultTableRow from './ResultTableRow';
 import ResultTableHeaderRow from './ResultTableHeaderRow';
 
@@ -47,7 +44,7 @@ const mode = (array) => {
 const StickyHeadTable = ({ classes }) => {
   const selectedCharacter = useSelector(getSelectedCharacter);
   const list = useSelector(getList) || [];
-  
+
   let mostCommonAffix = null;
   if (/* status !== RUNNING && */ list[0]) {
     mostCommonAffix = mode(list[0].gear);

--- a/src/components/sections/results/ResultTableRow.jsx
+++ b/src/components/sections/results/ResultTableRow.jsx
@@ -15,7 +15,9 @@ const ResultTableRow = ({ character, selected, mostCommonAffix }) => {
       onClick={(e) => dispatch(changeSelectedCharacter(character))}
       hover
     >
-      <TableCell scope="row">{character.attributes[character.settings.rankby].toFixed(2)}</TableCell>
+      <TableCell scope="row">
+        {character.attributes[character.settings.rankby].toFixed(2)}
+      </TableCell>
       {character.gear.map((element, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <TableCell align="center" key={element + index} padding="none">

--- a/src/components/sections/results/WeaponSelect.jsx
+++ b/src/components/sections/results/WeaponSelect.jsx
@@ -25,8 +25,8 @@ const WeaponSelect = ({ classes }) => {
 
   const classData = Classes[profession.toLowerCase()];
 
-  const canOffhand1 =
-    classData.weapons.mainHand.find((w) => w.name === wea1mh).type !== 'twoHanded';
+  // const canOffhand1 =
+  //   classData.weapons.mainHand.find((w) => w.name === wea1mh).type !== 'twoHanded';
 
   return (
     <>

--- a/src/components/sections/traits/Traits.jsx
+++ b/src/components/sections/traits/Traits.jsx
@@ -86,7 +86,7 @@ const Traits = ({ classes, data }) => {
     // remove modifiers before we dispatch the trait change
     dispatch(removeTraitModifierWithGW2id(selected[e.tier]));
     selected[e.tier] = e.id;
-    dispatch(changeTraits({ index: index, selected: selected }));
+    dispatch(changeTraits({ index, selected }));
   }
 
   /**

--- a/src/hocs/withGw2Theme.jsx
+++ b/src/hocs/withGw2Theme.jsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { MuiThemeProvider, withTheme } from "@material-ui/core/styles";
+import React from 'react';
+import { MuiThemeProvider, withTheme } from '@material-ui/core/styles';
 
-import gw2Styles from "../styles/gw2";
+import gw2Styles from '../styles/gw2';
 
 const specializationAliases = {
   dragonhunter: 'guardian',
@@ -24,32 +24,27 @@ const specializationAliases = {
   scourge: 'necromancer',
 };
 
-export default props => Component =>
+export default (props) => (Component) =>
   withTheme()(({ theme, ...rest }) => {
     const { profession, specialization, type } = props || { ...rest };
 
     let alias;
 
-    alias =
-      profession && typeof profession === 'string' && profession.toLowerCase();
+    alias = profession && typeof profession === 'string' && profession.toLowerCase();
 
     if (!alias) {
       const lowerCaseSpecialization =
-        specialization &&
-        typeof specialization === 'string' &&
-        specialization.toLowerCase();
+        specialization && typeof specialization === 'string' && specialization.toLowerCase();
       alias =
         lowerCaseSpecialization &&
-        (specializationAliases[lowerCaseSpecialization] ||
-          lowerCaseSpecialization);
+        (specializationAliases[lowerCaseSpecialization] || lowerCaseSpecialization);
     }
 
     if (!alias) {
       alias = type && typeof type === 'string' && type.toLowerCase();
     }
 
-    const gw2Theme =
-      alias && (!theme || alias !== theme.name) && gw2Styles[alias];
+    const gw2Theme = alias && (!theme || alias !== theme.name) && gw2Styles[alias];
 
     return gw2Theme ? (
       <MuiThemeProvider theme={gw2Theme}>

--- a/src/hocs/withLayout.jsx
+++ b/src/hocs/withLayout.jsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React from 'react';
 
-import Layout from "../components/baseComponents/Layout";
+import Layout from '../components/baseComponents/Layout';
 
 export default (layout) =>
   (Component) =>

--- a/src/hocs/withRoot.jsx
+++ b/src/hocs/withRoot.jsx
@@ -1,11 +1,11 @@
-import React from "react";
-import { CssBaseline, MuiThemeProvider } from "@material-ui/core";
-import { JssProvider } from "react-jss";
-import { ThemeProvider } from "theme-ui";
+import React from 'react';
+import { CssBaseline, MuiThemeProvider } from '@material-ui/core';
+import { JssProvider } from 'react-jss';
+import { ThemeProvider } from 'theme-ui';
 
-import baseTheme from "../styles/baseTheme";
+import baseTheme from '../styles/baseTheme';
 
-import getPageContext from "../utils/getPageContext";
+import getPageContext from '../utils/getPageContext';
 
 export default (Component) =>
   class extends React.Component {
@@ -16,7 +16,7 @@ export default (Component) =>
 
     componentDidMount() {
       // Remove the server-side injected CSS.
-      const jssStyles = document.getElementById("jss-server-side");
+      const jssStyles = document.getElementById('jss-server-side');
       if (jssStyles && jssStyles.parentNode) {
         jssStyles.parentNode.removeChild(jssStyles);
       }

--- a/src/hocs/withRoot.jsx
+++ b/src/hocs/withRoot.jsx
@@ -23,6 +23,7 @@ export default (Component) =>
     }
 
     render() {
+      // eslint-disable-next-line no-unused-vars
       const { theme, sheetsManager, generateClassName } = this.muiPageContext;
 
       return (

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,28 +1,28 @@
-import * as React from "react";
-import { Link } from "gatsby";
+import * as React from 'react';
+import { Link } from 'gatsby';
 
 // styles
 const pageStyles = {
-  color: "#232129",
-  padding: "96px",
-  fontFamily: "-apple-system, Roboto, sans-serif, serif",
-}
+  color: '#232129',
+  padding: '96px',
+  fontFamily: '-apple-system, Roboto, sans-serif, serif',
+};
 const headingStyles = {
   marginTop: 0,
   marginBottom: 64,
   maxWidth: 320,
-}
+};
 
 const paragraphStyles = {
   marginBottom: 48,
-}
+};
 const codeStyles = {
-  color: "#8A6534",
+  color: '#8A6534',
   padding: 4,
-  backgroundColor: "#FFF4DB",
-  fontSize: "1.25rem",
+  backgroundColor: '#FFF4DB',
+  fontSize: '1.25rem',
   borderRadius: 4,
-}
+};
 
 // markup
 const NotFoundPage = () => {
@@ -31,13 +31,13 @@ const NotFoundPage = () => {
       <title>Not found</title>
       <h1 style={headingStyles}>Page not found</h1>
       <p style={paragraphStyles}>
-        Sorry{" "}
+        Sorry{' '}
         <span role="img" aria-label="Pensive emoji">
           😔
-        </span>{" "}
+        </span>{' '}
         we couldn’t find what you were looking for.
         <br />
-        {process.env.NODE_ENV === "development" ? (
+        {process.env.NODE_ENV === 'development' ? (
           <>
             <br />
             Try creating a page in <code style={codeStyles}>src/pages/</code>.
@@ -48,7 +48,7 @@ const NotFoundPage = () => {
         <Link to="/">Go home</Link>.
       </p>
     </main>
-  )
-}
+  );
+};
 
-export default NotFoundPage
+export default NotFoundPage;

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-filename-extension */
 import * as React from 'react';
 import { Link } from 'gatsby';
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 import { Link, Typography, withStyles } from '@material-ui/core';
 import MuiAlert from '@material-ui/lab/Alert';
+import GitHubIcon from '@material-ui/icons/GitHub';
 import GearOptimizer from '../components/GearOptimizer';
 import withLayout from '../hocs/withLayout';
-import GitHubIcon from '@material-ui/icons/GitHub';
 
 const styles = (theme) => ({
   headline: {
@@ -17,15 +17,17 @@ const IndexPage = ({ classes }) => {
   return (
     <>
       <MuiAlert elevation={6} variant="filled" severity="warning">
-        The gear optimizer is currently in beta! Templates are not final and phantasm and lifesteal damage is inaccurate. Please report potential issues to us in{' '}
+        The gear optimizer is currently in beta! Templates are not final and phantasm and lifesteal
+        damage is inaccurate. Please report potential issues to us in{' '}
         <Link href="https://discord.gg/Qdt7nFY" color="textPrimary">
           Discord
         </Link>{' '}
         or{' '}
-        <Link href="https://github.com/discretize/discretize-gear-optimizer/tree/react-recode" color="textPrimary">
-          <GitHubIcon fontSize="small" />
-          {' '}
-          Github
+        <Link
+          href="https://github.com/discretize/discretize-gear-optimizer/tree/react-recode"
+          color="textPrimary"
+        >
+          <GitHubIcon fontSize="small" /> Github
         </Link>
         .
       </MuiAlert>

--- a/src/state/createStore.js
+++ b/src/state/createStore.js
@@ -38,7 +38,7 @@ const storage = typeof window === 'undefined' ? createNoopStorage() : createWebS
 const persistConfig = {
   key: 'root',
   whitelist: 'gw2UiStore',
-  storage: storage,
+  storage,
 };
 
 const reducers = combineReducers({

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -267,7 +267,7 @@ export function setup(input) {
   if (input.percentDistribution && input.distributionVersion !== 2) {
     const { Power, ...rest } = input.percentDistribution;
     settings.distribution = {};
-    settings.distribution['Power'] = Power * 2597 / 1025;
+    settings.distribution['Power'] = (Power * 2597) / 1025;
     for (const [condition, value] of Object.entries(rest)) {
       settings.distribution[condition] = value / Condition[condition].baseDamage;
     }
@@ -927,7 +927,7 @@ function calcPower(_character, multipliers) {
     attributes['Power'] * (1 + critChance * (critDmg - 1)) * multipliers['Effective Power'];
 
   // 2597: standard enemy armor value, also used for ingame damage tooltips
-  const damage = settings.distribution['Power'] / 2597 * attributes['Effective Power'];
+  const damage = (settings.distribution['Power'] / 2597) * attributes['Effective Power'];
   attributes['Power DPS'] = damage;
 
   return damage;

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-use-before-define */
 /* eslint-disable no-console */
 /* eslint-disable prefer-object-spread */
 /* eslint-disable prefer-template */
@@ -189,8 +190,8 @@ export function setup(input) {
                   } else {
                     throw new Error(
                       'Multipliers can only modify primary, secondary or ' +
-                        'effective attributes, not ' +
-                        attribute,
+                      'effective attributes, not ' +
+                      attribute,
                     );
                   }
 
@@ -202,8 +203,8 @@ export function setup(input) {
                   } else {
                     throw new Error(
                       'Flat modifiers can only increase primary, secondary or ' +
-                        'derived attributes, not ' +
-                        attribute,
+                      'derived attributes, not ' +
+                      attribute,
                     );
                   }
 
@@ -215,8 +216,8 @@ export function setup(input) {
                   } else {
                     throw new Error(
                       'Buff modifiers can only increase primary, secondary or ' +
-                        'derived attributes, not ' +
-                        attribute,
+                      'derived attributes, not ' +
+                      attribute,
                     );
                   }
 
@@ -234,7 +235,7 @@ export function setup(input) {
                   } else {
                     throw new Error(
                       'Conversions can only modify primary or secondary attributes, not ' +
-                        attribute,
+                      attribute,
                     );
                   }
 
@@ -297,7 +298,7 @@ export function setup(input) {
     } else {
       throw new Error(
         'Primary infusion can only increase primary, secondary or derived attributes, not ' +
-          primaryInfusionInput,
+        primaryInfusionInput,
       );
     }
   }
@@ -320,8 +321,8 @@ export function setup(input) {
     } else {
       throw new Error(
         'Secondary infusion can only increase ' +
-          'primary, secondary or derived attributes, not ' +
-          secondaryInfusionInput,
+        'primary, secondary or derived attributes, not ' +
+        secondaryInfusionInput,
       );
     }
   }

--- a/src/state/slices/omnipotion.js
+++ b/src/state/slices/omnipotion.js
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { Omnipotion } from '../../utils/gw2-data';
-import { changeExpertMode, setBuildTemplate, setModifiers } from '../gearOptimizerSlice';
+import { setModifiers } from '../gearOptimizerSlice';
 
 export const omnipotionSlice = createSlice({
   name: 'omnipotion',

--- a/src/state/slices/priorities.js
+++ b/src/state/slices/priorities.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { setBuildTemplate, setModifiers } from '../gearOptimizerSlice';
+import { setBuildTemplate } from '../gearOptimizerSlice';
 
 export const prioritiesSlice = createSlice({
   name: 'priorities',

--- a/src/styles/globals.js
+++ b/src/styles/globals.js
@@ -1,77 +1,77 @@
-import theme from "./theme";
+import theme from './theme';
 
 export default {
-  "@global": {
-    "::selection": {
+  '@global': {
+    '::selection': {
       backgroundColor: theme.palette.primary.dark,
-      color: theme.palette.common.white
+      color: theme.palette.common.white,
     },
 
-    "code, pre, samp": {
-      fontFamily: "Fira Mono",
+    'code, pre, samp': {
+      fontFamily: 'Fira Mono',
       lineHeight: 1,
-      fontSize: "0.875rem"
+      fontSize: '0.875rem',
     },
 
-    "code, samp": {
+    'code, samp': {
       color: theme.palette.common.white,
       backgroundColor: theme.palette.background.embossed,
       padding: `${theme.spacing(0.25)}px ${theme.spacing(0.75)}px`,
       border: `1px solid ${theme.palette.divider}`,
       borderRadius: theme.shape.borderRadius,
-      boxShadow: theme.shadows[1]
+      boxShadow: theme.shadows[1],
     },
 
     pre: {
       margin: `0 ${theme.spacing(2)}px ${theme.spacing(2)}px`,
-      [theme.breakpoints.up("sm")]: {
+      [theme.breakpoints.up('sm')]: {
         marginLeft: theme.spacing(3),
-        marginRight: theme.spacing(3)
+        marginRight: theme.spacing(3),
       },
-      whiteSpace: "pre",
-      "& > code": {
+      whiteSpace: 'pre',
+      '& > code': {
         padding: theme.spacing(2),
-        display: "block",
-        width: "100%",
+        display: 'block',
+        width: '100%',
         boxShadow: theme.shadows[2],
-        wordWrap: "normal",
-        wordBreak: "normal",
-        whiteSpace: "pre",
-        overflowX: "auto"
-      }
+        wordWrap: 'normal',
+        wordBreak: 'normal',
+        whiteSpace: 'pre',
+        overflowX: 'auto',
+      },
     },
 
     blockquote: {
       borderLeft: `2px solid ${theme.palette.primary.main}`,
       padding: theme.spacing(2),
       margin: `${theme.spacing(2)}px ${theme.spacing(2)}px`,
-      [theme.breakpoints.up("sm")]: {
+      [theme.breakpoints.up('sm')]: {
         marginLeft: theme.spacing(3),
-        marginRight: theme.spacing(3)
-      }
+        marginRight: theme.spacing(3),
+      },
     },
 
-    "::-webkit-scrollbar": {
+    '::-webkit-scrollbar': {
       width: theme.spacing(1),
-      height: theme.spacing(1)
+      height: theme.spacing(1),
     },
-    "::-webkit-scrollbar-track": {
-      background: "#1e2124"
+    '::-webkit-scrollbar-track': {
+      background: '#1e2124',
     },
-    "::-webkit-scrollbar-thumb": {
-      background: "#484b51",
-      borderRadius: theme.shape.borderRadius
+    '::-webkit-scrollbar-thumb': {
+      background: '#484b51',
+      borderRadius: theme.shape.borderRadius,
     },
-    "::-webkit-scrollbar-thumb:hover": {
-      background: "#b1b1b5"
+    '::-webkit-scrollbar-thumb:hover': {
+      background: '#b1b1b5',
     },
-    "::-webkit-scrollbar-corner": {
-      background: "#1e2124"
+    '::-webkit-scrollbar-corner': {
+      background: '#1e2124',
     },
 
-    "#nprogress .bar": {
+    '#nprogress .bar': {
       zIndex: 1501,
-      height: 3
-    }
-  }
+      height: 3,
+    },
+  },
 };

--- a/src/utils/getPageContext.jsx
+++ b/src/utils/getPageContext.jsx
@@ -18,9 +18,11 @@ const createPageContext = () => ({
 export default () => {
   // Make sure to create a new context for every server-side request so that data
   // isn't shared between connections (which would be bad).
-  /*if (!process.browser) {
-    return createPageContext();
-  }*/
+
+  // if (!process.browser) {
+  //   return createPageContext();
+  // }
+
   // no idea why this needs to be commented out. Apparently process only exists when the
   // server is run with node? Since we have a static page I assume this is a relict from looooong ago. ~pri
 

--- a/src/utils/getPageContext.jsx
+++ b/src/utils/getPageContext.jsx
@@ -1,9 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 
-import { SheetsRegistry } from "jss";
-import { createGenerateClassName } from "@material-ui/core/styles";
+import { SheetsRegistry } from 'jss';
+import { createGenerateClassName } from '@material-ui/core/styles';
 
-import theme from "../styles/theme";
+import theme from '../styles/theme';
 
 const createPageContext = () => ({
   theme,
@@ -12,7 +12,7 @@ const createPageContext = () => ({
   // This is needed in order to inject the critical CSS.
   sheetsRegistry: new SheetsRegistry(),
   // The standard class name generator.
-  generateClassName: createGenerateClassName()
+  generateClassName: createGenerateClassName(),
 });
 
 export default () => {

--- a/src/utils/map-gw2-ids.js
+++ b/src/utils/map-gw2-ids.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const { startCase } = require('lodash');
 
 const itemMapping = require('./mapping/items.json');

--- a/src/utils/map-gw2-ids.js
+++ b/src/utils/map-gw2-ids.js
@@ -14,9 +14,9 @@ const normalize = (string) =>
   string === undefined
     ? string
     : string
-        .replace(/[^A-Za-z]/g, '')
-        .toLowerCase()
-        .trim();
+      .replace(/[^A-Za-z]/g, '')
+      .toLowerCase()
+      .trim();
 
 const findMatch = ({
   tag,

--- a/src/utils/usefulFunctions.js
+++ b/src/utils/usefulFunctions.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+
 export function firstUppercase(text) {
   if (typeof text === 'undefined' || text === null || text === '') return '';
   return text.charAt(0).toUpperCase() + text.slice(1).toLowerCase();

--- a/src/utils/usefulFunctions.js
+++ b/src/utils/usefulFunctions.js
@@ -1,4 +1,4 @@
 export function firstUppercase(text) {
-  if (typeof text === "undefined" || text === null || text === "") return "";
+  if (typeof text === 'undefined' || text === null || text === '') return '';
   return text.charAt(0).toUpperCase() + text.slice(1).toLowerCase();
 }


### PR DESCRIPTION
This ~~crashes the github webpage if you open the diff~~ formats the Javascript and YAML with Prettier and puts back a few previously disabled eslint rules. No more commits where half the diff is the Prettier autoformat, hopefully.