### PR TITLE
Update extramodifiers implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "typeface-fira-mono": "^0.0.72",
     "typeface-menomonia": "^0.1.2",
     "typeface-muli": "^1.1.3",
-    "typeface-raleway": "^0.0.75"
+    "typeface-raleway": "^0.0.75",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.0.0",
@@ -73,7 +74,6 @@
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",
     "eslint-plugin-testing-library": "^3.9.0",
-    "gh-pages": "^3.2.3",
-    "js-yaml": "^4.1.0"
+    "gh-pages": "^3.2.3"
   }
 }

--- a/src/assets/modifierdata/metadata.js
+++ b/src/assets/modifierdata/metadata.js
@@ -80,3 +80,75 @@ export const attributePercentKeysBlacklist = [
   ...damagingConditions.map((condition) => `${condition} Duration`),
   'Maximum Health',
 ];
+
+export const exampleItem = `
+    - id: example
+      text: Example Item
+      subText: with hammer
+      minor: true
+      amountData:
+        label: '% uptime'
+        default: 50
+        quantityEntered: 100
+      modifiers:
+        damage:
+          Strike Damage: [10%, mult]
+          All Damage: [20%, add]
+          Critical Damage: [20%, unknown]
+          Burning Damage: [33%, unknown]
+        attributes:
+          Ferocity: [100, converted]
+          Healing Power: [30, buff]
+          Condition Damage: [60, converted]
+          Critical Chance: 20%
+          Quickness Duration: 10%
+          Torment Duration: 25%
+          Outgoing Healing: 5%
+        conversion:
+          Power: {Precision: 3%, Ferocity: 6%}
+          Expertise: {Toughness: 3%}
+          Outgoing Healing: {Healing Power: 0.006%}
+      gw2id: 1234
+      type: CommonEffect # gw2-ui component type (only used in buffs)
+      defaultEnabled: true`;
+
+export const exampleModifiers = `damage:
+  Strike Damage: [10%, mult]
+  All Damage: [20%, add]
+  Critical Damage: [20%, unknown]
+  Burning Damage: [33%, unknown]
+attributes:
+  Ferocity: [100, converted]
+  Healing Power: [30, buff]
+  Condition Damage: [60, converted]
+  Critical Chance: 20%
+  Quickness Duration: 10%
+  Torment Duration: 25%
+  Outgoing Healing: 5%
+conversion:
+  Power: {Precision: 3%, Ferocity: 6%}
+  Expertise: {Toughness: 3%}
+  Outgoing Healing: {Healing Power: 0.006%}`;
+
+export const exampleModifiersJson = `{
+  "damage": {
+    "Strike Damage": [ "10%", "mult" ],
+    "All Damage": [ "20%", "add" ],
+    "Critical Damage": [ "20%", "unknown" ],
+    "Burning Damage": [ "33%", "unknown" ]
+  },
+  "attributes": {
+    "Ferocity": [ 100, "converted" ],
+    "Healing Power": [ 30, "buff" ],
+    "Condition Damage": [ 60, "converted" ],
+    "Critical Chance": "20%",
+    "Quickness Duration": "10%",
+    "Torment Duration": "25%",
+    "Outgoing Healing": "5%"
+  },
+  "conversion": {
+    "Power": { "Precision": "3%", "Ferocity": "6%" },
+    "Expertise": { "Toughness": "3%" },
+    "Outgoing Healing": { "Healing Power": "0.006%" }
+  }
+}`;

--- a/src/components/sections/extramodifiers/ExtraModifiersSection.jsx
+++ b/src/components/sections/extramodifiers/ExtraModifiersSection.jsx
@@ -8,8 +8,8 @@ const ExtraModifiersSection = () => {
       title="Extra Modifiers"
       helpText={
         <>
-          Allows adding arbitrary extra modifiers. The textbox expects valid JSON formatting. For
-          multiple modifiers please use a list. For more information visit the github repository.
+          Allows adding arbitrary extra modifiers. The textbox expects valid YAML or JSON formatting. 
+          Multiple modifiers can be entered as an array. For more information visit the GitHub repository.
         </>
       }
       content={<ExtraModifiers />}

--- a/src/state/slices/extraModifiers.js
+++ b/src/state/slices/extraModifiers.js
@@ -26,8 +26,8 @@ export const extraModifiersSlice = createSlice({
       // Apply extra (manual) modifiers
       if (extraModifiers.length > 0) {
         modifiers.push(
-          ...JSON.parse(extraModifiers).map((modi, index) => {
-            return { id: `extraModifier${index}`, modifiers: JSON.stringify(modi) };
+          ...extraModifiers.map((modi, index) => {
+            return { id: `extraModifier ${index + 1}`, modifiers: modi };
           }),
         );
       }


### PR DESCRIPTION
This allows the user to enter either YAML or JSON into the extramodifers box (as well as single modifiers or arrays of modifiers), and adds example data of each format to a dropdown.

It's still trivial to enter something that will not trigger validation but will crash the optimizer, but oh well.

The text box should use a fixed width font but I'm not sure the best way to do that. Can fix later.

We probably ultimately want something richer than a text box for extra modifiers, since a) they can't be translated to other languages this way and b) I mean, obviously the user experience for non developers. Good enough for now though?