### PR TITLE
fix: tables are now scrollable on mobile

### DIFF
--- a/src/components/baseComponents/Layout.jsx
+++ b/src/components/baseComponents/Layout.jsx
@@ -1,5 +1,4 @@
 import { Container, Paper, withStyles } from '@material-ui/core';
-import withWidth from '@material-ui/core/withWidth';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import injectSheet from 'react-jss';
@@ -11,15 +10,6 @@ import withRoot from '../../hocs/withRoot';
 import globals from '../../styles/globals';
 
 const styles = (theme) => ({
-  image: {
-    position: 'fixed !important',
-    width: '100vw',
-    height: '100vh',
-    left: 0,
-    bottom: 0,
-    opacity: 0.7,
-    zIndex: -1,
-  },
   paper: {
     padding: theme.spacing(2),
     backgroundColor: theme.palette.background.default,
@@ -51,4 +41,4 @@ Layout.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export default withRoot(injectSheet(globals)(withStyles(styles)(withWidth()(Layout))));
+export default withRoot(injectSheet(globals)(withStyles(styles)(Layout)));

--- a/src/components/sections/results/ResultTableHeaderRow.jsx
+++ b/src/components/sections/results/ResultTableHeaderRow.jsx
@@ -15,7 +15,7 @@ const ResultTableHeaderRow = ({ classes }) => {
     <TableRow>
       <TableCell className={classes.tablehead}>Damage</TableCell>
       {Slots[wield].map((slot) => (
-        <TableCell className={classes.tablehead} key={slot.name} align="center" padding="none">
+        <TableCell className={classes.tablehead} key={slot.name} align="center" padding="normal">
           {slot.short}
         </TableCell>
       ))}
@@ -24,7 +24,7 @@ const ResultTableHeaderRow = ({ classes }) => {
           className={classes.tablehead}
           key="primaryInfusion"
           align="center"
-          padding="none"
+          padding="normal"
         >
           <Item id={infusions.primaryInfusion} disableText disableLink />
         </TableCell>
@@ -34,7 +34,7 @@ const ResultTableHeaderRow = ({ classes }) => {
           className={classes.tablehead}
           key="secondaryInfusion"
           align="center"
-          padding="none"
+          padding="normal"
         >
           <Item id={infusions.secondaryInfusion} disableText disableLink />
         </TableCell>

--- a/src/styles/baseTheme.js
+++ b/src/styles/baseTheme.js
@@ -21,6 +21,4 @@ export default {
   initialColorModeName: 'dark',
   useBorderBox: false,
   useLocalStorage: false,
-
-  useBulkRequests: true,
 };

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -189,20 +189,9 @@ export default createTheme({
         marginBottom: theme.spacing(2),
       },
     },
-    MuiTableHead: {
-      root: {
-        [theme.breakpoints.down('sm')]: {
-          display: 'block',
-          width: 'auto',
-        },
-      },
-    },
+
     MuiTableBody: {
       root: {
-        [theme.breakpoints.down('sm')]: {
-          display: 'block',
-          width: 'auto',
-        },
         '&> tr:last-child': {
           '&> th, td': {
             borderBottom: 'none',
@@ -210,34 +199,9 @@ export default createTheme({
         },
       },
     },
-    MuiTableRow: {
-      root: {
-        [theme.breakpoints.down('sm')]: {
-          paddingTop: theme.spacing(1),
-          paddingBottom: theme.spacing(1),
-          display: 'block',
-          width: 'auto',
-          height: 'auto',
-          '&:not(:last-child)': {
-            borderBottom: `1px solid ${theme.palette.divider}`,
-          },
-        },
-      },
-      head: {
-        [theme.breakpoints.down('sm')]: {
-          height: 'auto',
-          borderBottom: `1px solid ${theme.palette.divider}`,
-        },
-      },
-    },
     MuiTableCell: {
       root: {
         borderBottom: `1px solid ${theme.palette.divider}`,
-        [theme.breakpoints.down('sm')]: {
-          display: 'block',
-          width: 'auto',
-          borderBottom: 'none',
-        },
         'th&': {
           fontWeight: 700,
         },


### PR DESCRIPTION
This PR fixes the tables scaling weirdly on mobile. The issue was buried in the old MUI theme that we copied from the main site. Apparently once upon a time someone thought it would be a smart idea to make tables scale like that. For bigger tables like ours this is total nonsense.