### PR TITLE
Chore: pretty-print mapping JSON

### DIFF
--- a/src/utils/mapping/items.json
+++ b/src/utils/mapping/items.json
@@ -1,1 +1,12267 @@
-[{"id":8664,"name":"metalrod","type":"generic"},{"id":8678,"name":"rock","type":"generic"},{"id":8686,"name":"ashlegionspykit","type":"utility"},{"id":8732,"name":"powermatrix","type":"generic"},{"id":8759,"name":"woodenplank","type":"generic"},{"id":8764,"name":"harpyfeathers","type":"generic"},{"id":8801,"name":"orderofwhispersspykit","type":"generic"},{"id":8879,"name":"powerfulpotionofflamelegionslaying","type":"utility"},{"id":8880,"name":"powerfulpotionofcentaurslaying","type":"utility"},{"id":8881,"name":"powerfulpotionofoutlawslaying","type":"utility"},{"id":8882,"name":"powerfulpotionofnightmarecourtslaying","type":"utility"},{"id":8883,"name":"powerfulpotionofsonsofsvanirslaying","type":"utility"},{"id":8884,"name":"powerfulpotionofdestroyerslaying","type":"utility"},{"id":8885,"name":"powerfulpotionofelementalslaying","type":"utility"},{"id":8886,"name":"powerfulpotionofdemonslaying","type":"utility"},{"id":8887,"name":"powerfulpotionofinquestslaying","type":"utility"},{"id":8888,"name":"powerfulpotionofogreslaying","type":"utility"},{"id":8889,"name":"powerfulpotionoficebroodslaying","type":"utility"},{"id":8890,"name":"powerfulpotionofgrawlslaying","type":"utility"},{"id":8891,"name":"powerfulpotionofkraitslaying","type":"utility"},{"id":8892,"name":"powerfulpotionofdredgeslaying","type":"utility"},{"id":8893,"name":"powerfulpotionofundeadslaying","type":"utility"},{"id":9443,"name":"superiorsharpeningstone","type":"utility"},{"id":9461,"name":"mastermaintenanceoil","type":"utility"},{"id":9476,"name":"mastertuningcrystal","type":"utility"},{"id":12452,"name":"omnomberrybar","type":"food"},{"id":12453,"name":"chocolateomnomberrycream","type":"food"},{"id":12454,"name":"spicychocolatecookie","type":"food"},{"id":12455,"name":"omnomberrycookie","type":"food"},{"id":12456,"name":"mangopie","type":"food"},{"id":12457,"name":"omnomberrypie","type":"food"},{"id":12458,"name":"omnomberrycompote","type":"food"},{"id":12459,"name":"omnomberrytart","type":"food"},{"id":12460,"name":"chocolateomnomberrycake","type":"food"},{"id":12461,"name":"bowloftruffleravioli","type":"food"},{"id":12462,"name":"plateoflemongrasspoultry","type":"food"},{"id":12463,"name":"fancytruffleburger","type":"food"},{"id":12464,"name":"rareveggiepizza","type":"food"},{"id":12465,"name":"bowloftrufflerisotto","type":"food"},{"id":12466,"name":"plateoffireflanksteak","type":"food"},{"id":12467,"name":"plateoftrufflesteak","type":"food"},{"id":12468,"name":"plateoforriansteakfrittes","type":"food"},{"id":12469,"name":"plateoftrufflesteakdinner","type":"food"},{"id":12470,"name":"bowloflotusstirfry","type":"food"},{"id":12471,"name":"bowlofseaweedsalad","type":"food"},{"id":12472,"name":"cupoflotusfries","type":"food"},{"id":12473,"name":"loafofomnomberrybread","type":"food"},{"id":12474,"name":"loafofsaffronbread","type":"food"},{"id":12475,"name":"bowlofroastedlotusroot","type":"food"},{"id":12476,"name":"saffronstuffedmushroom","type":"food"},{"id":12477,"name":"bowloffiresalsa","type":"food"},{"id":12478,"name":"bowloftrufflesautee","type":"food"},{"id":12479,"name":"ghostpepperpopper","type":"food"},{"id":12480,"name":"bowlofsaffronscentedpoultrysoup","type":"food"},{"id":12481,"name":"bowloflemongrasspoultrysoup","type":"food"},{"id":12482,"name":"bowloforriantrufflesoup","type":"food"},{"id":12483,"name":"bowloffireveggiechili","type":"food"},{"id":12484,"name":"bowloffiremeatchili","type":"food"},{"id":12485,"name":"bowloffancypotatoandleeksoup","type":"food"},{"id":12486,"name":"bowlofcurrybutternutsquashsoup","type":"food"},{"id":12487,"name":"bowlofcurrypumpkinsoup","type":"food"},{"id":12488,"name":"bowloforriantruffleandmeatstew","type":"food"},{"id":24548,"name":"fire","type":"sigil"},{"id":24551,"name":"water","type":"sigil"},{"id":24554,"name":"air","type":"sigil"},{"id":24555,"name":"ice","type":"sigil"},{"id":24560,"name":"earth","type":"sigil"},{"id":24561,"name":"rage","type":"sigil"},{"id":24562,"name":"strength","type":"sigil"},{"id":24567,"name":"frailty","type":"sigil"},{"id":24570,"name":"blood","type":"sigil"},{"id":24571,"name":"purity","type":"sigil"},{"id":24572,"name":"nullification","type":"sigil"},{"id":24575,"name":"bloodlust","type":"sigil"},{"id":24578,"name":"corruption","type":"sigil"},{"id":24580,"name":"perception","type":"sigil"},{"id":24582,"name":"life","type":"sigil"},{"id":24583,"name":"demons","type":"sigil"},{"id":24584,"name":"benevolence","type":"sigil"},{"id":24589,"name":"speed","type":"sigil"},{"id":24591,"name":"luck","type":"sigil"},{"id":24592,"name":"stamina","type":"sigil"},{"id":24594,"name":"restoration","type":"sigil"},{"id":24597,"name":"hydromancy","type":"sigil"},{"id":24599,"name":"leeching","type":"sigil"},{"id":24600,"name":"vision","type":"sigil"},{"id":24601,"name":"battle","type":"sigil"},{"id":24605,"name":"geomancy","type":"sigil"},{"id":24607,"name":"energy","type":"sigil"},{"id":24609,"name":"doom","type":"sigil"},{"id":24612,"name":"agony","type":"sigil"},{"id":24615,"name":"force","type":"sigil"},{"id":24618,"name":"accuracy","type":"sigil"},{"id":24621,"name":"peril","type":"sigil"},{"id":24624,"name":"smoldering","type":"sigil"},{"id":24627,"name":"hobbling","type":"sigil"},{"id":24630,"name":"chilling","type":"sigil"},{"id":24632,"name":"venom","type":"sigil"},{"id":24636,"name":"debility","type":"sigil"},{"id":24639,"name":"paralyzation","type":"sigil"},{"id":24642,"name":"undeadslaying","type":"sigil"},{"id":24645,"name":"centaurslaying","type":"sigil"},{"id":24648,"name":"grawlslaying","type":"sigil"},{"id":24651,"name":"icebroodslaying","type":"sigil"},{"id":24654,"name":"destroyerslaying","type":"sigil"},{"id":24655,"name":"ogreslaying","type":"sigil"},{"id":24658,"name":"serpentslaying","type":"sigil"},{"id":24661,"name":"elementalslaying","type":"sigil"},{"id":24664,"name":"demonslaying","type":"sigil"},{"id":24667,"name":"wrath","type":"sigil"},{"id":24672,"name":"madscientists","type":"sigil"},{"id":24675,"name":"smoring","type":"sigil"},{"id":24678,"name":"justice","type":"sigil"},{"id":24681,"name":"dreams","type":"sigil"},{"id":24684,"name":"sorrow","type":"sigil"},{"id":24687,"name":"afflicted","type":"rune"},{"id":24688,"name":"lich","type":"rune"},{"id":24691,"name":"traveler","type":"rune"},{"id":24696,"name":"flock","type":"rune"},{"id":24699,"name":"dolyak","type":"rune"},{"id":24702,"name":"pack","type":"rune"},{"id":24703,"name":"infiltration","type":"rune"},{"id":24708,"name":"mercy","type":"rune"},{"id":24711,"name":"vampirism","type":"rune"},{"id":24714,"name":"strength","type":"rune"},{"id":24717,"name":"rage","type":"rune"},{"id":24720,"name":"speed","type":"rune"},{"id":24723,"name":"eagle","type":"rune"},{"id":24726,"name":"ratasum","type":"rune"},{"id":24729,"name":"hoelbrak","type":"rune"},{"id":24732,"name":"divinity","type":"rune"},{"id":24735,"name":"grove","type":"rune"},{"id":24738,"name":"scavenging","type":"rune"},{"id":24741,"name":"citadel","type":"rune"},{"id":24744,"name":"earth","type":"rune"},{"id":24747,"name":"fire","type":"rune"},{"id":24750,"name":"air","type":"rune"},{"id":24753,"name":"ice","type":"rune"},{"id":24756,"name":"ogre","type":"rune"},{"id":24757,"name":"undead","type":"rune"},{"id":24762,"name":"krait","type":"rune"},{"id":24765,"name":"balthazar","type":"rune"},{"id":24768,"name":"dwayna","type":"rune"},{"id":24771,"name":"melandru","type":"rune"},{"id":24776,"name":"lyssa","type":"rune"},{"id":24779,"name":"grenth","type":"rune"},{"id":24782,"name":"privateer","type":"rune"},{"id":24785,"name":"golemancer","type":"rune"},{"id":24788,"name":"centaur","type":"rune"},{"id":24791,"name":"wurm","type":"rune"},{"id":24794,"name":"svanir","type":"rune"},{"id":24797,"name":"flamelegion","type":"rune"},{"id":24800,"name":"elementalist","type":"rune"},{"id":24803,"name":"mesmer","type":"rune"},{"id":24806,"name":"necromancer","type":"rune"},{"id":24809,"name":"ghostslaying","type":"sigil"},{"id":24812,"name":"engineer","type":"rune"},{"id":24815,"name":"ranger","type":"rune"},{"id":24818,"name":"thief","type":"rune"},{"id":24821,"name":"warrior","type":"rune"},{"id":24824,"name":"guardian","type":"rune"},{"id":24827,"name":"trooper","type":"rune"},{"id":24830,"name":"adventurer","type":"rune"},{"id":24833,"name":"brawler","type":"rune"},{"id":24836,"name":"scholar","type":"rune"},{"id":24839,"name":"water","type":"rune"},{"id":24842,"name":"monk","type":"rune"},{"id":24845,"name":"aristocracy","type":"rune"},{"id":24848,"name":"nightmare","type":"rune"},{"id":24851,"name":"forgeman","type":"rune"},{"id":24854,"name":"baelfire","type":"rune"},{"id":24857,"name":"sanctuary","type":"rune"},{"id":24860,"name":"orr","type":"rune"},{"id":24865,"name":"celerity","type":"sigil"},{"id":24868,"name":"impact","type":"sigil"},{"id":36044,"name":"madking","type":"rune"},{"id":36053,"name":"night","type":"sigil"},{"id":36083,"name":"omnomberryghost","type":"food"},{"id":36084,"name":"spicypumpkincookie","type":"food"},{"id":36092,"name":"powerfulpotionofhalloweenslaying","type":"utility"},{"id":36793,"name":"bowloftropicalfruitsalad","type":"food"},{"id":36841,"name":"bowloftropicalmousse","type":"food"},{"id":37039,"name":"betafractalcapacitorinfused","type":"backitem","affix":"berserker"},{"id":37062,"name":"betafractalcapacitorinfused","type":"backitem","affix":"cavalier"},{"id":37125,"name":"healingagonyinfusion","type":"infusion"},{"id":37130,"name":"malignagonyinfusion","type":"infusion"},{"id":37131,"name":"mightyagonyinfusion","type":"infusion"},{"id":37132,"name":"preciseagonyinfusion","type":"infusion"},{"id":37135,"name":"resilientagonyinfusion","type":"infusion"},{"id":37136,"name":"vitalagonyinfusion","type":"infusion"},{"id":37912,"name":"karkaslaying","type":"sigil"},{"id":38206,"name":"altruism","type":"rune"},{"id":38210,"name":"bowlofsaffronmangoicecream","type":"food"},{"id":38294,"name":"generosity","type":"sigil"},{"id":39224,"name":"durmandspen","type":"accessory","affix":"soldier"},{"id":39225,"name":"goldenrelicofrin","type":"accessory","affix":"soldier"},{"id":39228,"name":"halfmadsmug","type":"accessory","affix":"cavalier"},{"id":39229,"name":"applesellersluckycog","type":"accessory","affix":"cavalier"},{"id":39230,"name":"marrinersflask","type":"accessory","affix":"rabid"},{"id":39231,"name":"fierceshotsarrowhead","type":"accessory","affix":"rabid"},{"id":39232,"name":"magistersfieldjournal","type":"accessory","affix":"berserker"},{"id":39233,"name":"altheasashes","type":"accessory","affix":"berserker"},{"id":39234,"name":"plagueidol","type":"accessory","affix":"direandrabid"},{"id":39235,"name":"matriarchsquill","type":"accessory","affix":"direandrabid"},{"id":39236,"name":"zinnsdatacrystal","type":"accessory","affix":"berserkerandvalkyrie"},{"id":39237,"name":"experimentzx","type":"accessory","affix":"berserkerandvalkyrie"},{"id":39238,"name":"imperialchefyilengsgoldenspoon","type":"accessory","affix":"rabidandapothecary"},{"id":39239,"name":"gargoyleskull","type":"accessory","affix":"rabidandapothecary"},{"id":39242,"name":"celestialsigil","type":"accessory","affix":"celestial"},{"id":39243,"name":"ancientmursaattoken","type":"accessory","affix":"celestial"},{"id":39264,"name":"thackerayfamilycrest","type":"amulet","affix":"soldier"},{"id":39265,"name":"markoftheimperialguard","type":"amulet","affix":"soldier"},{"id":39268,"name":"collarofthefirstcommissar","type":"amulet","affix":"cavalier"},{"id":39269,"name":"gwensnecklace","type":"amulet","affix":"cavalier"},{"id":39270,"name":"thesleepingseed","type":"amulet","affix":"rabid"},{"id":39271,"name":"hymntotheprophets","type":"amulet","affix":"rabid"},{"id":39272,"name":"callofthewild","type":"amulet","affix":"berserker"},{"id":39273,"name":"markofthetethyoshouses","type":"amulet","affix":"berserker"},{"id":39274,"name":"jadewindorb","type":"amulet","affix":"direandrabid"},{"id":39275,"name":"symbolofthedeceiver","type":"amulet","affix":"direandrabid"},{"id":39276,"name":"godrockamulet","type":"amulet","affix":"berserkerandvalkyrie"},{"id":39277,"name":"conundrumofmaut","type":"amulet","affix":"berserkerandvalkyrie"},{"id":39278,"name":"theheartofmellaggan","type":"amulet","affix":"rabidandapothecary"},{"id":39279,"name":"bloodofthekhanur","type":"amulet","affix":"rabidandapothecary"},{"id":39282,"name":"theeyesofabaddon","type":"amulet","affix":"celestial"},{"id":39283,"name":"eyeofjanthir","type":"amulet","affix":"celestial"},{"id":39304,"name":"barradinfamilycrest","type":"amulet","affix":"soldier"},{"id":39306,"name":"jalisironhammerscrest","type":"amulet","affix":"cavalier"},{"id":39307,"name":"speakersdawncord","type":"amulet","affix":"rabid"},{"id":39308,"name":"distinguishedcircleoflogic","type":"amulet","affix":"berserker"},{"id":39309,"name":"themastersspecialserum","type":"amulet","affix":"direandrabid"},{"id":39310,"name":"budofthepaletree","type":"amulet","affix":"berserkerandvalkyrie"},{"id":39311,"name":"featheroftheowl","type":"amulet","affix":"rabidandapothecary"},{"id":39313,"name":"syzygy","type":"amulet","affix":"celestial"},{"id":39341,"name":"triforgependant","type":"amulet","affix":"celestial"},{"id":39546,"name":"preservedredirisflower","type":"accessory","affix":"cleric"},{"id":39547,"name":"kurzickbauble","type":"accessory","affix":"cleric"},{"id":39550,"name":"warmastersfamilyheirloom","type":"accessory","affix":"knight"},{"id":39551,"name":"totemofthegorilla","type":"accessory","affix":"knight"},{"id":39554,"name":"fledglingcharm","type":"accessory","affix":"rampager"},{"id":39555,"name":"antonssecret","type":"accessory","affix":"rampager"},{"id":39558,"name":"passiflorakarkinata","type":"accessory","affix":"apothecary"},{"id":39559,"name":"ancientkarkacarapace","type":"accessory","affix":"apothecary"},{"id":39562,"name":"moltenore","type":"accessory","affix":"captain"},{"id":39563,"name":"bigmamastooth","type":"accessory","affix":"captain"},{"id":39566,"name":"amuletofprotection","type":"amulet","affix":"cleric"},{"id":39567,"name":"salmasdiamondjubileenecklace","type":"amulet","affix":"cleric"},{"id":39570,"name":"kodanprayerbeads","type":"amulet","affix":"knight"},{"id":39571,"name":"amuletoftheskies","type":"amulet","affix":"knight"},{"id":39574,"name":"petrifiedskulljuju","type":"amulet","affix":"rampager"},{"id":39575,"name":"nornbearsremembrance","type":"amulet","affix":"rampager"},{"id":39578,"name":"archaicgrawlnecklace","type":"amulet","affix":"apothecary"},{"id":39579,"name":"thesouthsunrose","type":"amulet","affix":"apothecary"},{"id":39582,"name":"charisma","type":"amulet","affix":"captain"},{"id":39583,"name":"thirdplacemedal","type":"amulet","affix":"captain"},{"id":39586,"name":"prayertootter","type":"amulet","affix":"cleric"},{"id":39587,"name":"thequeensnecklace","type":"amulet","affix":"knight"},{"id":39588,"name":"luxonpendant","type":"amulet","affix":"rampager"},{"id":39589,"name":"thebeetlestonediamond","type":"amulet","affix":"apothecary"},{"id":39590,"name":"protomatterchain","type":"amulet","affix":"captain"},{"id":41561,"name":"carrotsouffl","type":"food"},{"id":41562,"name":"bowlofrefugeesbeetsoup","type":"food"},{"id":41563,"name":"spicymarinatedmushroom","type":"food"},{"id":41564,"name":"plateoffrostgorgeclams","type":"food"},{"id":41565,"name":"bowlofgarlickalesautee","type":"food"},{"id":41566,"name":"mushroomloaf","type":"food"},{"id":41567,"name":"plateofspicyherbedchicken","type":"food"},{"id":41568,"name":"bowlofzestyturnipsoup","type":"food"},{"id":41569,"name":"bowlofsweetandspicybutternutsquashsoup","type":"food"},{"id":42427,"name":"potionofkarkaslaying","type":"utility"},{"id":42428,"name":"potionofkarkatoughness","type":"utility"},{"id":43449,"name":"potentmastertuningcrystal","type":"utility"},{"id":43450,"name":"potentmastermaintenanceoil","type":"utility"},{"id":43451,"name":"potentsuperiorsharpeningstone","type":"utility"},{"id":44642,"name":"watchworkportaldevice","type":"generic"},{"id":44944,"name":"bursting","type":"sigil"},{"id":44947,"name":"renewal","type":"sigil"},{"id":44950,"name":"malice","type":"sigil"},{"id":44951,"name":"exuberance","type":"rune"},{"id":44956,"name":"tormenting","type":"rune"},{"id":44957,"name":"perplexity","type":"rune"},{"id":46759,"name":"zojjasreaver","type":"axe","affix":"berserker"},{"id":46760,"name":"zojjasrazor","type":"dagger","affix":"berserker"},{"id":46761,"name":"zojjasartifact","type":"focus","affix":"berserker"},{"id":46762,"name":"zojjasclaymore","type":"greatsword","affix":"berserker"},{"id":46763,"name":"zojjaswarhammer","type":"hammer","affix":"berserker"},{"id":46764,"name":"zojjasimpaler","type":"harpoon","affix":"berserker"},{"id":46765,"name":"zojjasgreatbow","type":"longbow","affix":"berserker"},{"id":46766,"name":"zojjasflangedmace","type":"mace","affix":"berserker"},{"id":46767,"name":"zojjasrevolver","type":"pistol","affix":"berserker"},{"id":46768,"name":"zojjasmusket","type":"rifle","affix":"berserker"},{"id":46769,"name":"zojjaswand","type":"scepter","affix":"berserker"},{"id":46770,"name":"zojjasbastion","type":"shield","affix":"berserker"},{"id":46771,"name":"zojjasshortbow","type":"shortbow","affix":"berserker"},{"id":46772,"name":"zojjasharpoongun","type":"speargun","affix":"berserker"},{"id":46773,"name":"zojjasspire","type":"staff","affix":"berserker"},{"id":46774,"name":"zojjasblade","type":"sword","affix":"berserker"},{"id":46775,"name":"zojjasbrazier","type":"torch","affix":"berserker"},{"id":46776,"name":"zojjastrident","type":"trident","affix":"berserker"},{"id":46777,"name":"zojjasherald","type":"warhorn","affix":"berserker"},{"id":46778,"name":"coalforgesreaver","type":"axe","affix":"rampager"},{"id":46779,"name":"coalforgesrazor","type":"dagger","affix":"rampager"},{"id":46780,"name":"coalforgesartifact","type":"focus","affix":"rampager"},{"id":46781,"name":"coalforgesclaymore","type":"greatsword","affix":"rampager"},{"id":46782,"name":"coalforgeswarhammer","type":"hammer","affix":"rampager"},{"id":46783,"name":"coalforgesimpaler","type":"harpoon","affix":"rampager"},{"id":46784,"name":"coalforgesgreatbow","type":"longbow","affix":"rampager"},{"id":46785,"name":"coalforgesflangedmace","type":"mace","affix":"rampager"},{"id":46786,"name":"coalforgesrevolver","type":"pistol","affix":"rampager"},{"id":46787,"name":"coalforgesmusket","type":"rifle","affix":"rampager"},{"id":46788,"name":"coalforgeswand","type":"scepter","affix":"rampager"},{"id":46789,"name":"coalforgesbastion","type":"shield","affix":"rampager"},{"id":46790,"name":"coalforgesshortbow","type":"shortbow","affix":"rampager"},{"id":46791,"name":"coalforgesharpoongun","type":"speargun","affix":"rampager"},{"id":46792,"name":"coalforgesspire","type":"staff","affix":"rampager"},{"id":46793,"name":"coalforgesblade","type":"sword","affix":"rampager"},{"id":46794,"name":"coalforgesbrazier","type":"torch","affix":"rampager"},{"id":46795,"name":"coalforgestrident","type":"trident","affix":"rampager"},{"id":46796,"name":"coalforgesherald","type":"warhorn","affix":"rampager"},{"id":46797,"name":"stonecleaversreaver","type":"axe","affix":"valkyrie"},{"id":46798,"name":"stonecleaversrazor","type":"dagger","affix":"valkyrie"},{"id":46799,"name":"stonecleaversartifact","type":"focus","affix":"valkyrie"},{"id":46800,"name":"stonecleaversclaymore","type":"greatsword","affix":"valkyrie"},{"id":46801,"name":"stonecleaverswarhammer","type":"hammer","affix":"valkyrie"},{"id":46802,"name":"stonecleaversimpaler","type":"harpoon","affix":"valkyrie"},{"id":46803,"name":"stonecleaversgreatbow","type":"longbow","affix":"valkyrie"},{"id":46804,"name":"stonecleaversflangedmace","type":"mace","affix":"valkyrie"},{"id":46805,"name":"stonecleaversrevolver","type":"pistol","affix":"valkyrie"},{"id":46806,"name":"stonecleaversmusket","type":"rifle","affix":"valkyrie"},{"id":46807,"name":"stonecleaverswand","type":"scepter","affix":"valkyrie"},{"id":46808,"name":"stonecleaversbastion","type":"shield","affix":"valkyrie"},{"id":46809,"name":"stonecleaversshortbow","type":"shortbow","affix":"valkyrie"},{"id":46810,"name":"stonecleaversharpoongun","type":"speargun","affix":"valkyrie"},{"id":46811,"name":"stonecleaversspire","type":"staff","affix":"valkyrie"},{"id":46812,"name":"stonecleaversblade","type":"sword","affix":"valkyrie"},{"id":46813,"name":"stonecleaversbrazier","type":"torch","affix":"valkyrie"},{"id":46814,"name":"stonecleaverstrident","type":"trident","affix":"valkyrie"},{"id":46815,"name":"stonecleaversherald","type":"warhorn","affix":"valkyrie"},{"id":46816,"name":"beigarthsreaver","type":"axe","affix":"knight"},{"id":46817,"name":"beigarthsrazor","type":"dagger","affix":"knight"},{"id":46818,"name":"beigarthsartifact","type":"focus","affix":"knight"},{"id":46819,"name":"beigarthsclaymore","type":"greatsword","affix":"knight"},{"id":46820,"name":"beigarthswarhammer","type":"hammer","affix":"knight"},{"id":46821,"name":"beigarthsimpaler","type":"harpoon","affix":"knight"},{"id":46822,"name":"beigarthsgreatbow","type":"longbow","affix":"knight"},{"id":46823,"name":"beigarthsflangedmace","type":"mace","affix":"knight"},{"id":46824,"name":"beigarthsrevolver","type":"pistol","affix":"knight"},{"id":46825,"name":"beigarthsmusket","type":"rifle","affix":"knight"},{"id":46826,"name":"beigarthswand","type":"scepter","affix":"knight"},{"id":46827,"name":"beigarthsbastion","type":"shield","affix":"knight"},{"id":46828,"name":"beigarthsshortbow","type":"shortbow","affix":"knight"},{"id":46829,"name":"beigarthsharpoongun","type":"speargun","affix":"knight"},{"id":46830,"name":"beigarthsspire","type":"staff","affix":"knight"},{"id":46831,"name":"beigarthsblade","type":"sword","affix":"knight"},{"id":46832,"name":"beigarthsbrazier","type":"torch","affix":"knight"},{"id":46833,"name":"beigarthstrident","type":"trident","affix":"knight"},{"id":46834,"name":"beigarthsherald","type":"warhorn","affix":"knight"},{"id":46835,"name":"occamsreaver","type":"axe","affix":"carrion"},{"id":46836,"name":"occamsrazor","type":"dagger","affix":"carrion"},{"id":46837,"name":"occamsartifact","type":"focus","affix":"carrion"},{"id":46838,"name":"occamsclaymore","type":"greatsword","affix":"carrion"},{"id":46839,"name":"occamswarhammer","type":"hammer","affix":"carrion"},{"id":46840,"name":"occamsimpaler","type":"harpoon","affix":"carrion"},{"id":46841,"name":"occamsgreatbow","type":"longbow","affix":"carrion"},{"id":46842,"name":"occamsflangedmace","type":"mace","affix":"carrion"},{"id":46843,"name":"occamsrevolver","type":"pistol","affix":"carrion"},{"id":46844,"name":"occamsmusket","type":"rifle","affix":"carrion"},{"id":46845,"name":"occamswand","type":"scepter","affix":"carrion"},{"id":46846,"name":"occamsbastion","type":"shield","affix":"carrion"},{"id":46847,"name":"occamsshortbow","type":"shortbow","affix":"carrion"},{"id":46848,"name":"occamsharpoongun","type":"speargun","affix":"carrion"},{"id":46849,"name":"occamsspire","type":"staff","affix":"carrion"},{"id":46850,"name":"occamsblade","type":"sword","affix":"carrion"},{"id":46851,"name":"occamsbrazier","type":"torch","affix":"carrion"},{"id":46852,"name":"occamstrident","type":"trident","affix":"carrion"},{"id":46853,"name":"occamsherald","type":"warhorn","affix":"carrion"},{"id":46854,"name":"zintlreaver","type":"axe","affix":"shaman"},{"id":46855,"name":"zintlrazor","type":"dagger","affix":"shaman"},{"id":46856,"name":"zintlartifact","type":"focus","affix":"shaman"},{"id":46857,"name":"zintlclaymore","type":"greatsword","affix":"shaman"},{"id":46858,"name":"zintlwarhammer","type":"hammer","affix":"shaman"},{"id":46859,"name":"zintlimpaler","type":"harpoon","affix":"shaman"},{"id":46860,"name":"zintlgreatbow","type":"longbow","affix":"shaman"},{"id":46861,"name":"zintlflangedmace","type":"mace","affix":"shaman"},{"id":46862,"name":"zintlrevolver","type":"pistol","affix":"shaman"},{"id":46863,"name":"zintlmusket","type":"rifle","affix":"shaman"},{"id":46864,"name":"zintlwand","type":"scepter","affix":"shaman"},{"id":46865,"name":"zintlbastion","type":"shield","affix":"shaman"},{"id":46866,"name":"zintlshortbow","type":"shortbow","affix":"shaman"},{"id":46867,"name":"zintlharpoongun","type":"speargun","affix":"shaman"},{"id":46868,"name":"zintlspire","type":"staff","affix":"shaman"},{"id":46869,"name":"zintlblade","type":"sword","affix":"shaman"},{"id":46870,"name":"zintlbrazier","type":"torch","affix":"shaman"},{"id":46871,"name":"zintltrident","type":"trident","affix":"shaman"},{"id":46872,"name":"zintlherald","type":"warhorn","affix":"shaman"},{"id":46873,"name":"tonnsreaver","type":"axe","affix":"sentinel"},{"id":46874,"name":"tonnsrazor","type":"dagger","affix":"sentinel"},{"id":46875,"name":"tonnsartifact","type":"focus","affix":"sentinel"},{"id":46876,"name":"tonnsclaymore","type":"greatsword","affix":"sentinel"},{"id":46877,"name":"tonnswarhammer","type":"hammer","affix":"sentinel"},{"id":46878,"name":"tonnsimpaler","type":"harpoon","affix":"sentinel"},{"id":46879,"name":"tonnsgreatbow","type":"longbow","affix":"sentinel"},{"id":46880,"name":"tonnsflangedmace","type":"mace","affix":"sentinel"},{"id":46881,"name":"tonnsrevolver","type":"pistol","affix":"sentinel"},{"id":46882,"name":"tonnsmusket","type":"rifle","affix":"sentinel"},{"id":46883,"name":"tonnswand","type":"scepter","affix":"sentinel"},{"id":46884,"name":"tonnsbastion","type":"shield","affix":"sentinel"},{"id":46885,"name":"tonnsshortbow","type":"shortbow","affix":"sentinel"},{"id":46886,"name":"tonnsharpoongun","type":"speargun","affix":"sentinel"},{"id":46887,"name":"tonnsspire","type":"staff","affix":"sentinel"},{"id":46888,"name":"tonnsblade","type":"sword","affix":"sentinel"},{"id":46889,"name":"tonnsbrazier","type":"torch","affix":"sentinel"},{"id":46890,"name":"tonnstrident","type":"trident","affix":"sentinel"},{"id":46891,"name":"tonnsherald","type":"warhorn","affix":"sentinel"},{"id":46892,"name":"ebonmanesreaver","type":"axe","affix":"apothecary"},{"id":46893,"name":"ebonmanesrazor","type":"dagger","affix":"apothecary"},{"id":46894,"name":"ebonmanesartifact","type":"focus","affix":"apothecary"},{"id":46895,"name":"ebonmanesclaymore","type":"greatsword","affix":"apothecary"},{"id":46896,"name":"ebonmaneswarhammer","type":"hammer","affix":"apothecary"},{"id":46897,"name":"ebonmanesimpaler","type":"harpoon","affix":"apothecary"},{"id":46898,"name":"ebonmanesgreatbow","type":"longbow","affix":"apothecary"},{"id":46899,"name":"ebonmanesflangedmace","type":"mace","affix":"apothecary"},{"id":46900,"name":"ebonmanesrevolver","type":"pistol","affix":"apothecary"},{"id":46901,"name":"ebonmanesmusket","type":"rifle","affix":"apothecary"},{"id":46902,"name":"ebonmaneswand","type":"scepter","affix":"apothecary"},{"id":46903,"name":"ebonmanesbastion","type":"shield","affix":"apothecary"},{"id":46904,"name":"ebonmanesshortbow","type":"shortbow","affix":"apothecary"},{"id":46905,"name":"ebonmanesharpoongun","type":"speargun","affix":"apothecary"},{"id":46906,"name":"ebonmanesspire","type":"staff","affix":"apothecary"},{"id":46907,"name":"ebonmanesblade","type":"sword","affix":"apothecary"},{"id":46908,"name":"ebonmanesbrazier","type":"torch","affix":"apothecary"},{"id":46909,"name":"ebonmanestrident","type":"trident","affix":"apothecary"},{"id":46910,"name":"ebonmanesherald","type":"warhorn","affix":"apothecary"},{"id":46911,"name":"leftpawsreaver","type":"axe","affix":"settler"},{"id":46912,"name":"leftpawsrazor","type":"dagger","affix":"settler"},{"id":46913,"name":"leftpawsartifact","type":"focus","affix":"settler"},{"id":46914,"name":"leftpawsclaymore","type":"greatsword","affix":"settler"},{"id":46915,"name":"leftpawswarhammer","type":"hammer","affix":"settler"},{"id":46916,"name":"leftpawsimpaler","type":"harpoon","affix":"settler"},{"id":46917,"name":"leftpawsgreatbow","type":"longbow","affix":"settler"},{"id":46918,"name":"leftpawsflangedmace","type":"mace","affix":"settler"},{"id":46919,"name":"leftpawsrevolver","type":"pistol","affix":"settler"},{"id":46920,"name":"leftpawsmusket","type":"rifle","affix":"settler"},{"id":46921,"name":"leftpawswand","type":"scepter","affix":"settler"},{"id":46922,"name":"leftpawsbastion","type":"shield","affix":"settler"},{"id":46923,"name":"leftpawsshortbow","type":"shortbow","affix":"settler"},{"id":46924,"name":"leftpawsharpoongun","type":"speargun","affix":"settler"},{"id":46925,"name":"leftpawsspire","type":"staff","affix":"settler"},{"id":46926,"name":"leftpawsblade","type":"sword","affix":"settler"},{"id":46927,"name":"leftpawsbrazier","type":"torch","affix":"settler"},{"id":46928,"name":"leftpawstrident","type":"trident","affix":"settler"},{"id":46929,"name":"leftpawsherald","type":"warhorn","affix":"settler"},{"id":46930,"name":"angchureaver","type":"axe","affix":"cavalier"},{"id":46931,"name":"angchurazor","type":"dagger","affix":"cavalier"},{"id":46932,"name":"angchuartifact","type":"focus","affix":"cavalier"},{"id":46933,"name":"angchuclaymore","type":"greatsword","affix":"cavalier"},{"id":46934,"name":"angchuwarhammer","type":"hammer","affix":"cavalier"},{"id":46935,"name":"angchuimpaler","type":"harpoon","affix":"cavalier"},{"id":46936,"name":"angchugreatbow","type":"longbow","affix":"cavalier"},{"id":46937,"name":"angchuflangedmace","type":"mace","affix":"cavalier"},{"id":46938,"name":"angchurevolver","type":"pistol","affix":"cavalier"},{"id":46939,"name":"angchumusket","type":"rifle","affix":"cavalier"},{"id":46940,"name":"angchuwand","type":"scepter","affix":"cavalier"},{"id":46941,"name":"angchubastion","type":"shield","affix":"cavalier"},{"id":46942,"name":"angchushortbow","type":"shortbow","affix":"cavalier"},{"id":46943,"name":"angchuharpoongun","type":"speargun","affix":"cavalier"},{"id":46944,"name":"angchuspire","type":"staff","affix":"cavalier"},{"id":46945,"name":"angchublade","type":"sword","affix":"cavalier"},{"id":46946,"name":"angchubrazier","type":"torch","affix":"cavalier"},{"id":46947,"name":"angchutrident","type":"trident","affix":"cavalier"},{"id":46948,"name":"angchuherald","type":"warhorn","affix":"cavalier"},{"id":46949,"name":"grizzlemouthsreaver","type":"axe","affix":"rabid"},{"id":46950,"name":"grizzlemouthsrazor","type":"dagger","affix":"rabid"},{"id":46951,"name":"grizzlemouthsartifact","type":"focus","affix":"rabid"},{"id":46952,"name":"grizzlemouthsclaymore","type":"greatsword","affix":"rabid"},{"id":46953,"name":"grizzlemouthswarhammer","type":"hammer","affix":"rabid"},{"id":46954,"name":"grizzlemouthsimpaler","type":"harpoon","affix":"rabid"},{"id":46955,"name":"grizzlemouthsgreatbow","type":"longbow","affix":"rabid"},{"id":46956,"name":"grizzlemouthsflangedmace","type":"mace","affix":"rabid"},{"id":46957,"name":"grizzlemouthsrevolver","type":"pistol","affix":"rabid"},{"id":46958,"name":"grizzlemouthsmusket","type":"rifle","affix":"rabid"},{"id":46959,"name":"grizzlemouthswand","type":"scepter","affix":"rabid"},{"id":46960,"name":"grizzlemouthsbastion","type":"shield","affix":"rabid"},{"id":46961,"name":"grizzlemouthsshortbow","type":"shortbow","affix":"rabid"},{"id":46962,"name":"grizzlemouthsharpoongun","type":"speargun","affix":"rabid"},{"id":46963,"name":"grizzlemouthsspire","type":"staff","affix":"rabid"},{"id":46964,"name":"grizzlemouthsblade","type":"sword","affix":"rabid"},{"id":46965,"name":"grizzlemouthsbrazier","type":"torch","affix":"rabid"},{"id":46966,"name":"grizzlemouthstrident","type":"trident","affix":"rabid"},{"id":46967,"name":"grizzlemouthsherald","type":"warhorn","affix":"rabid"},{"id":46968,"name":"hronksreaver","type":"axe","affix":"magi"},{"id":46969,"name":"hronksrazor","type":"dagger","affix":"magi"},{"id":46970,"name":"hronksartifact","type":"focus","affix":"magi"},{"id":46971,"name":"hronksclaymore","type":"greatsword","affix":"magi"},{"id":46972,"name":"hronkswarhammer","type":"hammer","affix":"magi"},{"id":46973,"name":"hronksimpaler","type":"harpoon","affix":"magi"},{"id":46974,"name":"hronksgreatbow","type":"longbow","affix":"magi"},{"id":46975,"name":"hronksflangedmace","type":"mace","affix":"magi"},{"id":46976,"name":"hronksrevolver","type":"pistol","affix":"magi"},{"id":46977,"name":"hronksmusket","type":"rifle","affix":"magi"},{"id":46978,"name":"hronkswand","type":"scepter","affix":"magi"},{"id":46979,"name":"hronksbastion","type":"shield","affix":"magi"},{"id":46980,"name":"hronksshortbow","type":"shortbow","affix":"magi"},{"id":46981,"name":"hronksharpoongun","type":"speargun","affix":"magi"},{"id":46982,"name":"hronksspire","type":"staff","affix":"magi"},{"id":46983,"name":"hronksblade","type":"sword","affix":"magi"},{"id":46984,"name":"hronksbrazier","type":"torch","affix":"magi"},{"id":46985,"name":"hronkstrident","type":"trident","affix":"magi"},{"id":46986,"name":"hronksherald","type":"warhorn","affix":"magi"},{"id":46987,"name":"chorbensreaver","type":"axe","affix":"soldier"},{"id":46988,"name":"chorbensrazor","type":"dagger","affix":"soldier"},{"id":46989,"name":"chorbensartifact","type":"focus","affix":"soldier"},{"id":46990,"name":"chorbensclaymore","type":"greatsword","affix":"soldier"},{"id":46991,"name":"chorbenswarhammer","type":"hammer","affix":"soldier"},{"id":46992,"name":"chorbensimpaler","type":"harpoon","affix":"soldier"},{"id":46993,"name":"chorbensgreatbow","type":"longbow","affix":"soldier"},{"id":46994,"name":"chorbensflangedmace","type":"mace","affix":"soldier"},{"id":46995,"name":"chorbensrevolver","type":"pistol","affix":"soldier"},{"id":46996,"name":"chorbensmusket","type":"rifle","affix":"soldier"},{"id":46997,"name":"chorbenswand","type":"scepter","affix":"soldier"},{"id":46998,"name":"chorbensbastion","type":"shield","affix":"soldier"},{"id":46999,"name":"chorbensshortbow","type":"shortbow","affix":"soldier"},{"id":47000,"name":"chorbensharpoongun","type":"speargun","affix":"soldier"},{"id":47001,"name":"chorbensspire","type":"staff","affix":"soldier"},{"id":47002,"name":"chorbensblade","type":"sword","affix":"soldier"},{"id":47003,"name":"chorbensbrazier","type":"torch","affix":"soldier"},{"id":47004,"name":"chorbenstrident","type":"trident","affix":"soldier"},{"id":47005,"name":"chorbensherald","type":"warhorn","affix":"soldier"},{"id":47006,"name":"wupwupreaver","type":"axe","affix":"celestial"},{"id":47007,"name":"wupwuprazor","type":"dagger","affix":"celestial"},{"id":47008,"name":"wupwupartifact","type":"focus","affix":"celestial"},{"id":47009,"name":"wupwupclaymore","type":"greatsword","affix":"celestial"},{"id":47010,"name":"wupwupwarhammer","type":"hammer","affix":"celestial"},{"id":47011,"name":"wupwupimpaler","type":"harpoon","affix":"celestial"},{"id":47012,"name":"wupwupgreatbow","type":"longbow","affix":"celestial"},{"id":47013,"name":"wupwupflangedmace","type":"mace","affix":"celestial"},{"id":47014,"name":"wupwuprevolver","type":"pistol","affix":"celestial"},{"id":47015,"name":"wupwupmusket","type":"rifle","affix":"celestial"},{"id":47016,"name":"wupwupwand","type":"scepter","affix":"celestial"},{"id":47017,"name":"wupwupbastion","type":"shield","affix":"celestial"},{"id":47018,"name":"wupwupshortbow","type":"shortbow","affix":"celestial"},{"id":47019,"name":"wupwupharpoongun","type":"speargun","affix":"celestial"},{"id":47020,"name":"wupwupspire","type":"staff","affix":"celestial"},{"id":47021,"name":"wupwupblade","type":"sword","affix":"celestial"},{"id":47022,"name":"wupwupbrazier","type":"torch","affix":"celestial"},{"id":47023,"name":"wupwuptrident","type":"trident","affix":"celestial"},{"id":47024,"name":"wupwupherald","type":"warhorn","affix":"celestial"},{"id":47025,"name":"theodosussreaver","type":"axe","affix":"cleric"},{"id":47026,"name":"theodosussrazor","type":"dagger","affix":"cleric"},{"id":47027,"name":"theodosussartifact","type":"focus","affix":"cleric"},{"id":47028,"name":"theodosussclaymore","type":"greatsword","affix":"cleric"},{"id":47029,"name":"theodosusswarhammer","type":"hammer","affix":"cleric"},{"id":47030,"name":"theodosussimpaler","type":"harpoon","affix":"cleric"},{"id":47031,"name":"theodosussgreatbow","type":"longbow","affix":"cleric"},{"id":47032,"name":"theodosussflangedmace","type":"mace","affix":"cleric"},{"id":47033,"name":"theodosussrevolver","type":"pistol","affix":"cleric"},{"id":47034,"name":"theodosussmusket","type":"rifle","affix":"cleric"},{"id":47035,"name":"theodosusswand","type":"scepter","affix":"cleric"},{"id":47036,"name":"theodosussbastion","type":"shield","affix":"cleric"},{"id":47037,"name":"theodosussshortbow","type":"shortbow","affix":"cleric"},{"id":47038,"name":"theodosussharpoongun","type":"speargun","affix":"cleric"},{"id":47039,"name":"theodosussspire","type":"staff","affix":"cleric"},{"id":47040,"name":"theodosussblade","type":"sword","affix":"cleric"},{"id":47041,"name":"theodosussbrazier","type":"torch","affix":"cleric"},{"id":47042,"name":"theodosusstrident","type":"trident","affix":"cleric"},{"id":47043,"name":"theodosussherald","type":"warhorn","affix":"cleric"},{"id":47044,"name":"sorossreaver","type":"axe","affix":"assassin"},{"id":47045,"name":"sorossrazor","type":"dagger","affix":"assassin"},{"id":47046,"name":"sorossartifact","type":"focus","affix":"assassin"},{"id":47047,"name":"sorossclaymore","type":"greatsword","affix":"assassin"},{"id":47048,"name":"sorosswarhammer","type":"hammer","affix":"assassin"},{"id":47049,"name":"sorossimpaler","type":"harpoon","affix":"assassin"},{"id":47050,"name":"sorossgreatbow","type":"longbow","affix":"assassin"},{"id":47051,"name":"sorossflangedmace","type":"mace","affix":"assassin"},{"id":47052,"name":"sorossrevolver","type":"pistol","affix":"assassin"},{"id":47053,"name":"sorossmusket","type":"rifle","affix":"assassin"},{"id":47054,"name":"sorosswand","type":"scepter","affix":"assassin"},{"id":47055,"name":"sorossbastion","type":"shield","affix":"assassin"},{"id":47056,"name":"sorossshortbow","type":"shortbow","affix":"assassin"},{"id":47057,"name":"sorossharpoongun","type":"speargun","affix":"assassin"},{"id":47058,"name":"sorossspire","type":"staff","affix":"assassin"},{"id":47059,"name":"sorossblade","type":"sword","affix":"assassin"},{"id":47060,"name":"sorossbrazier","type":"torch","affix":"assassin"},{"id":47061,"name":"sorosstrident","type":"trident","affix":"assassin"},{"id":47062,"name":"sorossherald","type":"warhorn","affix":"assassin"},{"id":47063,"name":"mathildesreaver","type":"axe","affix":"dire"},{"id":47064,"name":"mathildesrazor","type":"dagger","affix":"dire"},{"id":47065,"name":"mathildesartifact","type":"focus","affix":"dire"},{"id":47066,"name":"mathildesclaymore","type":"greatsword","affix":"dire"},{"id":47067,"name":"mathildeswarhammer","type":"hammer","affix":"dire"},{"id":47068,"name":"mathildesimpaler","type":"harpoon","affix":"dire"},{"id":47069,"name":"mathildesgreatbow","type":"longbow","affix":"dire"},{"id":47070,"name":"mathildesflangedmace","type":"mace","affix":"dire"},{"id":47071,"name":"mathildesrevolver","type":"pistol","affix":"dire"},{"id":47072,"name":"mathildesmusket","type":"rifle","affix":"dire"},{"id":47073,"name":"mathildeswand","type":"scepter","affix":"dire"},{"id":47074,"name":"mathildesbastion","type":"shield","affix":"dire"},{"id":47075,"name":"mathildesshortbow","type":"shortbow","affix":"dire"},{"id":47076,"name":"mathildesharpoongun","type":"speargun","affix":"dire"},{"id":47077,"name":"mathildesspire","type":"staff","affix":"dire"},{"id":47078,"name":"mathildesblade","type":"sword","affix":"dire"},{"id":47079,"name":"mathildesbrazier","type":"torch","affix":"dire"},{"id":47080,"name":"mathildestrident","type":"trident","affix":"dire"},{"id":47081,"name":"mathildesherald","type":"warhorn","affix":"dire"},{"id":47851,"name":"reaverofthesunless","type":"axe","affix":"rabid"},{"id":47852,"name":"razorofthesunless","type":"dagger","affix":"rabid"},{"id":47853,"name":"artifactofthesunless","type":"focus","affix":"rabid"},{"id":47854,"name":"claymoreofthesunless","type":"greatsword","affix":"rabid"},{"id":47855,"name":"warhammerofthesunless","type":"hammer","affix":"rabid"},{"id":47856,"name":"impalerofthesunless","type":"harpoon","affix":"rabid"},{"id":47857,"name":"greatbowofthesunless","type":"longbow","affix":"rabid"},{"id":47858,"name":"flangedmaceofthesunless","type":"mace","affix":"rabid"},{"id":47859,"name":"revolverofthesunless","type":"pistol","affix":"rabid"},{"id":47860,"name":"musketofthesunless","type":"rifle","affix":"rabid"},{"id":47861,"name":"wandofthesunless","type":"scepter","affix":"rabid"},{"id":47862,"name":"bastionofthesunless","type":"shield","affix":"rabid"},{"id":47863,"name":"shortbowofthesunless","type":"shortbow","affix":"rabid"},{"id":47864,"name":"harpoongunofthesunless","type":"speargun","affix":"rabid"},{"id":47865,"name":"spireofthesunless","type":"staff","affix":"rabid"},{"id":47866,"name":"bladeofthesunless","type":"sword","affix":"rabid"},{"id":47867,"name":"brazierofthesunless","type":"torch","affix":"rabid"},{"id":47868,"name":"tridentofthesunless","type":"trident","affix":"rabid"},{"id":47869,"name":"heraldofthesunless","type":"warhorn","affix":"rabid"},{"id":47908,"name":"sunless","type":"rune"},{"id":47910,"name":"beigarthsshoulderguard","type":"shoulders","affix":"knight","weight":"medium"},{"id":47911,"name":"beigarthsleggings","type":"leggings","affix":"knight","weight":"medium"},{"id":47912,"name":"beigarthsvisage","type":"helm","affix":"knight","weight":"medium"},{"id":47913,"name":"beigarthsgrips","type":"gloves","affix":"knight","weight":"medium"},{"id":47914,"name":"beigarthsguise","type":"coat","affix":"knight","weight":"medium"},{"id":47915,"name":"beigarthsstriders","type":"boots","affix":"knight","weight":"medium"},{"id":47916,"name":"beigarthsepaulets","type":"shoulders","affix":"knight","weight":"light"},{"id":47917,"name":"beigarthsbreeches","type":"leggings","affix":"knight","weight":"light"},{"id":47918,"name":"beigarthsmasque","type":"helm","affix":"knight","weight":"light"},{"id":47919,"name":"beigarthswristguards","type":"gloves","affix":"knight","weight":"light"},{"id":47920,"name":"beigarthsdoublet","type":"coat","affix":"knight","weight":"light"},{"id":47921,"name":"beigarthsfootwear","type":"boots","affix":"knight","weight":"light"},{"id":47922,"name":"beigarthspauldrons","type":"shoulders","affix":"knight","weight":"heavy"},{"id":47923,"name":"beigarthstassets","type":"leggings","affix":"knight","weight":"heavy"},{"id":47924,"name":"beigarthsvisor","type":"helm","affix":"knight","weight":"heavy"},{"id":47925,"name":"beigarthswarfists","type":"gloves","affix":"knight","weight":"heavy"},{"id":47926,"name":"beigarthsbreastplate","type":"coat","affix":"knight","weight":"heavy"},{"id":47927,"name":"beigarthsgreaves","type":"boots","affix":"knight","weight":"heavy"},{"id":47928,"name":"wupwupgreaves","type":"boots","affix":"celestial","weight":"heavy"},{"id":47929,"name":"wupwupbreastplate","type":"coat","affix":"celestial","weight":"heavy"},{"id":47930,"name":"wupwupwarfists","type":"gloves","affix":"celestial","weight":"heavy"},{"id":47931,"name":"wupwupvisor","type":"helm","affix":"celestial","weight":"heavy"},{"id":47932,"name":"wupwuptassets","type":"leggings","affix":"celestial","weight":"heavy"},{"id":47933,"name":"wupwuppauldrons","type":"shoulders","affix":"celestial","weight":"heavy"},{"id":47934,"name":"wupwupfootwear","type":"boots","affix":"celestial","weight":"light"},{"id":47935,"name":"wupwupdoublet","type":"coat","affix":"celestial","weight":"light"},{"id":47936,"name":"wupwupwristguards","type":"gloves","affix":"celestial","weight":"light"},{"id":47937,"name":"wupwupmasque","type":"helm","affix":"celestial","weight":"light"},{"id":47938,"name":"wupwupbreeches","type":"leggings","affix":"celestial","weight":"light"},{"id":47939,"name":"wupwupepaulets","type":"shoulders","affix":"celestial","weight":"light"},{"id":47940,"name":"wupwupstriders","type":"boots","affix":"celestial","weight":"medium"},{"id":47941,"name":"wupwupguise","type":"coat","affix":"celestial","weight":"medium"},{"id":47942,"name":"wupwupgrips","type":"gloves","affix":"celestial","weight":"medium"},{"id":47943,"name":"wupwupvisage","type":"helm","affix":"celestial","weight":"medium"},{"id":47944,"name":"wupwupleggings","type":"leggings","affix":"celestial","weight":"medium"},{"id":47945,"name":"wupwupshoulderguard","type":"shoulders","affix":"celestial","weight":"medium"},{"id":47946,"name":"occamsgreaves","type":"boots","affix":"carrion","weight":"heavy"},{"id":47947,"name":"occamsbreastplate","type":"coat","affix":"carrion","weight":"heavy"},{"id":47948,"name":"occamswarfists","type":"gloves","affix":"carrion","weight":"heavy"},{"id":47949,"name":"occamsvisor","type":"helm","affix":"carrion","weight":"heavy"},{"id":47950,"name":"occamstassets","type":"leggings","affix":"carrion","weight":"heavy"},{"id":47951,"name":"occamspauldrons","type":"shoulders","affix":"carrion","weight":"heavy"},{"id":47952,"name":"occamsfootwear","type":"boots","affix":"carrion","weight":"light"},{"id":47953,"name":"occamsdoublet","type":"coat","affix":"carrion","weight":"light"},{"id":47954,"name":"occamswristguards","type":"gloves","affix":"carrion","weight":"light"},{"id":47955,"name":"occamsmasque","type":"helm","affix":"carrion","weight":"light"},{"id":47956,"name":"occamsbreeches","type":"leggings","affix":"carrion","weight":"light"},{"id":47957,"name":"occamsepaulets","type":"shoulders","affix":"carrion","weight":"light"},{"id":47958,"name":"occamsstriders","type":"boots","affix":"carrion","weight":"medium"},{"id":47959,"name":"occamsguise","type":"coat","affix":"carrion","weight":"medium"},{"id":47960,"name":"occamsgrips","type":"gloves","affix":"carrion","weight":"medium"},{"id":47961,"name":"occamsvisage","type":"helm","affix":"carrion","weight":"medium"},{"id":47962,"name":"occamsleggings","type":"leggings","affix":"carrion","weight":"medium"},{"id":47963,"name":"occamsshoulderguard","type":"shoulders","affix":"carrion","weight":"medium"},{"id":47964,"name":"ferratussgreaves","type":"boots","affix":"rabid","weight":"heavy"},{"id":47965,"name":"ferratussbreastplate","type":"coat","affix":"rabid","weight":"heavy"},{"id":47966,"name":"ferratusswarfists","type":"gloves","affix":"rabid","weight":"heavy"},{"id":47967,"name":"ferratussvisor","type":"helm","affix":"rabid","weight":"heavy"},{"id":47968,"name":"ferratusstassets","type":"leggings","affix":"rabid","weight":"heavy"},{"id":47969,"name":"ferratusspauldrons","type":"shoulders","affix":"rabid","weight":"heavy"},{"id":47970,"name":"ferratussfootwear","type":"boots","affix":"rabid","weight":"light"},{"id":47971,"name":"ferratussdoublet","type":"coat","affix":"rabid","weight":"light"},{"id":47972,"name":"ferratusswristguards","type":"gloves","affix":"rabid","weight":"light"},{"id":47973,"name":"ferratussmasque","type":"helm","affix":"rabid","weight":"light"},{"id":47974,"name":"ferratussbreeches","type":"leggings","affix":"rabid","weight":"light"},{"id":47975,"name":"ferratussepaulets","type":"shoulders","affix":"rabid","weight":"light"},{"id":47976,"name":"ferratussstriders","type":"boots","affix":"rabid","weight":"medium"},{"id":47977,"name":"ferratussguise","type":"coat","affix":"rabid","weight":"medium"},{"id":47978,"name":"ferratussgrips","type":"gloves","affix":"rabid","weight":"medium"},{"id":47979,"name":"ferratussvisage","type":"helm","affix":"rabid","weight":"medium"},{"id":47980,"name":"ferratussleggings","type":"leggings","affix":"rabid","weight":"medium"},{"id":47981,"name":"ferratussshoulderguard","type":"shoulders","affix":"rabid","weight":"medium"},{"id":47982,"name":"morbachsgreaves","type":"boots","affix":"dire","weight":"heavy"},{"id":47983,"name":"morbachsbreastplate","type":"coat","affix":"dire","weight":"heavy"},{"id":47984,"name":"morbachswarfists","type":"gloves","affix":"dire","weight":"heavy"},{"id":47985,"name":"morbachsvisor","type":"helm","affix":"dire","weight":"heavy"},{"id":47986,"name":"morbachstassets","type":"leggings","affix":"dire","weight":"heavy"},{"id":47987,"name":"morbachspauldrons","type":"shoulders","affix":"dire","weight":"heavy"},{"id":47988,"name":"morbachsfootwear","type":"boots","affix":"dire","weight":"light"},{"id":47989,"name":"morbachsdoublet","type":"coat","affix":"dire","weight":"light"},{"id":47990,"name":"morbachswristguards","type":"gloves","affix":"dire","weight":"light"},{"id":47991,"name":"morbachsmasque","type":"helm","affix":"dire","weight":"light"},{"id":47992,"name":"morbachsbreeches","type":"leggings","affix":"dire","weight":"light"},{"id":47993,"name":"morbachsepaulets","type":"shoulders","affix":"dire","weight":"light"},{"id":47994,"name":"morbachsstriders","type":"boots","affix":"dire","weight":"medium"},{"id":47995,"name":"morbachsguise","type":"coat","affix":"dire","weight":"medium"},{"id":47996,"name":"morbachsgrips","type":"gloves","affix":"dire","weight":"medium"},{"id":47997,"name":"morbachsvisage","type":"helm","affix":"dire","weight":"medium"},{"id":47998,"name":"morbachsleggings","type":"leggings","affix":"dire","weight":"medium"},{"id":47999,"name":"morbachsshoulderguard","type":"shoulders","affix":"dire","weight":"medium"},{"id":48000,"name":"tateossgreaves","type":"boots","affix":"cleric","weight":"heavy"},{"id":48001,"name":"tateossbreastplate","type":"coat","affix":"cleric","weight":"heavy"},{"id":48002,"name":"tateosswarfists","type":"gloves","affix":"cleric","weight":"heavy"},{"id":48003,"name":"tateossvisor","type":"helm","affix":"cleric","weight":"heavy"},{"id":48004,"name":"tateosstassets","type":"leggings","affix":"cleric","weight":"heavy"},{"id":48005,"name":"tateosspauldrons","type":"shoulders","affix":"cleric","weight":"heavy"},{"id":48006,"name":"tateossfootwear","type":"boots","affix":"cleric","weight":"light"},{"id":48007,"name":"tateossdoublet","type":"coat","affix":"cleric","weight":"light"},{"id":48008,"name":"tateosswristguards","type":"gloves","affix":"cleric","weight":"light"},{"id":48009,"name":"tateossmasque","type":"helm","affix":"cleric","weight":"light"},{"id":48010,"name":"tateossbreeches","type":"leggings","affix":"cleric","weight":"light"},{"id":48011,"name":"tateossepaulets","type":"shoulders","affix":"cleric","weight":"light"},{"id":48012,"name":"tateossstriders","type":"boots","affix":"cleric","weight":"medium"},{"id":48013,"name":"tateossguise","type":"coat","affix":"cleric","weight":"medium"},{"id":48014,"name":"tateossgrips","type":"gloves","affix":"cleric","weight":"medium"},{"id":48015,"name":"tateossvisage","type":"helm","affix":"cleric","weight":"medium"},{"id":48016,"name":"tateossleggings","type":"leggings","affix":"cleric","weight":"medium"},{"id":48017,"name":"tateossshoulderguard","type":"shoulders","affix":"cleric","weight":"medium"},{"id":48018,"name":"hronksgreaves","type":"boots","affix":"magi","weight":"heavy"},{"id":48019,"name":"hronksbreastplate","type":"coat","affix":"magi","weight":"heavy"},{"id":48020,"name":"hronkswarfists","type":"gloves","affix":"magi","weight":"heavy"},{"id":48021,"name":"hronksvisor","type":"helm","affix":"magi","weight":"heavy"},{"id":48022,"name":"hronkstassets","type":"leggings","affix":"magi","weight":"heavy"},{"id":48023,"name":"hronkspauldrons","type":"shoulders","affix":"magi","weight":"heavy"},{"id":48024,"name":"hronksfootwear","type":"boots","affix":"magi","weight":"light"},{"id":48025,"name":"hronksdoublet","type":"coat","affix":"magi","weight":"light"},{"id":48026,"name":"hronkswristguards","type":"gloves","affix":"magi","weight":"light"},{"id":48027,"name":"hronksmasque","type":"helm","affix":"magi","weight":"light"},{"id":48028,"name":"hronksbreeches","type":"leggings","affix":"magi","weight":"light"},{"id":48029,"name":"hronksepaulets","type":"shoulders","affix":"magi","weight":"light"},{"id":48030,"name":"hronksstriders","type":"boots","affix":"magi","weight":"medium"},{"id":48031,"name":"hronksguise","type":"coat","affix":"magi","weight":"medium"},{"id":48032,"name":"hronksgrips","type":"gloves","affix":"magi","weight":"medium"},{"id":48033,"name":"hronksvisage","type":"helm","affix":"magi","weight":"medium"},{"id":48034,"name":"hronksleggings","type":"leggings","affix":"magi","weight":"medium"},{"id":48035,"name":"hronksshoulderguard","type":"shoulders","affix":"magi","weight":"medium"},{"id":48036,"name":"veldrunnergreaves","type":"boots","affix":"apothecary","weight":"heavy"},{"id":48037,"name":"veldrunnerbreastplate","type":"coat","affix":"apothecary","weight":"heavy"},{"id":48038,"name":"veldrunnerwarfists","type":"gloves","affix":"apothecary","weight":"heavy"},{"id":48039,"name":"veldrunnervisor","type":"helm","affix":"apothecary","weight":"heavy"},{"id":48040,"name":"veldrunnertassets","type":"leggings","affix":"apothecary","weight":"heavy"},{"id":48041,"name":"veldrunnerpauldrons","type":"shoulders","affix":"apothecary","weight":"heavy"},{"id":48042,"name":"veldrunnerfootwear","type":"boots","affix":"apothecary","weight":"light"},{"id":48043,"name":"veldrunnerdoublet","type":"coat","affix":"apothecary","weight":"light"},{"id":48044,"name":"veldrunnerwristguards","type":"gloves","affix":"apothecary","weight":"light"},{"id":48045,"name":"veldrunnermasque","type":"helm","affix":"apothecary","weight":"light"},{"id":48046,"name":"veldrunnerbreeches","type":"leggings","affix":"apothecary","weight":"light"},{"id":48047,"name":"veldrunnerepaulets","type":"shoulders","affix":"apothecary","weight":"light"},{"id":48048,"name":"veldrunnerstriders","type":"boots","affix":"apothecary","weight":"medium"},{"id":48049,"name":"veldrunnerguise","type":"coat","affix":"apothecary","weight":"medium"},{"id":48050,"name":"veldrunnergrips","type":"gloves","affix":"apothecary","weight":"medium"},{"id":48051,"name":"veldrunnervisage","type":"helm","affix":"apothecary","weight":"medium"},{"id":48052,"name":"veldrunnerleggings","type":"leggings","affix":"apothecary","weight":"medium"},{"id":48053,"name":"veldrunnershoulderguard","type":"shoulders","affix":"apothecary","weight":"medium"},{"id":48054,"name":"gobrechsgreaves","type":"boots","affix":"valkyrie","weight":"heavy"},{"id":48055,"name":"gobrechsbreastplate","type":"coat","affix":"valkyrie","weight":"heavy"},{"id":48056,"name":"gobrechswarfists","type":"gloves","affix":"valkyrie","weight":"heavy"},{"id":48057,"name":"gobrechsvisor","type":"helm","affix":"valkyrie","weight":"heavy"},{"id":48058,"name":"gobrechstassets","type":"leggings","affix":"valkyrie","weight":"heavy"},{"id":48059,"name":"gobrechspauldrons","type":"shoulders","affix":"valkyrie","weight":"heavy"},{"id":48060,"name":"gobrechsfootwear","type":"boots","affix":"valkyrie","weight":"light"},{"id":48061,"name":"gobrechsdoublet","type":"coat","affix":"valkyrie","weight":"light"},{"id":48062,"name":"gobrechswristguards","type":"gloves","affix":"valkyrie","weight":"light"},{"id":48063,"name":"gobrechsmasque","type":"helm","affix":"valkyrie","weight":"light"},{"id":48064,"name":"gobrechsbreeches","type":"leggings","affix":"valkyrie","weight":"light"},{"id":48065,"name":"gobrechsepaulets","type":"shoulders","affix":"valkyrie","weight":"light"},{"id":48066,"name":"gobrechsstriders","type":"boots","affix":"valkyrie","weight":"medium"},{"id":48067,"name":"gobrechsguise","type":"coat","affix":"valkyrie","weight":"medium"},{"id":48068,"name":"gobrechsgrips","type":"gloves","affix":"valkyrie","weight":"medium"},{"id":48069,"name":"gobrechsvisage","type":"helm","affix":"valkyrie","weight":"medium"},{"id":48070,"name":"gobrechsleggings","type":"leggings","affix":"valkyrie","weight":"medium"},{"id":48071,"name":"gobrechsshoulderguard","type":"shoulders","affix":"valkyrie","weight":"medium"},{"id":48072,"name":"zojjasgreaves","type":"boots","affix":"berserker","weight":"heavy"},{"id":48073,"name":"zojjasbreastplate","type":"coat","affix":"berserker","weight":"heavy"},{"id":48074,"name":"zojjaswarfists","type":"gloves","affix":"berserker","weight":"heavy"},{"id":48075,"name":"zojjasvisor","type":"helm","affix":"berserker","weight":"heavy"},{"id":48076,"name":"zojjastassets","type":"leggings","affix":"berserker","weight":"heavy"},{"id":48077,"name":"zojjaspauldrons","type":"shoulders","affix":"berserker","weight":"heavy"},{"id":48078,"name":"zojjasfootwear","type":"boots","affix":"berserker","weight":"light"},{"id":48079,"name":"zojjasdoublet","type":"coat","affix":"berserker","weight":"light"},{"id":48080,"name":"zojjaswristguards","type":"gloves","affix":"berserker","weight":"light"},{"id":48081,"name":"zojjasmasque","type":"helm","affix":"berserker","weight":"light"},{"id":48082,"name":"zojjasbreeches","type":"leggings","affix":"berserker","weight":"light"},{"id":48083,"name":"zojjasepaulets","type":"shoulders","affix":"berserker","weight":"light"},{"id":48084,"name":"zojjasstriders","type":"boots","affix":"berserker","weight":"medium"},{"id":48085,"name":"zojjasguise","type":"coat","affix":"berserker","weight":"medium"},{"id":48086,"name":"zojjasgrips","type":"gloves","affix":"berserker","weight":"medium"},{"id":48087,"name":"zojjasvisage","type":"helm","affix":"berserker","weight":"medium"},{"id":48088,"name":"zojjasleggings","type":"leggings","affix":"berserker","weight":"medium"},{"id":48089,"name":"zojjasshoulderguard","type":"shoulders","affix":"berserker","weight":"medium"},{"id":48090,"name":"ahamidsgreaves","type":"boots","affix":"soldier","weight":"heavy"},{"id":48091,"name":"ahamidsbreastplate","type":"coat","affix":"soldier","weight":"heavy"},{"id":48092,"name":"ahamidswarfists","type":"gloves","affix":"soldier","weight":"heavy"},{"id":48093,"name":"ahamidsvisor","type":"helm","affix":"soldier","weight":"heavy"},{"id":48094,"name":"ahamidstassets","type":"leggings","affix":"soldier","weight":"heavy"},{"id":48095,"name":"ahamidspauldrons","type":"shoulders","affix":"soldier","weight":"heavy"},{"id":48096,"name":"ahamidsfootwear","type":"boots","affix":"soldier","weight":"light"},{"id":48097,"name":"ahamidsdoublet","type":"coat","affix":"soldier","weight":"light"},{"id":48098,"name":"ahamidswristguards","type":"gloves","affix":"soldier","weight":"light"},{"id":48099,"name":"ahamidsmasque","type":"helm","affix":"soldier","weight":"light"},{"id":48100,"name":"ahamidsbreeches","type":"leggings","affix":"soldier","weight":"light"},{"id":48101,"name":"ahamidsepaulets","type":"shoulders","affix":"soldier","weight":"light"},{"id":48102,"name":"ahamidsstriders","type":"boots","affix":"soldier","weight":"medium"},{"id":48103,"name":"ahamidsguise","type":"coat","affix":"soldier","weight":"medium"},{"id":48104,"name":"ahamidsgrips","type":"gloves","affix":"soldier","weight":"medium"},{"id":48105,"name":"ahamidsvisage","type":"helm","affix":"soldier","weight":"medium"},{"id":48106,"name":"ahamidsleggings","type":"leggings","affix":"soldier","weight":"medium"},{"id":48107,"name":"ahamidsshoulderguard","type":"shoulders","affix":"soldier","weight":"medium"},{"id":48108,"name":"forgemastersgreaves","type":"boots","affix":"rampager","weight":"heavy"},{"id":48109,"name":"forgemastersbreastplate","type":"coat","affix":"rampager","weight":"heavy"},{"id":48110,"name":"forgemasterswarfists","type":"gloves","affix":"rampager","weight":"heavy"},{"id":48111,"name":"forgemastersvisor","type":"helm","affix":"rampager","weight":"heavy"},{"id":48112,"name":"forgemasterstassets","type":"leggings","affix":"rampager","weight":"heavy"},{"id":48113,"name":"forgemasterspauldrons","type":"shoulders","affix":"rampager","weight":"heavy"},{"id":48114,"name":"forgemastersfootwear","type":"boots","affix":"rampager","weight":"light"},{"id":48115,"name":"forgemastersdoublet","type":"coat","affix":"rampager","weight":"light"},{"id":48116,"name":"forgemasterswristguards","type":"gloves","affix":"rampager","weight":"light"},{"id":48117,"name":"forgemastersmasque","type":"helm","affix":"rampager","weight":"light"},{"id":48118,"name":"forgemastersbreeches","type":"leggings","affix":"rampager","weight":"light"},{"id":48119,"name":"forgemastersepaulets","type":"shoulders","affix":"rampager","weight":"light"},{"id":48120,"name":"forgemastersstriders","type":"boots","affix":"rampager","weight":"medium"},{"id":48121,"name":"forgemastersguise","type":"coat","affix":"rampager","weight":"medium"},{"id":48122,"name":"forgemastersgrips","type":"gloves","affix":"rampager","weight":"medium"},{"id":48123,"name":"forgemastersvisage","type":"helm","affix":"rampager","weight":"medium"},{"id":48124,"name":"forgemastersleggings","type":"leggings","affix":"rampager","weight":"medium"},{"id":48125,"name":"forgemastersshoulderguard","type":"shoulders","affix":"rampager","weight":"medium"},{"id":48126,"name":"saphirsgreaves","type":"boots","affix":"assassin","weight":"heavy"},{"id":48127,"name":"saphirsbreastplate","type":"coat","affix":"assassin","weight":"heavy"},{"id":48128,"name":"saphirswarfists","type":"gloves","affix":"assassin","weight":"heavy"},{"id":48129,"name":"saphirsvisor","type":"helm","affix":"assassin","weight":"heavy"},{"id":48130,"name":"saphirstassets","type":"leggings","affix":"assassin","weight":"heavy"},{"id":48131,"name":"saphirspauldrons","type":"shoulders","affix":"assassin","weight":"heavy"},{"id":48132,"name":"saphirsfootwear","type":"boots","affix":"assassin","weight":"light"},{"id":48133,"name":"saphirsdoublet","type":"coat","affix":"assassin","weight":"light"},{"id":48134,"name":"saphirswristguards","type":"gloves","affix":"assassin","weight":"light"},{"id":48135,"name":"saphirsmasque","type":"helm","affix":"assassin","weight":"light"},{"id":48136,"name":"saphirsbreeches","type":"leggings","affix":"assassin","weight":"light"},{"id":48137,"name":"saphirsepaulets","type":"shoulders","affix":"assassin","weight":"light"},{"id":48138,"name":"saphirsstriders","type":"boots","affix":"assassin","weight":"medium"},{"id":48139,"name":"saphirsguise","type":"coat","affix":"assassin","weight":"medium"},{"id":48140,"name":"saphirsgrips","type":"gloves","affix":"assassin","weight":"medium"},{"id":48141,"name":"saphirsvisage","type":"helm","affix":"assassin","weight":"medium"},{"id":48142,"name":"saphirsleggings","type":"leggings","affix":"assassin","weight":"medium"},{"id":48143,"name":"saphirsshoulderguard","type":"shoulders","affix":"assassin","weight":"medium"},{"id":48144,"name":"leftpawsgreaves","type":"boots","affix":"settler","weight":"heavy"},{"id":48145,"name":"leftpawsbreastplate","type":"coat","affix":"settler","weight":"heavy"},{"id":48146,"name":"leftpawswarfists","type":"gloves","affix":"settler","weight":"heavy"},{"id":48147,"name":"leftpawsvisor","type":"helm","affix":"settler","weight":"heavy"},{"id":48148,"name":"leftpawstassets","type":"leggings","affix":"settler","weight":"heavy"},{"id":48149,"name":"leftpawspauldrons","type":"shoulders","affix":"settler","weight":"heavy"},{"id":48150,"name":"leftpawsfootwear","type":"boots","affix":"settler","weight":"light"},{"id":48151,"name":"leftpawsdoublet","type":"coat","affix":"settler","weight":"light"},{"id":48152,"name":"leftpawswristguards","type":"gloves","affix":"settler","weight":"light"},{"id":48153,"name":"leftpawsmasque","type":"helm","affix":"settler","weight":"light"},{"id":48154,"name":"leftpawsbreeches","type":"leggings","affix":"settler","weight":"light"},{"id":48155,"name":"leftpawsepaulets","type":"shoulders","affix":"settler","weight":"light"},{"id":48156,"name":"leftpawsstriders","type":"boots","affix":"settler","weight":"medium"},{"id":48157,"name":"leftpawsguise","type":"coat","affix":"settler","weight":"medium"},{"id":48158,"name":"leftpawsgrips","type":"gloves","affix":"settler","weight":"medium"},{"id":48159,"name":"leftpawsvisage","type":"helm","affix":"settler","weight":"medium"},{"id":48160,"name":"leftpawsleggings","type":"leggings","affix":"settler","weight":"medium"},{"id":48161,"name":"leftpawsshoulderguard","type":"shoulders","affix":"settler","weight":"medium"},{"id":48162,"name":"angchugreaves","type":"boots","affix":"cavalier","weight":"heavy"},{"id":48163,"name":"angchubreastplate","type":"coat","affix":"cavalier","weight":"heavy"},{"id":48164,"name":"angchuwarfists","type":"gloves","affix":"cavalier","weight":"heavy"},{"id":48165,"name":"angchuvisor","type":"helm","affix":"cavalier","weight":"heavy"},{"id":48166,"name":"angchutassets","type":"leggings","affix":"cavalier","weight":"heavy"},{"id":48167,"name":"angchupauldrons","type":"shoulders","affix":"cavalier","weight":"heavy"},{"id":48168,"name":"angchufootwear","type":"boots","affix":"cavalier","weight":"light"},{"id":48169,"name":"angchudoublet","type":"coat","affix":"cavalier","weight":"light"},{"id":48170,"name":"angchuwristguards","type":"gloves","affix":"cavalier","weight":"light"},{"id":48171,"name":"angchumasque","type":"helm","affix":"cavalier","weight":"light"},{"id":48172,"name":"angchubreeches","type":"leggings","affix":"cavalier","weight":"light"},{"id":48173,"name":"angchuepaulets","type":"shoulders","affix":"cavalier","weight":"light"},{"id":48174,"name":"angchustriders","type":"boots","affix":"cavalier","weight":"medium"},{"id":48175,"name":"angchuguise","type":"coat","affix":"cavalier","weight":"medium"},{"id":48176,"name":"angchugrips","type":"gloves","affix":"cavalier","weight":"medium"},{"id":48177,"name":"angchuvisage","type":"helm","affix":"cavalier","weight":"medium"},{"id":48178,"name":"angchuleggings","type":"leggings","affix":"cavalier","weight":"medium"},{"id":48179,"name":"angchushoulderguard","type":"shoulders","affix":"cavalier","weight":"medium"},{"id":48180,"name":"zintlgreaves","type":"boots","affix":"shaman","weight":"heavy"},{"id":48181,"name":"zintlbreastplate","type":"coat","affix":"shaman","weight":"heavy"},{"id":48182,"name":"zintlwarfists","type":"gloves","affix":"shaman","weight":"heavy"},{"id":48183,"name":"zintlvisor","type":"helm","affix":"shaman","weight":"heavy"},{"id":48184,"name":"zintltassets","type":"leggings","affix":"shaman","weight":"heavy"},{"id":48185,"name":"zintlpauldrons","type":"shoulders","affix":"shaman","weight":"heavy"},{"id":48186,"name":"zintlfootwear","type":"boots","affix":"shaman","weight":"light"},{"id":48187,"name":"zintldoublet","type":"coat","affix":"shaman","weight":"light"},{"id":48188,"name":"zintlwristguards","type":"gloves","affix":"shaman","weight":"light"},{"id":48189,"name":"zintlmasque","type":"helm","affix":"shaman","weight":"light"},{"id":48190,"name":"zintlbreeches","type":"leggings","affix":"shaman","weight":"light"},{"id":48191,"name":"zintlepaulets","type":"shoulders","affix":"shaman","weight":"light"},{"id":48192,"name":"zintlstriders","type":"boots","affix":"shaman","weight":"medium"},{"id":48193,"name":"zintlguise","type":"coat","affix":"shaman","weight":"medium"},{"id":48194,"name":"zintlgrips","type":"gloves","affix":"shaman","weight":"medium"},{"id":48195,"name":"zintlvisage","type":"helm","affix":"shaman","weight":"medium"},{"id":48196,"name":"zintlleggings","type":"leggings","affix":"shaman","weight":"medium"},{"id":48197,"name":"zintlshoulderguard","type":"shoulders","affix":"shaman","weight":"medium"},{"id":48198,"name":"weiqisgreaves","type":"boots","affix":"sentinel","weight":"heavy"},{"id":48199,"name":"weiqisbreastplate","type":"coat","affix":"sentinel","weight":"heavy"},{"id":48200,"name":"weiqiswarfists","type":"gloves","affix":"sentinel","weight":"heavy"},{"id":48201,"name":"weiqisvisor","type":"helm","affix":"sentinel","weight":"heavy"},{"id":48202,"name":"weiqistassets","type":"leggings","affix":"sentinel","weight":"heavy"},{"id":48203,"name":"weiqispauldrons","type":"shoulders","affix":"sentinel","weight":"heavy"},{"id":48204,"name":"weiqisfootwear","type":"boots","affix":"sentinel","weight":"light"},{"id":48205,"name":"weiqisdoublet","type":"coat","affix":"sentinel","weight":"light"},{"id":48206,"name":"weiqiswristguards","type":"gloves","affix":"sentinel","weight":"light"},{"id":48207,"name":"weiqismasque","type":"helm","affix":"sentinel","weight":"light"},{"id":48208,"name":"weiqisbreeches","type":"leggings","affix":"sentinel","weight":"light"},{"id":48209,"name":"weiqisepaulets","type":"shoulders","affix":"sentinel","weight":"light"},{"id":48210,"name":"weiqisstriders","type":"boots","affix":"sentinel","weight":"medium"},{"id":48211,"name":"weiqisguise","type":"coat","affix":"sentinel","weight":"medium"},{"id":48212,"name":"weiqisgrips","type":"gloves","affix":"sentinel","weight":"medium"},{"id":48213,"name":"weiqisvisage","type":"helm","affix":"sentinel","weight":"medium"},{"id":48214,"name":"weiqisleggings","type":"leggings","affix":"sentinel","weight":"medium"},{"id":48215,"name":"weiqisshoulderguard","type":"shoulders","affix":"sentinel","weight":"medium"},{"id":48907,"name":"antitoxin","type":"rune"},{"id":48911,"name":"torment","type":"sigil"},{"id":48915,"name":"toxicsharpeningstone","type":"utility"},{"id":48916,"name":"toxicmaintenanceoil","type":"utility"},{"id":48917,"name":"toxicfocusingcrystal","type":"utility"},{"id":48921,"name":"bowlofmarjorysexperimentalchili","type":"food"},{"id":49372,"name":"betafractalcapacitorinfused","type":"backitem","affix":"soldier"},{"id":49373,"name":"betafractalcapacitorinfused","type":"backitem","affix":"soldier"},{"id":49376,"name":"betafractalcapacitorinfused","type":"backitem","affix":"cavalier"},{"id":49377,"name":"betafractalcapacitorinfused","type":"backitem","affix":"cavalier"},{"id":49378,"name":"betafractalcapacitorinfused","type":"backitem","affix":"rabid"},{"id":49379,"name":"betafractalcapacitorinfused","type":"backitem","affix":"rabid"},{"id":49380,"name":"betafractalcapacitorinfused","type":"backitem","affix":"berserker"},{"id":49381,"name":"betafractalcapacitorinfused","type":"backitem","affix":"berserker"},{"id":49457,"name":"momentum","type":"sigil"},{"id":49460,"name":"resistance","type":"rune"},{"id":49611,"name":"keeperswarfists","type":"gloves","affix":"zealot","weight":"heavy"},{"id":49612,"name":"keepersshoulderguard","type":"shoulders","affix":"zealot","weight":"medium"},{"id":49613,"name":"keepersleggings","type":"leggings","affix":"zealot","weight":"medium"},{"id":49614,"name":"keepersvisage","type":"helm","affix":"zealot","weight":"medium"},{"id":49615,"name":"keepersgrips","type":"gloves","affix":"zealot","weight":"medium"},{"id":49616,"name":"keepersguise","type":"coat","affix":"zealot","weight":"medium"},{"id":49617,"name":"keepersstriders","type":"boots","affix":"zealot","weight":"medium"},{"id":49618,"name":"keepersepaulets","type":"shoulders","affix":"zealot","weight":"light"},{"id":49619,"name":"keepersbreeches","type":"leggings","affix":"zealot","weight":"light"},{"id":49620,"name":"keepersmasque","type":"helm","affix":"zealot","weight":"light"},{"id":49621,"name":"keeperswristguards","type":"gloves","affix":"zealot","weight":"light"},{"id":49622,"name":"keepersdoublet","type":"coat","affix":"zealot","weight":"light"},{"id":49623,"name":"keepersfootwear","type":"boots","affix":"zealot","weight":"light"},{"id":49624,"name":"keeperspauldrons","type":"shoulders","affix":"zealot","weight":"heavy"},{"id":49625,"name":"keeperstassets","type":"leggings","affix":"zealot","weight":"heavy"},{"id":49626,"name":"keepersvisor","type":"helm","affix":"zealot","weight":"heavy"},{"id":49627,"name":"keepersbreastplate","type":"coat","affix":"zealot","weight":"heavy"},{"id":49628,"name":"keepersgreaves","type":"boots","affix":"zealot","weight":"heavy"},{"id":49874,"name":"keepersartifact","type":"focus","affix":"zealot"},{"id":49875,"name":"keepersbastion","type":"shield","affix":"zealot"},{"id":49876,"name":"keepersshortbow","type":"shortbow","affix":"zealot"},{"id":49877,"name":"keepersharpoongun","type":"speargun","affix":"zealot"},{"id":49878,"name":"keepersspire","type":"staff","affix":"zealot"},{"id":49879,"name":"keepersblade","type":"sword","affix":"zealot"},{"id":49880,"name":"keepersreaver","type":"axe","affix":"zealot"},{"id":49881,"name":"keepersbrazier","type":"torch","affix":"zealot"},{"id":49882,"name":"keepersrazor","type":"dagger","affix":"zealot"},{"id":49883,"name":"keepersherald","type":"warhorn","affix":"zealot"},{"id":49884,"name":"keepersclaymore","type":"greatsword","affix":"zealot"},{"id":49885,"name":"keeperswarhammer","type":"hammer","affix":"zealot"},{"id":49886,"name":"keepersimpaler","type":"harpoon","affix":"zealot"},{"id":49887,"name":"keepersgreatbow","type":"longbow","affix":"zealot"},{"id":49888,"name":"keepersflangedmace","type":"mace","affix":"zealot"},{"id":49889,"name":"keepersrevolver","type":"pistol","affix":"zealot"},{"id":49890,"name":"keepersmusket","type":"rifle","affix":"zealot"},{"id":49891,"name":"keeperswand","type":"scepter","affix":"zealot"},{"id":49892,"name":"keeperstrident","type":"trident","affix":"zealot"},{"id":49940,"name":"executioneraxetoy","type":"gizmo"},{"id":50082,"name":"powerfulpotionofslayingscarletsarmies","type":"utility"},{"id":63366,"type":"rune"},{"id":66359,"name":"ventariswristguards","type":"gloves","affix":"nomad","weight":"light"},{"id":66360,"name":"ventarisshoulderguard","type":"shoulders","affix":"nomad","weight":"medium"},{"id":66361,"name":"ventarisleggings","type":"leggings","affix":"nomad","weight":"medium"},{"id":66362,"name":"ventarisvisage","type":"helm","affix":"nomad","weight":"medium"},{"id":66363,"name":"ventarisgrips","type":"gloves","affix":"nomad","weight":"medium"},{"id":66364,"name":"ventarisguise","type":"coat","affix":"nomad","weight":"medium"},{"id":66365,"name":"ventarisstriders","type":"boots","affix":"nomad","weight":"medium"},{"id":66366,"name":"ventarisepaulets","type":"shoulders","affix":"nomad","weight":"light"},{"id":66367,"name":"ventarisbreeches","type":"leggings","affix":"nomad","weight":"light"},{"id":66368,"name":"ventarisgreaves","type":"boots","affix":"nomad","weight":"heavy"},{"id":66369,"name":"ventarisvisor","type":"helm","affix":"nomad","weight":"heavy"},{"id":66370,"name":"ventarisdoublet","type":"coat","affix":"nomad","weight":"light"},{"id":66371,"name":"ventarisfootwear","type":"boots","affix":"nomad","weight":"light"},{"id":66372,"name":"ventarispauldrons","type":"shoulders","affix":"nomad","weight":"heavy"},{"id":66373,"name":"ventaristassets","type":"leggings","affix":"nomad","weight":"heavy"},{"id":66374,"name":"ventariswarfists","type":"gloves","affix":"nomad","weight":"heavy"},{"id":66375,"name":"ventarisbreastplate","type":"coat","affix":"nomad","weight":"heavy"},{"id":66376,"name":"ventarismasque","type":"helm","affix":"nomad","weight":"light"},{"id":66523,"name":"bowlofcactusfruitsalad","type":"food"},{"id":66526,"name":"pricklypearstuffednopal","type":"food"},{"id":66527,"name":"loafofcandycactuscornbread","type":"food"},{"id":66528,"name":"bowlofsweetandspicybeans","type":"food"},{"id":66529,"name":"bowlofblackpeppercactussalad","type":"food"},{"id":66530,"name":"bowlofnopalitossaut","type":"food"},{"id":66531,"name":"bowlofcactussoup","type":"food"},{"id":66536,"name":"plateofroastedcactus","type":"food"},{"id":66538,"name":"pricklypearpie","type":"food"},{"id":66539,"name":"bowlofpricklypearsorbet","type":"food"},{"id":66672,"name":"ventarisblade","type":"sword","affix":"nomad"},{"id":66673,"name":"ventarisreaver","type":"axe","affix":"nomad"},{"id":66674,"name":"ventariswand","type":"scepter","affix":"nomad"},{"id":66675,"name":"ventarisbastion","type":"shield","affix":"nomad"},{"id":66676,"name":"ventarisshortbow","type":"shortbow","affix":"nomad"},{"id":66677,"name":"ventarisharpoongun","type":"speargun","affix":"nomad"},{"id":66678,"name":"ventarisherald","type":"warhorn","affix":"nomad"},{"id":66679,"name":"ventarismusket","type":"rifle","affix":"nomad"},{"id":66680,"name":"ventarisspire","type":"staff","affix":"nomad"},{"id":66681,"name":"ventarisflangedmace","type":"mace","affix":"nomad"},{"id":66682,"name":"ventarisgreatbow","type":"longbow","affix":"nomad"},{"id":66683,"name":"ventarisimpaler","type":"harpoon","affix":"nomad"},{"id":66684,"name":"ventariswarhammer","type":"hammer","affix":"nomad"},{"id":66685,"name":"ventarisclaymore","type":"greatsword","affix":"nomad"},{"id":66686,"name":"ventarisartifact","type":"focus","affix":"nomad"},{"id":66687,"name":"ventarisrazor","type":"dagger","affix":"nomad"},{"id":66688,"name":"ventarisbrazier","type":"torch","affix":"nomad"},{"id":66689,"name":"ventarisrevolver","type":"pistol","affix":"nomad"},{"id":66690,"name":"ventaristrident","type":"trident","affix":"nomad"},{"id":67294,"name":"adelbernsburden","type":"accessory","affix":"sentinel"},{"id":67295,"name":"kudusphasingmatrix","type":"accessory","affix":"sentinel"},{"id":67298,"name":"delanascoinpurse","type":"accessory","affix":"assassin"},{"id":67299,"name":"baelfiresember","type":"accessory","affix":"carrion"},{"id":67301,"name":"forgemansgear","type":"accessory","affix":"carrion"},{"id":67302,"name":"zhaitansclaw","type":"accessory","affix":"assassin"},{"id":67306,"name":"banestooth","type":"accessory","affix":"magi"},{"id":67307,"name":"faolainsblossom","type":"accessory","affix":"magi"},{"id":67339,"name":"trapper","type":"rune"},{"id":67340,"name":"cleansing","type":"sigil"},{"id":67341,"name":"cruelty","type":"sigil"},{"id":67342,"name":"radiance","type":"rune"},{"id":67343,"name":"incapacitation","type":"sigil"},{"id":67344,"name":"evasion","type":"rune"},{"id":67442,"name":"veratasmasque","type":"helm","affix":"sinister","weight":"light"},{"id":67443,"name":"veratasshoulderguard","type":"shoulders","affix":"sinister","weight":"medium"},{"id":67444,"name":"veratasleggings","type":"leggings","affix":"sinister","weight":"medium"},{"id":67445,"name":"veratasvisage","type":"helm","affix":"sinister","weight":"medium"},{"id":67446,"name":"veratasgrips","type":"gloves","affix":"sinister","weight":"medium"},{"id":67447,"name":"veratasguise","type":"coat","affix":"sinister","weight":"medium"},{"id":67448,"name":"veratasstriders","type":"boots","affix":"sinister","weight":"medium"},{"id":67449,"name":"veratasepaulets","type":"shoulders","affix":"sinister","weight":"light"},{"id":67450,"name":"veratasbreeches","type":"leggings","affix":"sinister","weight":"light"},{"id":67451,"name":"veratasgreaves","type":"boots","affix":"sinister","weight":"heavy"},{"id":67452,"name":"verataswristguards","type":"gloves","affix":"sinister","weight":"light"},{"id":67453,"name":"veratasdoublet","type":"coat","affix":"sinister","weight":"light"},{"id":67454,"name":"veratasfootwear","type":"boots","affix":"sinister","weight":"light"},{"id":67455,"name":"verataspauldrons","type":"shoulders","affix":"sinister","weight":"heavy"},{"id":67456,"name":"veratastassets","type":"leggings","affix":"sinister","weight":"heavy"},{"id":67457,"name":"veratasvisor","type":"helm","affix":"sinister","weight":"heavy"},{"id":67458,"name":"verataswarfists","type":"gloves","affix":"sinister","weight":"heavy"},{"id":67459,"name":"veratasbreastplate","type":"coat","affix":"sinister","weight":"heavy"},{"id":67894,"name":"caithesremorse","type":"accessory","affix":"sinister"},{"id":67895,"name":"quetzalcrest","type":"accessory","affix":"nomad"},{"id":67896,"name":"caithesblossom","type":"accessory","affix":"sinister"},{"id":67897,"name":"ventarischisel","type":"accessory","affix":"nomad"},{"id":67898,"name":"wynneslocket","type":"amulet","affix":"sinister"},{"id":67899,"name":"ogdensankh","type":"amulet","affix":"nomad"},{"id":67900,"name":"jurahsjewel","type":"amulet","affix":"sinister"},{"id":67901,"name":"aspectamulet","type":"amulet","affix":"nomad"},{"id":67912,"name":"defender","type":"rune"},{"id":67913,"name":"blight","type":"sigil"},{"id":67934,"name":"veratasimpaler","type":"harpoon","affix":"sinister"},{"id":67935,"name":"veratastrident","type":"trident","affix":"sinister"},{"id":67936,"name":"veratasherald","type":"warhorn","affix":"sinister"},{"id":67937,"name":"veratasbrazier","type":"torch","affix":"sinister"},{"id":67938,"name":"veratasblade","type":"sword","affix":"sinister"},{"id":67939,"name":"veratasspire","type":"staff","affix":"sinister"},{"id":67940,"name":"veratasharpoongun","type":"speargun","affix":"sinister"},{"id":67941,"name":"veratasshortbow","type":"shortbow","affix":"sinister"},{"id":67942,"name":"veratasbastion","type":"shield","affix":"sinister"},{"id":67943,"name":"verataswand","type":"scepter","affix":"sinister"},{"id":67944,"name":"veratasreaver","type":"axe","affix":"sinister"},{"id":67945,"name":"veratasrevolver","type":"pistol","affix":"sinister"},{"id":67946,"name":"veratasflangedmace","type":"mace","affix":"sinister"},{"id":67947,"name":"veratasgreatbow","type":"longbow","affix":"sinister"},{"id":67948,"name":"veratasrazor","type":"dagger","affix":"sinister"},{"id":67949,"name":"verataswarhammer","type":"hammer","affix":"sinister"},{"id":67950,"name":"veratasclaymore","type":"greatsword","affix":"sinister"},{"id":67951,"name":"veratasartifact","type":"focus","affix":"sinister"},{"id":67952,"name":"veratasmusket","type":"rifle","affix":"sinister"},{"id":68436,"name":"mischief","type":"sigil"},{"id":68437,"name":"snowfall","type":"rune"},{"id":68633,"name":"friedgoldendumpling","type":"food"},{"id":68634,"name":"deliciousriceball","type":"food"},{"id":69370,"name":"revenant","type":"rune"},{"id":70165,"name":"weiqisguise","type":"coat","affix":"sentinel","weight":"medium"},{"id":70414,"name":"maklainsbreeches","type":"leggings","affix":"minstrel","weight":"light"},{"id":70416,"name":"ossasspire","type":"staff","affix":"crusader"},{"id":70442,"name":"svaardsharpoongun","type":"speargun","affix":"marauder"},{"id":70450,"name":"druid","type":"rune"},{"id":70456,"name":"leftpawsleatherbreather","type":"helmaquatic","affix":"settler","weight":"medium"},{"id":70470,"name":"rukasstriders","type":"boots","affix":"wanderer","weight":"medium"},{"id":70471,"name":"tizlaksvisage","type":"helm","affix":"commander","weight":"medium"},{"id":70482,"name":"svaardsrevolver","type":"pistol","affix":"marauder"},{"id":70504,"name":"yassithsgreatbow","type":"longbow","affix":"viper"},{"id":70508,"name":"rukasvisor","type":"helm","affix":"wanderer","weight":"heavy"},{"id":70538,"name":"saphirsmetalbreather","type":"helmaquatic","affix":"assassin","weight":"heavy"},{"id":70554,"name":"attunedkhilbronsphylacteryinfused","type":"ring","affix":"rabid"},{"id":70555,"name":"tizlaksepaulets","type":"shoulders","affix":"commander","weight":"light"},{"id":70574,"name":"keepersmetalbreather","type":"helmaquatic","affix":"zealot","weight":"heavy"},{"id":70593,"name":"svaardsgreaves","type":"boots","affix":"marauder","weight":"heavy"},{"id":70600,"name":"leadership","type":"rune"},{"id":70630,"name":"pahuaspauldrons","type":"shoulders","affix":"trailblazer","weight":"heavy"},{"id":70641,"name":"yassithsleggings","type":"leggings","affix":"viper","weight":"medium"},{"id":70671,"name":"sunmoonandstars","type":"amulet","affix":"marauder"},{"id":70685,"name":"laranthirstrident","type":"trident","affix":"vigilant"},{"id":70687,"name":"yassithstrident","type":"trident","affix":"viper"},{"id":70695,"name":"attunedplaguesignetinfused","type":"ring","affix":"sinister"},{"id":70699,"name":"rukaswristguards","type":"gloves","affix":"wanderer","weight":"light"},{"id":70712,"name":"wupwupleatherbreather","type":"helmaquatic","affix":"celestial","weight":"medium"},{"id":70720,"name":"rukasgrips","type":"gloves","affix":"wanderer","weight":"medium"},{"id":70729,"name":"ossasmusket","type":"rifle","affix":"crusader"},{"id":70794,"name":"maklainsbreastplate","type":"coat","affix":"minstrel","weight":"heavy"},{"id":70825,"name":"draining","type":"sigil"},{"id":70829,"name":"reaper","type":"rune"},{"id":70834,"name":"maklainsguise","type":"coat","affix":"minstrel","weight":"medium"},{"id":70838,"name":"yassithsblade","type":"sword","affix":"viper"},{"id":70839,"name":"beigarthsleatherbreather","type":"helmaquatic","affix":"knight","weight":"medium"},{"id":70848,"name":"svaardsleggings","type":"leggings","affix":"marauder","weight":"medium"},{"id":70889,"name":"abaddonscowl","type":"amulet","affix":"marauder"},{"id":70924,"name":"pahuasvisor","type":"helm","affix":"trailblazer","weight":"heavy"},{"id":70966,"name":"occamsleatherbreather","type":"helmaquatic","affix":"carrion","weight":"medium"},{"id":70993,"name":"pahuaswristguards","type":"gloves","affix":"trailblazer","weight":"light"},{"id":71005,"name":"ossasherald","type":"warhorn","affix":"crusader"},{"id":71007,"name":"yassithsclaymore","type":"greatsword","affix":"viper"},{"id":71014,"name":"tizlaksimpaler","type":"harpoon","affix":"commander"},{"id":71065,"name":"attunedmellagganswhorlinfused","type":"ring","affix":"rabidandapothecary"},{"id":71094,"name":"rukasguise","type":"coat","affix":"wanderer","weight":"medium"},{"id":71114,"name":"rukasgreatbow","type":"longbow","affix":"wanderer"},{"id":71116,"name":"maklainsherald","type":"warhorn","affix":"minstrel"},{"id":71117,"name":"tizlaksherald","type":"warhorn","affix":"commander"},{"id":71130,"name":"ruthlessness","type":"sigil"},{"id":71161,"name":"laranthirsbrazier","type":"torch","affix":"vigilant"},{"id":71205,"name":"saphirsclothbreather","type":"helmaquatic","affix":"assassin","weight":"light"},{"id":71219,"name":"tizlaksmusket","type":"rifle","affix":"commander"},{"id":71242,"name":"rukasfootwear","type":"boots","affix":"wanderer","weight":"light"},{"id":71249,"name":"tizlakstassets","type":"leggings","affix":"commander","weight":"heavy"},{"id":71256,"name":"morbachsleatherbreather","type":"helmaquatic","affix":"dire","weight":"medium"},{"id":71276,"name":"scrapper","type":"rune"},{"id":71308,"name":"rukasepaulets","type":"shoulders","affix":"wanderer","weight":"light"},{"id":71346,"name":"attunedroyalsignetofdoricinfused","type":"ring","affix":"soldier"},{"id":71361,"name":"pahuasreaver","type":"axe","affix":"trailblazer"},{"id":71381,"name":"zintlleatherbreather","type":"helmaquatic","affix":"shaman","weight":"medium"},{"id":71387,"name":"yassithsspire","type":"staff","affix":"viper"},{"id":71406,"name":"tateossmetalbreather","type":"helmaquatic","affix":"cleric","weight":"heavy"},{"id":71423,"name":"ahamidsleatherbreather","type":"helmaquatic","affix":"soldier","weight":"medium"},{"id":71424,"name":"laranthirsvisor","type":"helm","affix":"vigilant","weight":"heavy"},{"id":71425,"name":"berserker","type":"rune"},{"id":71436,"name":"yassithsdoublet","type":"coat","affix":"viper","weight":"light"},{"id":71450,"name":"zintlmetalbreather","type":"helmaquatic","affix":"shaman","weight":"heavy"},{"id":71456,"name":"maklainsgreaves","type":"boots","affix":"minstrel","weight":"heavy"},{"id":71457,"name":"maklainsflangedmace","type":"mace","affix":"minstrel"},{"id":71472,"name":"pahuasflangedmace","type":"mace","affix":"trailblazer"},{"id":71478,"name":"svaardsmusket","type":"rifle","affix":"marauder"},{"id":71570,"name":"laranthirsbreeches","type":"leggings","affix":"vigilant","weight":"light"},{"id":71576,"name":"leftpawsclothbreather","type":"helmaquatic","affix":"settler","weight":"light"},{"id":71584,"name":"yassithsartifact","type":"focus","affix":"viper"},{"id":71606,"name":"rukastrident","type":"trident","affix":"wanderer"},{"id":71607,"name":"pahuasimpaler","type":"harpoon","affix":"trailblazer"},{"id":71645,"name":"ossasshortbow","type":"shortbow","affix":"crusader"},{"id":71691,"name":"writofmasterfulspeed","type":"utility"},{"id":71698,"name":"svaardsimpaler","type":"harpoon","affix":"marauder"},{"id":71726,"name":"attunedveratassearedringinfused","type":"ring","affix":"sinister"},{"id":71735,"name":"pahuastassets","type":"leggings","affix":"trailblazer","weight":"heavy"},{"id":71740,"name":"ossasvisor","type":"helm","affix":"crusader","weight":"heavy"},{"id":71817,"name":"ossasgrips","type":"gloves","affix":"crusader","weight":"medium"},{"id":71870,"name":"angchumetalbreather","type":"helmaquatic","affix":"cavalier","weight":"heavy"},{"id":71917,"name":"ossasrazor","type":"dagger","affix":"crusader"},{"id":71925,"name":"gobrechsclothbreather","type":"helmaquatic","affix":"valkyrie","weight":"light"},{"id":71941,"name":"laranthirsshoulderguard","type":"shoulders","affix":"vigilant","weight":"medium"},{"id":71944,"name":"yassithsbastion","type":"shield","affix":"viper"},{"id":71968,"name":"svaardsdoublet","type":"coat","affix":"marauder","weight":"light"},{"id":72004,"name":"ossasbrazier","type":"torch","affix":"crusader"},{"id":72005,"name":"ossasartifact","type":"focus","affix":"crusader"},{"id":72079,"name":"rukasblade","type":"sword","affix":"wanderer"},{"id":72092,"name":"agility","type":"sigil"},{"id":72108,"name":"rukasrevolver","type":"pistol","affix":"wanderer"},{"id":72139,"name":"laranthirstassets","type":"leggings","affix":"vigilant","weight":"heavy"},{"id":72182,"name":"tizlaksdoublet","type":"coat","affix":"commander","weight":"light"},{"id":72188,"name":"maklainsartifact","type":"focus","affix":"minstrel"},{"id":72190,"name":"laranthirsgreaves","type":"boots","affix":"vigilant","weight":"heavy"},{"id":72214,"name":"rukaspauldrons","type":"shoulders","affix":"wanderer","weight":"heavy"},{"id":72221,"name":"wupwupmetalbreather","type":"helmaquatic","affix":"celestial","weight":"heavy"},{"id":72239,"name":"yassithsrevolver","type":"pistol","affix":"viper"},{"id":72249,"name":"angchuleatherbreather","type":"helmaquatic","affix":"cavalier","weight":"medium"},{"id":72251,"name":"svaardsfootwear","type":"boots","affix":"marauder","weight":"light"},{"id":72256,"name":"pahuasbrazier","type":"torch","affix":"trailblazer"},{"id":72259,"name":"yassithsshoulderguard","type":"shoulders","affix":"viper","weight":"medium"},{"id":72279,"name":"yassithsmusket","type":"rifle","affix":"viper"},{"id":72280,"name":"zojjasleatherbreather","type":"helmaquatic","affix":"berserker","weight":"medium"},{"id":72314,"name":"tizlaksclaymore","type":"greatsword","affix":"commander"},{"id":72339,"name":"concentration","type":"sigil"},{"id":72341,"name":"pahuasguise","type":"coat","affix":"trailblazer","weight":"medium"},{"id":72359,"name":"rukasrazor","type":"dagger","affix":"wanderer"},{"id":72369,"name":"laranthirsfootwear","type":"boots","affix":"vigilant","weight":"light"},{"id":72423,"name":"attunedlostsealofusokuinfused","type":"ring","affix":"soldier"},{"id":72452,"name":"ossastrident","type":"trident","affix":"crusader"},{"id":72456,"name":"pahuasgrips","type":"gloves","affix":"trailblazer","weight":"medium"},{"id":72466,"name":"tizlaksgreaves","type":"boots","affix":"commander","weight":"heavy"},{"id":72476,"name":"tizlaksreaver","type":"axe","affix":"commander"},{"id":72486,"name":"ferratussleatherbreather","type":"helmaquatic","affix":"rabid","weight":"medium"},{"id":72494,"name":"rukasdoublet","type":"coat","affix":"wanderer","weight":"light"},{"id":72496,"name":"rukastassets","type":"leggings","affix":"wanderer","weight":"heavy"},{"id":72509,"name":"forgemastersleatherbreather","type":"helmaquatic","affix":"rampager","weight":"medium"},{"id":72510,"name":"writofmasterfulmalice","type":"utility"},{"id":72529,"name":"vigilshonor","type":"amulet","affix":"crusader"},{"id":72532,"name":"thesisonstudiedspeed","type":"utility"},{"id":72546,"name":"laranthirsrazor","type":"dagger","affix":"vigilant"},{"id":72548,"name":"yassithsgreaves","type":"boots","affix":"viper","weight":"heavy"},{"id":72557,"name":"yassithspauldrons","type":"shoulders","affix":"viper","weight":"heavy"},{"id":72562,"name":"laranthirsbastion","type":"shield","affix":"vigilant"},{"id":72567,"name":"veratasleatherbreather","type":"helmaquatic","affix":"sinister","weight":"medium"},{"id":72584,"name":"weiqisleatherbreather","type":"helmaquatic","affix":"sentinel","weight":"medium"},{"id":72591,"name":"attunedossafamilysignetringinfused","type":"ring","affix":"knight"},{"id":72642,"name":"laranthirsimpaler","type":"harpoon","affix":"vigilant"},{"id":72663,"name":"tizlaksfootwear","type":"boots","affix":"commander","weight":"light"},{"id":72690,"name":"ossasgreaves","type":"boots","affix":"crusader","weight":"heavy"},{"id":72698,"name":"maklainsvisor","type":"helm","affix":"minstrel","weight":"heavy"},{"id":72719,"name":"rukasbreeches","type":"leggings","affix":"wanderer","weight":"light"},{"id":72765,"name":"rukasleggings","type":"leggings","affix":"wanderer","weight":"medium"},{"id":72816,"name":"pahuasfootwear","type":"boots","affix":"trailblazer","weight":"light"},{"id":72852,"name":"daredevil","type":"rune"},{"id":72860,"name":"pahuasrevolver","type":"pistol","affix":"trailblazer"},{"id":72872,"name":"absorption","type":"sigil"},{"id":72882,"name":"svaardsreaver","type":"axe","affix":"marauder"},{"id":72893,"name":"rukasbrazier","type":"torch","affix":"wanderer"},{"id":72912,"name":"thorns","type":"rune"},{"id":72919,"name":"veratasclothbreather","type":"helmaquatic","affix":"sinister","weight":"light"},{"id":72927,"name":"pahuasspire","type":"staff","affix":"trailblazer"},{"id":72932,"name":"attunedhealingsignetinfused","type":"ring","affix":"cleric"},{"id":72950,"name":"morbachsclothbreather","type":"helmaquatic","affix":"dire","weight":"light"},{"id":72998,"name":"laranthirsstriders","type":"boots","affix":"vigilant","weight":"medium"},{"id":73009,"name":"maklainspauldrons","type":"shoulders","affix":"minstrel","weight":"heavy"},{"id":73059,"name":"tizlaksrazor","type":"dagger","affix":"commander"},{"id":73068,"name":"rukasartifact","type":"focus","affix":"wanderer"},{"id":73090,"name":"laranthirsgrips","type":"gloves","affix":"vigilant","weight":"medium"},{"id":73127,"name":"forgemastersmetalbreather","type":"helmaquatic","affix":"rampager","weight":"heavy"},{"id":73191,"name":"writofmasterfulstrength","type":"utility"},{"id":73220,"name":"maklainswand","type":"scepter","affix":"minstrel"},{"id":73225,"name":"yassithsepaulets","type":"shoulders","affix":"viper","weight":"light"},{"id":73233,"name":"veldrunnerclothbreather","type":"helmaquatic","affix":"apothecary","weight":"light"},{"id":73234,"name":"ossasbreeches","type":"leggings","affix":"crusader","weight":"light"},{"id":73280,"name":"svaardsshortbow","type":"shortbow","affix":"marauder"},{"id":73281,"name":"attunedouroborosloopinfused","type":"ring","affix":"rabid"},{"id":73287,"name":"pahuaswand","type":"scepter","affix":"trailblazer"},{"id":73298,"name":"ossaswarhammer","type":"hammer","affix":"crusader"},{"id":73339,"name":"svaardsguise","type":"coat","affix":"marauder","weight":"medium"},{"id":73343,"name":"svaardsrazor","type":"dagger","affix":"marauder"},{"id":73357,"name":"laranthirsmusket","type":"rifle","affix":"vigilant"},{"id":73364,"name":"keepersclothbreather","type":"helmaquatic","affix":"zealot","weight":"light"},{"id":73365,"name":"maklainsharpoongun","type":"speargun","affix":"minstrel"},{"id":73373,"name":"ossasblade","type":"sword","affix":"crusader"},{"id":73392,"name":"pahuasbreeches","type":"leggings","affix":"trailblazer","weight":"light"},{"id":73395,"name":"pahuasleggings","type":"leggings","affix":"trailblazer","weight":"medium"},{"id":73399,"name":"chronomancer","type":"rune"},{"id":73403,"name":"ventarisclothbreather","type":"helmaquatic","affix":"nomad","weight":"light"},{"id":73479,"name":"maklainstrident","type":"trident","affix":"minstrel"},{"id":73487,"name":"rukasflangedmace","type":"mace","affix":"wanderer"},{"id":73497,"name":"maklainsmusket","type":"rifle","affix":"minstrel"},{"id":73514,"name":"svaardsclaymore","type":"greatsword","affix":"marauder"},{"id":73521,"name":"rukasmasque","type":"helm","affix":"wanderer","weight":"light"},{"id":73532,"name":"rending","type":"sigil"},{"id":73549,"name":"maklainsrevolver","type":"pistol","affix":"minstrel"},{"id":73560,"name":"attunedvineofthepaletreeinfused","type":"ring","affix":"berserkerandvalkyrie"},{"id":73580,"name":"yassithsimpaler","type":"harpoon","affix":"viper"},{"id":73613,"name":"rukasshoulderguard","type":"shoulders","affix":"wanderer","weight":"medium"},{"id":73614,"name":"tizlaksrevolver","type":"pistol","affix":"commander"},{"id":73631,"name":"laranthirsflangedmace","type":"mace","affix":"vigilant"},{"id":73649,"name":"tizlaksleggings","type":"leggings","affix":"commander","weight":"medium"},{"id":73652,"name":"laranthirsguise","type":"coat","affix":"vigilant","weight":"medium"},{"id":73653,"name":"durability","type":"rune"},{"id":73662,"name":"gobrechsmetalbreather","type":"helmaquatic","affix":"valkyrie","weight":"heavy"},{"id":73670,"name":"maklainsepaulets","type":"shoulders","affix":"minstrel","weight":"light"},{"id":73687,"name":"ossasbastion","type":"shield","affix":"crusader"},{"id":73697,"name":"pahuaswarfists","type":"gloves","affix":"trailblazer","weight":"heavy"},{"id":73719,"name":"ossastassets","type":"leggings","affix":"crusader","weight":"heavy"},{"id":73723,"name":"ahamidsclothbreather","type":"helmaquatic","affix":"soldier","weight":"light"},{"id":73724,"name":"tizlaksblade","type":"sword","affix":"commander"},{"id":73756,"name":"attuneddruidscircleinfused","type":"ring","affix":"cleric"},{"id":73766,"name":"ossasfootwear","type":"boots","affix":"crusader","weight":"light"},{"id":73782,"name":"rukaswarfists","type":"gloves","affix":"wanderer","weight":"heavy"},{"id":73813,"name":"attunedsolariacircleofthesuninfused","type":"ring","affix":"celestial"},{"id":73835,"name":"tizlaksstriders","type":"boots","affix":"commander","weight":"medium"},{"id":73852,"name":"yassithswristguards","type":"gloves","affix":"viper","weight":"light"},{"id":73854,"name":"yassithsstriders","type":"boots","affix":"viper","weight":"medium"},{"id":73859,"name":"morbachsmetalbreather","type":"helmaquatic","affix":"dire","weight":"heavy"},{"id":73882,"name":"laranthirsdoublet","type":"coat","affix":"vigilant","weight":"light"},{"id":73925,"name":"ossasrevolver","type":"pistol","affix":"crusader"},{"id":73932,"name":"ossasshoulderguard","type":"shoulders","affix":"crusader","weight":"medium"},{"id":73948,"name":"maklainsgreatbow","type":"longbow","affix":"minstrel"},{"id":73970,"name":"maklainsmasque","type":"helm","affix":"minstrel","weight":"light"},{"id":73971,"name":"tizlaksshoulderguard","type":"shoulders","affix":"commander","weight":"medium"},{"id":73984,"name":"pahuasblade","type":"sword","affix":"trailblazer"},{"id":73996,"name":"laranthirsclaymore","type":"greatsword","affix":"vigilant"},{"id":74004,"name":"ossasvisage","type":"helm","affix":"crusader","weight":"medium"},{"id":74034,"name":"yassithsharpoongun","type":"speargun","affix":"viper"},{"id":74056,"name":"laranthirswand","type":"scepter","affix":"vigilant"},{"id":74064,"name":"laranthirsblade","type":"sword","affix":"vigilant"},{"id":74083,"name":"tizlaksshortbow","type":"shortbow","affix":"commander"},{"id":74117,"name":"ferratussmetalbreather","type":"helmaquatic","affix":"rabid","weight":"heavy"},{"id":74119,"name":"ferratussclothbreather","type":"helmaquatic","affix":"rabid","weight":"light"},{"id":74124,"name":"ossaswand","type":"scepter","affix":"crusader"},{"id":74172,"name":"svaardstrident","type":"trident","affix":"marauder"},{"id":74179,"name":"yassithsrazor","type":"dagger","affix":"viper"},{"id":74197,"name":"rukasharpoongun","type":"speargun","affix":"wanderer"},{"id":74264,"name":"yassithsfootwear","type":"boots","affix":"viper","weight":"light"},{"id":74326,"name":"transference","type":"sigil"},{"id":74331,"name":"rukasvisage","type":"helm","affix":"wanderer","weight":"medium"},{"id":74332,"name":"nightfury","type":"shoulders","affix":"sinister","weight":"light"},{"id":74333,"name":"tateossleatherbreather","type":"helmaquatic","affix":"cleric","weight":"medium"},{"id":74343,"name":"attunedbarbedsignetinfused","type":"ring","affix":"rampager"},{"id":74353,"name":"zojjasmetalbreather","type":"helmaquatic","affix":"berserker","weight":"heavy"},{"id":74357,"name":"yassithsvisage","type":"helm","affix":"viper","weight":"medium"},{"id":74363,"name":"yassithswarhammer","type":"hammer","affix":"viper"},{"id":74412,"name":"yassithsvisor","type":"helm","affix":"viper","weight":"heavy"},{"id":74425,"name":"svaardsbastion","type":"shield","affix":"marauder"},{"id":74448,"name":"maklainsdoublet","type":"coat","affix":"minstrel","weight":"light"},{"id":74500,"name":"svaardsbrazier","type":"torch","affix":"marauder"},{"id":74512,"name":"laranthirswristguards","type":"gloves","affix":"vigilant","weight":"light"},{"id":74516,"name":"svaardsartifact","type":"focus","affix":"marauder"},{"id":74518,"name":"svaardswristguards","type":"gloves","affix":"marauder","weight":"light"},{"id":74522,"name":"laranthirsmasque","type":"helm","affix":"vigilant","weight":"light"},{"id":74524,"name":"pahuasdoublet","type":"coat","affix":"trailblazer","weight":"light"},{"id":74547,"name":"nightfury","type":"shoulders","affix":"sinister","weight":"medium"},{"id":74569,"name":"yassithsshortbow","type":"shortbow","affix":"viper"},{"id":74612,"name":"laranthirsrevolver","type":"pistol","affix":"vigilant"},{"id":74645,"name":"laranthirspauldrons","type":"shoulders","affix":"vigilant","weight":"heavy"},{"id":74667,"name":"laranthirsvisage","type":"helm","affix":"vigilant","weight":"medium"},{"id":74679,"name":"rukasreaver","type":"axe","affix":"wanderer"},{"id":74680,"name":"zintlclothbreather","type":"helmaquatic","affix":"shaman","weight":"light"},{"id":74691,"name":"leftpawsmetalbreather","type":"helmaquatic","affix":"settler","weight":"heavy"},{"id":74695,"name":"whisperssecret","type":"amulet","affix":"crusader"},{"id":74735,"name":"rukasspire","type":"staff","affix":"wanderer"},{"id":74737,"name":"svaardsstriders","type":"boots","affix":"marauder","weight":"medium"},{"id":74744,"name":"attunedsealofthekhanurinfused","type":"ring","affix":"rabidandapothecary"},{"id":74748,"name":"maklainsbastion","type":"shield","affix":"minstrel"},{"id":74751,"name":"ossasstriders","type":"boots","affix":"crusader","weight":"medium"},{"id":74776,"name":"pahuaswarhammer","type":"hammer","affix":"trailblazer"},{"id":74824,"name":"beigarthsmetalbreather","type":"helmaquatic","affix":"knight","weight":"heavy"},{"id":74836,"name":"ossaswristguards","type":"gloves","affix":"crusader","weight":"light"},{"id":74905,"name":"maklainsreaver","type":"axe","affix":"minstrel"},{"id":74921,"name":"weiqismetalbreather","type":"helmaquatic","affix":"sentinel","weight":"heavy"},{"id":74929,"name":"svaardsvisor","type":"helm","affix":"marauder","weight":"heavy"},{"id":74935,"name":"ossasgreatbow","type":"longbow","affix":"crusader"},{"id":74953,"name":"tizlaksgreatbow","type":"longbow","affix":"commander"},{"id":74962,"name":"svaardstassets","type":"leggings","affix":"marauder","weight":"heavy"},{"id":74978,"name":"dragonhunter","type":"rune"},{"id":74979,"name":"veldrunnerleatherbreather","type":"helmaquatic","affix":"apothecary","weight":"medium"},{"id":75009,"name":"ossasclaymore","type":"greatsword","affix":"crusader"},{"id":75022,"name":"maklainsvisage","type":"helm","affix":"minstrel","weight":"medium"},{"id":75023,"name":"laranthirsepaulets","type":"shoulders","affix":"vigilant","weight":"light"},{"id":75025,"name":"laranthirsgreatbow","type":"longbow","affix":"vigilant"},{"id":75029,"name":"attunedpurgesignetinfused","type":"ring","affix":"apothecary"},{"id":75030,"name":"occamsclothbreather","type":"helmaquatic","affix":"carrion","weight":"light"},{"id":75042,"name":"rukasherald","type":"warhorn","affix":"wanderer"},{"id":75103,"name":"laranthirsharpoongun","type":"speargun","affix":"vigilant"},{"id":75107,"name":"tizlaksbreastplate","type":"coat","affix":"commander","weight":"heavy"},{"id":75135,"name":"ossasimpaler","type":"harpoon","affix":"crusader"},{"id":75142,"name":"maklainswarfists","type":"gloves","affix":"minstrel","weight":"heavy"},{"id":75156,"name":"attunedruriksroyalsignetringinfused","type":"ring","affix":"cavalier"},{"id":75174,"name":"laranthirswarhammer","type":"hammer","affix":"vigilant"},{"id":75175,"name":"attunedralenasbandinfused","type":"ring","affix":"direandrabid"},{"id":75183,"name":"svaardsbreeches","type":"leggings","affix":"marauder","weight":"light"},{"id":75200,"name":"maklainsspire","type":"staff","affix":"minstrel"},{"id":75201,"name":"svaardsherald","type":"warhorn","affix":"marauder"},{"id":75203,"name":"ossasharpoongun","type":"speargun","affix":"crusader"},{"id":75224,"name":"laranthirsreaver","type":"axe","affix":"vigilant"},{"id":75231,"name":"hronksclothbreather","type":"helmaquatic","affix":"magi","weight":"light"},{"id":75248,"name":"pahuasstriders","type":"boots","affix":"trailblazer","weight":"medium"},{"id":75269,"name":"svaardswand","type":"scepter","affix":"marauder"},{"id":75277,"name":"attunedvassarsbandinfused","type":"ring","affix":"direandrabid"},{"id":75285,"name":"pahuasvisage","type":"helm","affix":"trailblazer","weight":"medium"},{"id":75307,"name":"rukasclaymore","type":"greatsword","affix":"wanderer"},{"id":75312,"name":"attunedsandfordfamilyringinfused","type":"ring","affix":"nomad"},{"id":75315,"name":"attunedbaghnakhinfused","type":"ring","affix":"berserkerandvalkyrie"},{"id":75325,"name":"yassithsherald","type":"warhorn","affix":"viper"},{"id":75331,"name":"pahuasartifact","type":"focus","affix":"trailblazer"},{"id":75340,"name":"maklainsleggings","type":"leggings","affix":"minstrel","weight":"medium"},{"id":75349,"name":"maklainsfootwear","type":"boots","affix":"minstrel","weight":"light"},{"id":75355,"name":"attunedbandofthebrotherhoodinfused","type":"ring","affix":"captain"},{"id":75356,"name":"tizlaksartifact","type":"focus","affix":"commander"},{"id":75378,"name":"yassithsbreeches","type":"leggings","affix":"viper","weight":"light"},{"id":75388,"name":"maklainsrazor","type":"dagger","affix":"minstrel"},{"id":75413,"name":"rukasimpaler","type":"harpoon","affix":"wanderer"},{"id":75422,"name":"pahuasrazor","type":"dagger","affix":"trailblazer"},{"id":75425,"name":"beigarthsclothbreather","type":"helmaquatic","affix":"knight","weight":"light"},{"id":75438,"name":"attunedcirqueofarahinfused","type":"ring","affix":"captain"},{"id":75521,"name":"rukaswarhammer","type":"hammer","affix":"wanderer"},{"id":75554,"name":"laranthirswarfists","type":"gloves","affix":"vigilant","weight":"heavy"},{"id":75559,"name":"svaardsflangedmace","type":"mace","affix":"marauder"},{"id":75572,"name":"pahuasshoulderguard","type":"shoulders","affix":"trailblazer","weight":"medium"},{"id":75573,"name":"zojjasclothbreather","type":"helmaquatic","affix":"berserker","weight":"light"},{"id":75581,"name":"ossasflangedmace","type":"mace","affix":"crusader"},{"id":75583,"name":"ossasleggings","type":"leggings","affix":"crusader","weight":"medium"},{"id":75589,"name":"svaardsshoulderguard","type":"shoulders","affix":"marauder","weight":"medium"},{"id":75611,"name":"tizlaksbrazier","type":"torch","affix":"commander"},{"id":75626,"name":"yassithsgrips","type":"gloves","affix":"viper","weight":"medium"},{"id":75642,"name":"pahuasgreatbow","type":"longbow","affix":"trailblazer"},{"id":75644,"name":"maklainsshortbow","type":"shortbow","affix":"minstrel"},{"id":75667,"name":"ossasreaver","type":"axe","affix":"crusader"},{"id":75668,"name":"laranthirsartifact","type":"focus","affix":"vigilant"},{"id":75669,"name":"attunedringofreddeathinfused","type":"ring","affix":"berserker"},{"id":75697,"name":"pahuasherald","type":"warhorn","affix":"trailblazer"},{"id":75718,"name":"svaardsgrips","type":"gloves","affix":"marauder","weight":"medium"},{"id":75727,"name":"tizlaksmasque","type":"helm","affix":"commander","weight":"light"},{"id":75743,"name":"rukasshortbow","type":"shortbow","affix":"wanderer"},{"id":75747,"name":"svaardsgreatbow","type":"longbow","affix":"marauder"},{"id":75765,"name":"hronksleatherbreather","type":"helmaquatic","affix":"magi","weight":"medium"},{"id":75770,"name":"yassithsmasque","type":"helm","affix":"viper","weight":"light"},{"id":75795,"name":"janthirsgaze","type":"amulet","affix":"marauder"},{"id":75820,"name":"maklainsbrazier","type":"torch","affix":"minstrel"},{"id":75858,"name":"svaardswarfists","type":"gloves","affix":"marauder","weight":"heavy"},{"id":75866,"name":"maklainswristguards","type":"gloves","affix":"minstrel","weight":"light"},{"id":75897,"name":"svaardswarhammer","type":"hammer","affix":"marauder"},{"id":75912,"name":"ossasguise","type":"coat","affix":"crusader","weight":"medium"},{"id":75940,"name":"svaardsmasque","type":"helm","affix":"marauder","weight":"light"},{"id":75943,"name":"attunedpalawajokosfingercuffinfused","type":"ring","affix":"rampager"},{"id":75954,"name":"ahamidsmetalbreather","type":"helmaquatic","affix":"soldier","weight":"heavy"},{"id":75987,"name":"ossaspauldrons","type":"shoulders","affix":"crusader","weight":"heavy"},{"id":76007,"name":"gobrechsleatherbreather","type":"helmaquatic","affix":"valkyrie","weight":"medium"},{"id":76024,"name":"attunedcrystallinebandinfused","type":"ring","affix":"berserker"},{"id":76049,"name":"rukaswand","type":"scepter","affix":"wanderer"},{"id":76055,"name":"pahuasclaymore","type":"greatsword","affix":"trailblazer"},{"id":76075,"name":"tizlaksbastion","type":"shield","affix":"commander"},{"id":76089,"name":"tizlaksspire","type":"staff","affix":"commander"},{"id":76092,"name":"ossaswarfists","type":"gloves","affix":"crusader","weight":"heavy"},{"id":76100,"name":"herald","type":"rune"},{"id":76110,"name":"tizlaksguise","type":"coat","affix":"commander","weight":"medium"},{"id":76139,"name":"tizlaksbreeches","type":"leggings","affix":"commander","weight":"light"},{"id":76166,"name":"tempest","type":"rune"},{"id":76184,"name":"keepersleatherbreather","type":"helmaquatic","affix":"zealot","weight":"medium"},{"id":76186,"name":"ossasepaulets","type":"shoulders","affix":"crusader","weight":"light"},{"id":76198,"name":"rukasbastion","type":"shield","affix":"wanderer"},{"id":76207,"name":"pahuastrident","type":"trident","affix":"trailblazer"},{"id":76212,"name":"maklainsimpaler","type":"harpoon","affix":"minstrel"},{"id":76245,"name":"svaardsbreastplate","type":"coat","affix":"marauder","weight":"heavy"},{"id":76253,"name":"hronksmetalbreather","type":"helmaquatic","affix":"magi","weight":"heavy"},{"id":76256,"name":"pahuasshortbow","type":"shortbow","affix":"trailblazer"},{"id":76262,"name":"maklainswarhammer","type":"hammer","affix":"minstrel"},{"id":76263,"name":"pahuasgreaves","type":"boots","affix":"trailblazer","weight":"heavy"},{"id":76271,"name":"yassithsbrazier","type":"torch","affix":"viper"},{"id":76324,"name":"angchuclothbreather","type":"helmaquatic","affix":"cavalier","weight":"light"},{"id":76377,"name":"yassithsbreastplate","type":"coat","affix":"viper","weight":"heavy"},{"id":76403,"name":"tateossclothbreather","type":"helmaquatic","affix":"cleric","weight":"light"},{"id":76406,"name":"pahuasepaulets","type":"shoulders","affix":"trailblazer","weight":"light"},{"id":76420,"name":"ossasbreastplate","type":"coat","affix":"crusader","weight":"heavy"},{"id":76436,"name":"pahuasharpoongun","type":"speargun","affix":"trailblazer"},{"id":76501,"name":"maklainsclaymore","type":"greatsword","affix":"minstrel"},{"id":76504,"name":"attunedforgottenbandinfused","type":"ring","affix":"nomad"},{"id":76551,"name":"svaardspauldrons","type":"shoulders","affix":"marauder","weight":"heavy"},{"id":76557,"name":"attunedettinbandinfused","type":"ring","affix":"knight"},{"id":76599,"name":"thesisonmasterfulaccuracy","type":"utility"},{"id":76631,"name":"laranthirsspire","type":"staff","affix":"vigilant"},{"id":76648,"name":"tizlaksharpoongun","type":"speargun","affix":"commander"},{"id":76658,"name":"maklainsshoulderguard","type":"shoulders","affix":"minstrel","weight":"medium"},{"id":76660,"name":"prioryshistory","type":"amulet","affix":"crusader"},{"id":76671,"name":"svaardsepaulets","type":"shoulders","affix":"marauder","weight":"light"},{"id":76688,"name":"yassithswand","type":"scepter","affix":"viper"},{"id":76698,"name":"tizlaksgrips","type":"gloves","affix":"commander","weight":"medium"},{"id":76710,"name":"yassithsguise","type":"coat","affix":"viper","weight":"medium"},{"id":76717,"name":"pahuasbastion","type":"shield","affix":"trailblazer"},{"id":76729,"name":"maklainsgrips","type":"gloves","affix":"minstrel","weight":"medium"},{"id":76730,"name":"maklainsblade","type":"sword","affix":"minstrel"},{"id":76738,"name":"thesisonmasterfulmalice","type":"utility"},{"id":76768,"name":"occamsmetalbreather","type":"helmaquatic","affix":"carrion","weight":"heavy"},{"id":76776,"name":"yassithswarfists","type":"gloves","affix":"viper","weight":"heavy"},{"id":76786,"name":"yassithsflangedmace","type":"mace","affix":"viper"},{"id":76809,"name":"attunedlunariacircleofthemooninfused","type":"ring","affix":"celestial"},{"id":76813,"name":"surging","type":"rune"},{"id":76814,"name":"rukasbreastplate","type":"coat","affix":"wanderer","weight":"heavy"},{"id":76821,"name":"tizlakswand","type":"scepter","affix":"commander"},{"id":76823,"name":"attunedadelbernsroyalsignetringinfused","type":"ring","affix":"cavalier"},{"id":76824,"name":"laranthirsherald","type":"warhorn","affix":"vigilant"},{"id":76833,"name":"writofmasterfulaccuracy","type":"utility"},{"id":76834,"name":"pahuasmasque","type":"helm","affix":"trailblazer","weight":"light"},{"id":76837,"name":"wupwupclothbreather","type":"helmaquatic","affix":"celestial","weight":"light"},{"id":76854,"name":"ossasdoublet","type":"coat","affix":"crusader","weight":"light"},{"id":76861,"name":"forgemastersclothbreather","type":"helmaquatic","affix":"rampager","weight":"light"},{"id":76878,"name":"laranthirsshortbow","type":"shortbow","affix":"vigilant"},{"id":76885,"name":"nightfury","type":"shoulders","affix":"sinister","weight":"heavy"},{"id":76889,"name":"svaardsspire","type":"staff","affix":"marauder"},{"id":76908,"name":"pahuasbreastplate","type":"coat","affix":"trailblazer","weight":"heavy"},{"id":76936,"name":"attunedluccesealinfused","type":"ring","affix":"apothecary"},{"id":76942,"name":"rukasgreaves","type":"boots","affix":"wanderer","weight":"heavy"},{"id":76970,"name":"tizlakstrident","type":"trident","affix":"commander"},{"id":76977,"name":"tizlakswarhammer","type":"hammer","affix":"commander"},{"id":76984,"name":"pahuasmusket","type":"rifle","affix":"trailblazer"},{"id":76985,"name":"svaardsblade","type":"sword","affix":"marauder"},{"id":76988,"name":"tizlaksflangedmace","type":"mace","affix":"commander"},{"id":76993,"name":"veldrunnermetalbreather","type":"helmaquatic","affix":"apothecary","weight":"heavy"},{"id":77022,"name":"maklainstassets","type":"leggings","affix":"minstrel","weight":"heavy"},{"id":77055,"name":"rukasmusket","type":"rifle","affix":"wanderer"},{"id":77057,"name":"svaardsvisage","type":"helm","affix":"marauder","weight":"medium"},{"id":77058,"name":"veratasmetalbreather","type":"helmaquatic","affix":"sinister","weight":"heavy"},{"id":77096,"name":"ventarismetalbreather","type":"helmaquatic","affix":"nomad","weight":"heavy"},{"id":77100,"name":"ventarisleatherbreather","type":"helmaquatic","affix":"nomad","weight":"medium"},{"id":77102,"name":"weiqisclothbreather","type":"helmaquatic","affix":"sentinel","weight":"light"},{"id":77108,"name":"ossasmasque","type":"helm","affix":"crusader","weight":"light"},{"id":77122,"name":"yassithsreaver","type":"axe","affix":"viper"},{"id":77127,"name":"tizlakspauldrons","type":"shoulders","affix":"commander","weight":"heavy"},{"id":77143,"name":"yassithstassets","type":"leggings","affix":"viper","weight":"heavy"},{"id":77146,"name":"thesisonmasterfulstrength","type":"utility"},{"id":77150,"name":"laranthirsleggings","type":"leggings","affix":"vigilant","weight":"medium"},{"id":77169,"name":"tizlaksvisor","type":"helm","affix":"commander","weight":"heavy"},{"id":77177,"name":"saphirsleatherbreather","type":"helmaquatic","affix":"assassin","weight":"medium"},{"id":77204,"name":"maklainsstriders","type":"boots","affix":"minstrel","weight":"medium"},{"id":77208,"name":"tizlakswristguards","type":"gloves","affix":"commander","weight":"light"},{"id":77229,"name":"laranthirsbreastplate","type":"coat","affix":"vigilant","weight":"heavy"},{"id":77249,"name":"tizlakswarfists","type":"gloves","affix":"commander","weight":"heavy"},{"id":77567,"name":"tuningicicle","type":"utility"},{"id":77569,"name":"tinoffruitcake","type":"utility"},{"id":77632,"name":"peppermintoil","type":"utility"},{"id":78305,"name":"superiorsharpeningstone","type":"utility"},{"id":78658,"name":"mangopie","type":"food"},{"id":78786,"name":"shiningbladebountynoticeruyethecrimson","type":"gizmo"},{"id":78978,"name":"whitemantleportaldevice","type":"gizmo"},{"id":80116,"name":"thackeraysrifle","type":"rifle","affix":"seraph"},{"id":80132,"name":"thackeraysgreaves","type":"boots","affix":"seraph","weight":"heavy"},{"id":80133,"name":"thackeraysbulwark","type":"shield","affix":"seraph"},{"id":80137,"name":"thackeraysshoulderguard","type":"shoulders","affix":"seraph","weight":"medium"},{"id":80158,"name":"thackerayspillar","type":"staff","affix":"seraph"},{"id":80163,"name":"thackeraysslicer","type":"dagger","affix":"seraph"},{"id":80226,"name":"thackerayscrusader","type":"greatsword","affix":"seraph"},{"id":80227,"name":"thackeraysgauntlets","type":"gloves","affix":"seraph","weight":"heavy"},{"id":80244,"name":"thackeraysdoublet","type":"coat","affix":"seraph","weight":"light"},{"id":80268,"name":"thackeraysgloves","type":"gloves","affix":"seraph","weight":"light"},{"id":80274,"name":"thackeraystassets","type":"leggings","affix":"seraph","weight":"heavy"},{"id":80280,"name":"thackerayscuirass","type":"coat","affix":"seraph","weight":"medium"},{"id":80300,"name":"thackeraysboots","type":"boots","affix":"seraph","weight":"medium"},{"id":80318,"name":"thackerayscleaver","type":"axe","affix":"seraph"},{"id":80361,"name":"thackeraysbreastplate","type":"coat","affix":"seraph","weight":"heavy"},{"id":80370,"name":"thackeraysvisage","type":"helm","affix":"seraph","weight":"medium"},{"id":80375,"name":"thackeraysrod","type":"scepter","affix":"seraph"},{"id":80391,"name":"thackerayscrescent","type":"shortbow","affix":"seraph"},{"id":80402,"name":"thackeraysgreatbow","type":"longbow","affix":"seraph"},{"id":80407,"name":"thackeraysbugle","type":"warhorn","affix":"seraph"},{"id":80447,"name":"thackeraysharpoongun","type":"speargun","affix":"vigilant"},{"id":80448,"name":"thackeraysepaulets","type":"shoulders","affix":"seraph","weight":"light"},{"id":80451,"name":"thackeraysbarbute","type":"helm","affix":"seraph","weight":"heavy"},{"id":80486,"name":"thackeraysfocus","type":"focus","affix":"seraph"},{"id":80491,"name":"thackeraysfootwear","type":"boots","affix":"seraph","weight":"light"},{"id":80512,"name":"thackeraysgladius","type":"sword","affix":"seraph"},{"id":80520,"name":"thackerayshandcannon","type":"pistol","affix":"seraph"},{"id":80522,"name":"thackerayscrusher","type":"hammer","affix":"seraph"},{"id":80588,"name":"thackeraysvambraces","type":"gloves","affix":"seraph","weight":"medium"},{"id":80616,"name":"thackerayspauldrons","type":"shoulders","affix":"seraph","weight":"heavy"},{"id":80618,"name":"thackeraysspire","type":"trident","affix":"seraph"},{"id":80624,"name":"thackeraysgavel","type":"mace","affix":"seraph"},{"id":80637,"name":"thackeraysleggings","type":"leggings","affix":"seraph","weight":"medium"},{"id":80661,"name":"thackeraysmasque","type":"helm","affix":"seraph","weight":"light"},{"id":80664,"name":"thackerayspants","type":"leggings","affix":"seraph","weight":"light"},{"id":80670,"name":"thackeraysskewer","type":"harpoon","affix":"seraph"},{"id":80683,"name":"thackeraysflame","type":"torch","affix":"seraph"},{"id":81045,"name":"bounty","type":"sigil"},{"id":81091,"name":"naturesbounty","type":"rune"},{"id":82505,"name":"attuneddunkorostreasureinfused","type":"ring","affix":"marshal"},{"id":82599,"name":"firstspearsicon","type":"amulet","affix":"marshal"},{"id":82633,"name":"holosmith","type":"rune"},{"id":82705,"name":"attunedsigilofthefoolinfused","type":"ring","affix":"harrier"},{"id":82769,"name":"gorenseeltoothcharm","type":"amulet","affix":"harrier"},{"id":82791,"name":"deadeye","type":"rune"},{"id":82876,"name":"frenzy","type":"sigil"},{"id":82897,"name":"jahnussstainedpectoral","type":"amulet","affix":"grieving"},{"id":83321,"name":"attunednadijehsdynasticsignetinfused","type":"ring","affix":"marshal"},{"id":83338,"name":"firebrand","type":"rune"},{"id":83367,"name":"cavalier","type":"rune"},{"id":83404,"name":"mourningbell","type":"accessory","affix":"grieving"},{"id":83423,"name":"weaver","type":"rune"},{"id":83429,"name":"eloniantransitpass","type":"accessory","affix":"harrier"},{"id":83502,"name":"renegade","type":"rune"},{"id":83663,"name":"scourge","type":"rune"},{"id":83675,"name":"attunedcorsairsringinfused","type":"ring","affix":"harrier"},{"id":83964,"name":"soulbeast","type":"rune"},{"id":84127,"name":"mirage","type":"rune"},{"id":84171,"name":"rebirth","type":"rune"},{"id":84212,"name":"attunedkolestormentedeyeinfused","type":"ring","affix":"grieving"},{"id":84296,"name":"anthemofliberty","type":"accessory","affix":"marshal"},{"id":84505,"name":"severance","type":"sigil"},{"id":84577,"name":"attunedgiftofthehiddenscioninfused","type":"ring","affix":"grieving"},{"id":84749,"name":"spellbreaker","type":"rune"},{"id":84866,"name":"nadijehswristguards","type":"gloves","affix":"marshal","weight":"light"},{"id":84876,"name":"thetwinsblade","type":"sword","affix":"grieving"},{"id":84878,"name":"zehtukasrevolver","type":"pistol","affix":"harrier"},{"id":84879,"name":"zehtukasvisor","type":"helm","affix":"harrier","weight":"heavy"},{"id":84883,"name":"nadijehsvisage","type":"helm","affix":"marshal","weight":"medium"},{"id":84886,"name":"nadijehsmusket","type":"rifle","affix":"marshal"},{"id":84909,"name":"nadijehsrazor","type":"dagger","affix":"marshal"},{"id":84911,"name":"thetwinstassets","type":"leggings","affix":"grieving","weight":"heavy"},{"id":84912,"name":"zehtukasflangedmace","type":"mace","affix":"harrier"},{"id":84923,"name":"zehtukasguise","type":"coat","affix":"harrier","weight":"medium"},{"id":84926,"name":"zehtukasbreeches","type":"leggings","affix":"harrier","weight":"light"},{"id":84931,"name":"thetwinsrevolver","type":"pistol","affix":"grieving"},{"id":84936,"name":"thetwinsrazor","type":"dagger","affix":"grieving"},{"id":84939,"name":"zehtukasblade","type":"sword","affix":"harrier"},{"id":84944,"name":"thetwinsharpoongun","type":"speargun","affix":"grieving"},{"id":84954,"name":"nadijehsstriders","type":"boots","affix":"marshal","weight":"medium"},{"id":84957,"name":"zehtukasbastion","type":"shield","affix":"harrier"},{"id":84973,"name":"zehtukasherald","type":"warhorn","affix":"harrier"},{"id":84983,"name":"zehtukasgrips","type":"gloves","affix":"harrier","weight":"medium"},{"id":85001,"name":"thetwinsspire","type":"staff","affix":"grieving"},{"id":85004,"name":"zehtukaswristguards","type":"gloves","affix":"harrier","weight":"light"},{"id":85006,"name":"thetwinsbrazier","type":"torch","affix":"grieving"},{"id":85007,"name":"thetwinsfootwear","type":"boots","affix":"grieving","weight":"light"},{"id":85008,"name":"nadijehsblade","type":"sword","affix":"marshal"},{"id":85013,"name":"zehtukasbrazier","type":"torch","affix":"harrier"},{"id":85019,"name":"thetwinsclaymore","type":"greatsword","affix":"grieving"},{"id":85021,"name":"nadijehsleggings","type":"leggings","affix":"marshal","weight":"medium"},{"id":85024,"name":"zehtukastassets","type":"leggings","affix":"harrier","weight":"heavy"},{"id":85027,"name":"zehtukaswand","type":"scepter","affix":"harrier"},{"id":85036,"name":"zehtukasharpoongun","type":"speargun","affix":"harrier"},{"id":85041,"name":"nadijehsgreaves","type":"boots","affix":"marshal","weight":"heavy"},{"id":85042,"name":"thetwinsbreastplate","type":"coat","affix":"grieving","weight":"heavy"},{"id":85044,"name":"thetwinsartifact","type":"focus","affix":"grieving"},{"id":85047,"name":"zehtukasreaver","type":"axe","affix":"harrier"},{"id":85048,"name":"thetwinswristguards","type":"gloves","affix":"grieving","weight":"light"},{"id":85051,"name":"zehtukasrazor","type":"dagger","affix":"harrier"},{"id":85054,"name":"thetwinsshoulderguard","type":"shoulders","affix":"grieving","weight":"medium"},{"id":85061,"name":"nadijehsrevolver","type":"pistol","affix":"marshal"},{"id":85062,"name":"thetwinsguise","type":"coat","affix":"grieving","weight":"medium"},{"id":85066,"name":"nadijehsepaulets","type":"shoulders","affix":"marshal","weight":"light"},{"id":85067,"name":"thetwinsvisage","type":"helm","affix":"grieving","weight":"medium"},{"id":85071,"name":"nadijehstassets","type":"leggings","affix":"marshal","weight":"heavy"},{"id":85072,"name":"thetwinsmusket","type":"rifle","affix":"grieving"},{"id":85073,"name":"nadijehsgreatbow","type":"longbow","affix":"marshal"},{"id":85074,"name":"thetwinsherald","type":"warhorn","affix":"grieving"},{"id":85076,"name":"thetwinswand","type":"scepter","affix":"grieving"},{"id":85083,"name":"nadijehsguise","type":"coat","affix":"marshal","weight":"medium"},{"id":85089,"name":"zehtukasepaulets","type":"shoulders","affix":"harrier","weight":"light"},{"id":85093,"name":"thetwinsgreaves","type":"boots","affix":"grieving","weight":"heavy"},{"id":85094,"name":"thetwinstrident","type":"trident","affix":"grieving"},{"id":85098,"name":"zehtukasdoublet","type":"coat","affix":"harrier","weight":"light"},{"id":85109,"name":"nadijehswand","type":"scepter","affix":"marshal"},{"id":85111,"name":"zehtukasgreatbow","type":"longbow","affix":"harrier"},{"id":85112,"name":"zehtukasspire","type":"staff","affix":"harrier"},{"id":85116,"name":"nadijehsherald","type":"warhorn","affix":"marshal"},{"id":85121,"name":"zehtukasclaymore","type":"greatsword","affix":"harrier"},{"id":85126,"name":"zehtukasbreastplate","type":"coat","affix":"harrier","weight":"heavy"},{"id":85131,"name":"zehtukasimpaler","type":"harpoon","affix":"harrier"},{"id":85149,"name":"zehtukasleggings","type":"leggings","affix":"harrier","weight":"medium"},{"id":85152,"name":"nadijehsbrazier","type":"torch","affix":"marshal"},{"id":85154,"name":"nadijehsgrips","type":"gloves","affix":"marshal","weight":"medium"},{"id":85156,"name":"nadijehsshortbow","type":"shortbow","affix":"marshal"},{"id":85161,"name":"zehtukasmasque","type":"helm","affix":"harrier","weight":"light"},{"id":85166,"name":"nadijehsflangedmace","type":"mace","affix":"marshal"},{"id":85172,"name":"zehtukasvisage","type":"helm","affix":"harrier","weight":"medium"},{"id":85180,"name":"nadijehsbreeches","type":"leggings","affix":"marshal","weight":"light"},{"id":85183,"name":"zehtukasshoulderguard","type":"shoulders","affix":"harrier","weight":"medium"},{"id":85187,"name":"nadijehstrident","type":"trident","affix":"marshal"},{"id":85196,"name":"zehtukasgreaves","type":"boots","affix":"harrier","weight":"heavy"},{"id":85200,"name":"zehtukasshortbow","type":"shortbow","affix":"harrier"},{"id":85208,"name":"thetwinsgrips","type":"gloves","affix":"grieving","weight":"medium"},{"id":85212,"name":"thetwinsgreatbow","type":"longbow","affix":"grieving"},{"id":85222,"name":"nadijehsclaymore","type":"greatsword","affix":"marshal"},{"id":85223,"name":"nadijehsbreastplate","type":"coat","affix":"marshal","weight":"heavy"},{"id":85224,"name":"nadijehsartifact","type":"focus","affix":"marshal"},{"id":85225,"name":"nadijehswarfists","type":"gloves","affix":"marshal","weight":"heavy"},{"id":85226,"name":"nadijehsshoulderguard","type":"shoulders","affix":"marshal","weight":"medium"},{"id":85228,"name":"zehtukaswarhammer","type":"hammer","affix":"harrier"},{"id":85233,"name":"nadijehsreaver","type":"axe","affix":"marshal"},{"id":85241,"name":"thetwinsepaulets","type":"shoulders","affix":"grieving","weight":"light"},{"id":85242,"name":"thetwinsshortbow","type":"shortbow","affix":"grieving"},{"id":85244,"name":"endlesschoyapinatatonic","type":"gizmo"},{"id":85249,"name":"thetwinswarhammer","type":"hammer","affix":"grieving"},{"id":85253,"name":"thetwinsreaver","type":"axe","affix":"grieving"},{"id":85254,"name":"thetwinsimpaler","type":"harpoon","affix":"grieving"},{"id":85266,"name":"thetwinsbastion","type":"shield","affix":"grieving"},{"id":85274,"name":"nadijehsvisor","type":"helm","affix":"marshal","weight":"heavy"},{"id":85285,"name":"nadijehsmasque","type":"helm","affix":"marshal","weight":"light"},{"id":85286,"name":"zehtukaspauldrons","type":"shoulders","affix":"harrier","weight":"heavy"},{"id":85288,"name":"nadijehsdoublet","type":"coat","affix":"marshal","weight":"light"},{"id":85293,"name":"nadijehsharpoongun","type":"speargun","affix":"marshal"},{"id":85295,"name":"thetwinsflangedmace","type":"mace","affix":"grieving"},{"id":85296,"name":"thetwinsmasque","type":"helm","affix":"grieving","weight":"light"},{"id":85300,"name":"thetwinswarfists","type":"gloves","affix":"grieving","weight":"heavy"},{"id":85308,"name":"thetwinsstriders","type":"boots","affix":"grieving","weight":"medium"},{"id":85317,"name":"zehtukasfootwear","type":"boots","affix":"harrier","weight":"light"},{"id":85319,"name":"thetwinsdoublet","type":"coat","affix":"grieving","weight":"light"},{"id":85324,"name":"thetwinsleggings","type":"leggings","affix":"grieving","weight":"medium"},{"id":85330,"name":"zehtukaswarfists","type":"gloves","affix":"harrier","weight":"heavy"},{"id":85335,"name":"nadijehspauldrons","type":"shoulders","affix":"marshal","weight":"heavy"},{"id":85342,"name":"nadijehsfootwear","type":"boots","affix":"marshal","weight":"light"},{"id":85343,"name":"zehtukasstriders","type":"boots","affix":"harrier","weight":"medium"},{"id":85345,"name":"zehtukastrident","type":"trident","affix":"harrier"},{"id":85346,"name":"zehtukasartifact","type":"focus","affix":"harrier"},{"id":85347,"name":"nadijehswarhammer","type":"hammer","affix":"marshal"},{"id":85348,"name":"zehtukasmusket","type":"rifle","affix":"harrier"},{"id":85350,"name":"thetwinsvisor","type":"helm","affix":"grieving","weight":"heavy"},{"id":85352,"name":"thetwinsbreeches","type":"leggings","affix":"grieving","weight":"light"},{"id":85355,"name":"thetwinspauldrons","type":"shoulders","affix":"grieving","weight":"heavy"},{"id":85356,"name":"nadijehsspire","type":"staff","affix":"marshal"},{"id":85357,"name":"nadijehsbastion","type":"shield","affix":"marshal"},{"id":85364,"name":"nadijehsimpaler","type":"harpoon","affix":"marshal"},{"id":85380,"name":"antonina","type":"scepter","affix":"sinister"},{"id":85406,"name":"sikandar","type":"mace","affix":"sinister"},{"id":85527,"name":"spellbreaker","type":"rune"},{"id":85559,"name":"renegade","type":"rune"},{"id":85573,"name":"deadeye","type":"rune"},{"id":85578,"name":"firebrand","type":"rune"},{"id":85588,"name":"weaver","type":"rune"},{"id":85602,"name":"mirage","type":"rune"},{"id":85606,"name":"soulbeast","type":"rune"},{"id":85617,"name":"holosmith","type":"rune"},{"id":85695,"name":"marshalsstellarharbinger","type":"warhorn","affix":"marshal"},{"id":85713,"name":"stars","type":"rune"},{"id":85755,"name":"marshalsstellaravenger","type":"greatsword","affix":"marshal"},{"id":85794,"name":"marshalsstellarscepter","type":"scepter","affix":"marshal"},{"id":85862,"name":"marshalsstellarknobkerrie","type":"mace","affix":"marshal"},{"id":85926,"name":"marshalsstellarspire","type":"staff","affix":"marshal"},{"id":85946,"name":"marshalsstellarcannon","type":"rifle","affix":"marshal"},{"id":86007,"name":"marshalsstellarbeacon","type":"torch","affix":"marshal"},{"id":86026,"name":"marshalsstellardisk","type":"shield","affix":"marshal"},{"id":86074,"name":"marshalsstellarshortbow","type":"shortbow","affix":"marshal"},{"id":86085,"name":"marshalsstellarrazor","type":"dagger","affix":"marshal"},{"id":86113,"name":"spitefulagonyinfusion","type":"infusion"},{"id":86170,"name":"stars","type":"sigil"},{"id":86178,"name":"marshalsstellarcleaver","type":"axe","affix":"marshal"},{"id":86180,"name":"mysticalagonyinfusion","type":"infusion"},{"id":86233,"name":"marshalsstellarlongbow","type":"longbow","affix":"marshal"},{"id":86279,"name":"marshalsstellarapparatus","type":"focus","affix":"marshal"},{"id":86300,"name":"marshalsstellarrevolver","type":"pistol","affix":"marshal"},{"id":86348,"name":"marshalsstellarkhopesh","type":"sword","affix":"marshal"},{"id":86354,"name":"marshalsstellarorrery","type":"hammer","affix":"marshal"},{"id":86389,"name":"giftbringersvisor","type":"helm","affix":"bringer","weight":"heavy"},{"id":86402,"name":"giftbringersgreatbow","type":"longbow","affix":"bringer"},{"id":86411,"name":"giftbringersgreaves","type":"boots","affix":"bringer","weight":"heavy"},{"id":86412,"name":"tixxsleggings","type":"leggings","affix":"giver","weight":"medium"},{"id":86420,"name":"tixxstrident","type":"trident","affix":"giver"},{"id":86422,"name":"tixxsfootwear","type":"boots","affix":"giver","weight":"light"},{"id":86434,"name":"giftbringerswarhammer","type":"hammer","affix":"bringer"},{"id":86435,"name":"giftbringersvisage","type":"helm","affix":"bringer","weight":"medium"},{"id":86439,"name":"tixxsbrazier","type":"torch","affix":"giver"},{"id":86440,"name":"tixxsherald","type":"warhorn","affix":"giver"},{"id":86443,"name":"tixxswand","type":"scepter","affix":"giver"},{"id":86444,"name":"tixxsreaver","type":"axe","affix":"giver"},{"id":86450,"name":"giftbringersblade","type":"sword","affix":"bringer"},{"id":86451,"name":"giftbringersflangedmace","type":"mace","affix":"bringer"},{"id":86460,"name":"giftbringersreaver","type":"axe","affix":"bringer"},{"id":86463,"name":"tixxsartifact","type":"focus","affix":"giver"},{"id":86471,"name":"tixxsbreeches","type":"leggings","affix":"giver","weight":"light"},{"id":86483,"name":"tixxsgreatbow","type":"longbow","affix":"giver"},{"id":86486,"name":"tixxsdoublet","type":"coat","affix":"giver","weight":"light"},{"id":86489,"name":"giftbringersharpoongun","type":"speargun","affix":"bringer"},{"id":86504,"name":"tixxsflangedmace","type":"mace","affix":"giver"},{"id":86505,"name":"tixxsbastion","type":"shield","affix":"giver"},{"id":86506,"name":"tixxsgrips","type":"gloves","affix":"giver","weight":"medium"},{"id":86510,"name":"giftbringersbreastplate","type":"coat","affix":"bringer","weight":"heavy"},{"id":86518,"name":"tixxswristguards","type":"gloves","affix":"giver","weight":"light"},{"id":86520,"name":"giftbringersfootwear","type":"boots","affix":"bringer","weight":"light"},{"id":86526,"name":"tixxsrevolver","type":"pistol","affix":"giver"},{"id":86530,"name":"giftbringerswand","type":"scepter","affix":"bringer"},{"id":86536,"name":"tixxsbreastplate","type":"coat","affix":"giver","weight":"heavy"},{"id":86541,"name":"tixxspauldrons","type":"shoulders","affix":"giver","weight":"heavy"},{"id":86542,"name":"giftbringersartifact","type":"focus","affix":"bringer"},{"id":86544,"name":"giftbringersguise","type":"coat","affix":"bringer","weight":"medium"},{"id":86548,"name":"tixxstassets","type":"leggings","affix":"giver","weight":"heavy"},{"id":86558,"name":"giftbringersbastion","type":"shield","affix":"bringer"},{"id":86561,"name":"tixxsspire","type":"staff","affix":"giver"},{"id":86564,"name":"tixxswarhammer","type":"hammer","affix":"giver"},{"id":86574,"name":"tixxsharpoongun","type":"speargun","affix":"giver"},{"id":86583,"name":"giftbringersrazor","type":"dagger","affix":"bringer"},{"id":86594,"name":"tixxsclaymore","type":"greatsword","affix":"giver"},{"id":86604,"name":"giftbringerspauldrons","type":"shoulders","affix":"bringer","weight":"heavy"},{"id":86610,"name":"giftbringersspire","type":"staff","affix":"bringer"},{"id":86620,"name":"giftbringersshoulderguard","type":"shoulders","affix":"bringer","weight":"medium"},{"id":86623,"name":"tixxsshoulderguard","type":"shoulders","affix":"giver","weight":"medium"},{"id":86628,"name":"giftbringersepaulets","type":"shoulders","affix":"bringer","weight":"light"},{"id":86629,"name":"giftbringerstassets","type":"leggings","affix":"bringer","weight":"heavy"},{"id":86632,"name":"giftbringersclaymore","type":"greatsword","affix":"bringer"},{"id":86633,"name":"giftbringersbreeches","type":"leggings","affix":"bringer","weight":"light"},{"id":86640,"name":"giftbringersbrazier","type":"torch","affix":"bringer"},{"id":86642,"name":"tixxsmasque","type":"helm","affix":"giver","weight":"light"},{"id":86648,"name":"tixxsvisage","type":"helm","affix":"giver","weight":"medium"},{"id":86650,"name":"tixxsepaulets","type":"shoulders","affix":"giver","weight":"light"},{"id":86653,"name":"giftbringersherald","type":"warhorn","affix":"bringer"},{"id":86662,"name":"tixxsblade","type":"sword","affix":"giver"},{"id":86668,"name":"tixxsmusket","type":"rifle","affix":"giver"},{"id":86670,"name":"giftbringersdoublet","type":"coat","affix":"bringer","weight":"light"},{"id":86671,"name":"giftbringersmasque","type":"helm","affix":"bringer","weight":"light"},{"id":86672,"name":"tixxsvisor","type":"helm","affix":"giver","weight":"heavy"},{"id":86673,"name":"giftbringersmusket","type":"rifle","affix":"bringer"},{"id":86681,"name":"giftbringersleggings","type":"leggings","affix":"bringer","weight":"medium"},{"id":86682,"name":"giftbringerstrident","type":"trident","affix":"bringer"},{"id":86684,"name":"tixxsguise","type":"coat","affix":"giver","weight":"medium"},{"id":86686,"name":"tixxsstriders","type":"boots","affix":"giver","weight":"medium"},{"id":86687,"name":"giftbringersrevolver","type":"pistol","affix":"bringer"},{"id":86688,"name":"tixxsimpaler","type":"harpoon","affix":"giver"},{"id":86689,"name":"tixxsrazor","type":"dagger","affix":"giver"},{"id":86691,"name":"giftbringerswristguards","type":"gloves","affix":"bringer","weight":"light"},{"id":86698,"name":"giftbringersimpaler","type":"harpoon","affix":"bringer"},{"id":86703,"name":"giftbringerswarfists","type":"gloves","affix":"bringer","weight":"heavy"},{"id":86706,"name":"tixxsshortbow","type":"shortbow","affix":"giver"},{"id":86707,"name":"giftbringersstriders","type":"boots","affix":"bringer","weight":"medium"},{"id":86709,"name":"giftbringersgrips","type":"gloves","affix":"bringer","weight":"medium"},{"id":86717,"name":"tixxswarfists","type":"gloves","affix":"giver","weight":"heavy"},{"id":86730,"name":"tixxsgreaves","type":"boots","affix":"giver","weight":"heavy"},{"id":86731,"name":"giftbringersshortbow","type":"shortbow","affix":"bringer"},{"id":87592,"name":"nerashisartifact","type":"focus","affix":"plaguedoctor"},{"id":87604,"name":"nerashisclaymore","type":"greatsword","affix":"plaguedoctor"},{"id":87605,"name":"nerashisreaver","type":"axe","affix":"plaguedoctor"},{"id":87608,"name":"nerashisbastion","type":"shield","affix":"plaguedoctor"},{"id":87629,"name":"nerashisstriders","type":"boots","affix":"plaguedoctor","weight":"medium"},{"id":87650,"name":"nerashisbreastplate","type":"coat","affix":"plaguedoctor","weight":"heavy"},{"id":87671,"name":"nerashiswarhammer","type":"hammer","affix":"plaguedoctor"},{"id":87696,"name":"nerashisfootwear","type":"boots","affix":"plaguedoctor","weight":"light"},{"id":87739,"name":"nerashisflangedmace","type":"mace","affix":"plaguedoctor"},{"id":87742,"name":"nerashisgreaves","type":"boots","affix":"plaguedoctor","weight":"heavy"},{"id":87751,"name":"nerashisgrips","type":"gloves","affix":"plaguedoctor","weight":"medium"},{"id":87784,"name":"nerashisimpaler","type":"harpoon","affix":"plaguedoctor"},{"id":87785,"name":"nerashisspire","type":"staff","affix":"plaguedoctor"},{"id":87805,"name":"nerashisvisage","type":"helm","affix":"plaguedoctor","weight":"medium"},{"id":87806,"name":"nerashisbreeches","type":"leggings","affix":"plaguedoctor","weight":"light"},{"id":87811,"name":"nerashisshortbow","type":"shortbow","affix":"plaguedoctor"},{"id":87823,"name":"nerashisrazor","type":"dagger","affix":"plaguedoctor"},{"id":87857,"name":"nerashiswand","type":"scepter","affix":"plaguedoctor"},{"id":87858,"name":"nerashisbrazier","type":"torch","affix":"plaguedoctor"},{"id":87859,"name":"nerashisshoulderguard","type":"shoulders","affix":"plaguedoctor","weight":"medium"},{"id":87860,"name":"scarabchoker","type":"amulet","affix":"plaguedoctor"},{"id":87866,"name":"nerashisgreatbow","type":"longbow","affix":"plaguedoctor"},{"id":87873,"name":"tarnishedkournancoin","type":"accessory","affix":"plaguedoctor"},{"id":87884,"name":"attunedlonaissignetringinfused","type":"ring","affix":"plaguedoctor"},{"id":87885,"name":"nerashisblade","type":"sword","affix":"plaguedoctor"},{"id":87887,"name":"nerashiswarfists","type":"gloves","affix":"plaguedoctor","weight":"heavy"},{"id":87898,"name":"nerashisherald","type":"warhorn","affix":"plaguedoctor"},{"id":87948,"name":"nerashistrident","type":"trident","affix":"plaguedoctor"},{"id":87956,"name":"nerashismusket","type":"rifle","affix":"plaguedoctor"},{"id":87960,"name":"nerashiswristguards","type":"gloves","affix":"plaguedoctor","weight":"light"},{"id":87977,"name":"nerashisdoublet","type":"coat","affix":"plaguedoctor","weight":"light"},{"id":87985,"name":"nerashisguise","type":"coat","affix":"plaguedoctor","weight":"medium"},{"id":87994,"name":"nerashisharpoongun","type":"speargun","affix":"plaguedoctor"},{"id":88003,"name":"nerashistassets","type":"leggings","affix":"plaguedoctor","weight":"heavy"},{"id":88022,"name":"nerashismasque","type":"helm","affix":"plaguedoctor","weight":"light"},{"id":88025,"name":"nerashisleggings","type":"leggings","affix":"plaguedoctor","weight":"medium"},{"id":88047,"name":"nerashisrevolver","type":"pistol","affix":"plaguedoctor"},{"id":88073,"name":"nerashispauldrons","type":"shoulders","affix":"plaguedoctor","weight":"heavy"},{"id":88085,"name":"nerashisepaulets","type":"shoulders","affix":"plaguedoctor","weight":"light"},{"id":88105,"name":"nerashisvisor","type":"helm","affix":"plaguedoctor","weight":"heavy"},{"id":88118,"name":"zephyrite","type":"rune"},{"id":88370,"name":"svaardsleatherbreather","type":"helmaquatic","affix":"marauder","weight":"medium"},{"id":88371,"name":"tizlaksclothbreather","type":"helmaquatic","affix":"commander","weight":"light"},{"id":88373,"name":"ossasclothbreather","type":"helmaquatic","affix":"crusader","weight":"light"},{"id":88376,"name":"yassithsmetalbreather","type":"helmaquatic","affix":"viper","weight":"heavy"},{"id":88380,"name":"pahuasmetalbreather","type":"helmaquatic","affix":"trailblazer","weight":"heavy"},{"id":88392,"name":"svaardsclothbreather","type":"helmaquatic","affix":"marauder","weight":"light"},{"id":88400,"name":"yassithsclothbreather","type":"helmaquatic","affix":"viper","weight":"light"},{"id":88405,"name":"pahuasclothbreather","type":"helmaquatic","affix":"trailblazer","weight":"light"},{"id":88410,"name":"svaardsmetalbreather","type":"helmaquatic","affix":"marauder","weight":"heavy"},{"id":88413,"name":"rukasclothbreather","type":"helmaquatic","affix":"wanderer","weight":"light"},{"id":88418,"name":"ossasmetalbreather","type":"helmaquatic","affix":"crusader","weight":"heavy"},{"id":88419,"name":"ossasleatherbreather","type":"helmaquatic","affix":"crusader","weight":"medium"},{"id":88420,"name":"yassithsleatherbreather","type":"helmaquatic","affix":"viper","weight":"medium"},{"id":88422,"name":"tizlaksleatherbreather","type":"helmaquatic","affix":"commander","weight":"medium"},{"id":88424,"name":"pahuasleatherbreather","type":"helmaquatic","affix":"trailblazer","weight":"medium"},{"id":88427,"name":"maklainsclothbreather","type":"helmaquatic","affix":"minstrel","weight":"light"},{"id":88429,"name":"laranthirsmetalbreather","type":"helmaquatic","affix":"vigilant","weight":"heavy"},{"id":88432,"name":"thackeraysleatherbreather","type":"helmaquatic","affix":"seraph","weight":"medium"},{"id":88440,"name":"thackeraysmetalbreather","type":"helmaquatic","affix":"seraph","weight":"heavy"},{"id":88443,"name":"maklainsleatherbreather","type":"helmaquatic","affix":"minstrel","weight":"medium"},{"id":88445,"name":"maklainsmetalbreather","type":"helmaquatic","affix":"minstrel","weight":"heavy"},{"id":88452,"name":"rukasleatherbreather","type":"helmaquatic","affix":"wanderer","weight":"medium"},{"id":88455,"name":"laranthirsleatherbreather","type":"helmaquatic","affix":"vigilant","weight":"medium"},{"id":88458,"name":"laranthirsclothbreather","type":"helmaquatic","affix":"vigilant","weight":"light"},{"id":88463,"name":"rukasmetalbreather","type":"helmaquatic","affix":"wanderer","weight":"heavy"},{"id":88466,"name":"thackeraysclothbreather","type":"helmaquatic","affix":"seraph","weight":"light"},{"id":88467,"name":"tizlaksmetalbreather","type":"helmaquatic","affix":"commander","weight":"heavy"},{"id":89441,"name":"heroicdragonsbloodshield","type":"shield","affix":"diviner"},{"id":89446,"name":"heroicdragonsbloodstaff","type":"staff","affix":"diviner"},{"id":89452,"name":"steelstarsfootwear","type":"boots","affix":"diviner","weight":"light"},{"id":89460,"name":"steelstarstassets","type":"leggings","affix":"diviner","weight":"heavy"},{"id":89461,"name":"dragoncrystalpotion","type":"utility"},{"id":89484,"name":"steelstarswand","type":"scepter","affix":"diviner"},{"id":89495,"name":"heroicdragonsbloodscepter","type":"scepter","affix":"diviner"},{"id":89503,"name":"heroicdragonsbloodlongbow","type":"longbow","affix":"diviner"},{"id":89528,"name":"steelstarsguise","type":"coat","affix":"diviner","weight":"medium"},{"id":89544,"name":"dagnarsbadge","type":"accessory","affix":"diviner"},{"id":89566,"name":"heroicdragonsbloodsword","type":"sword","affix":"diviner"},{"id":89592,"name":"heroicdragonsbloodwarhorn","type":"warhorn","affix":"diviner"},{"id":89610,"name":"steelstarsimpaler","type":"harpoon","affix":"diviner"},{"id":89612,"name":"steelstarsbrazier","type":"torch","affix":"diviner"},{"id":89624,"name":"steelstarsherald","type":"warhorn","affix":"diviner"},{"id":89628,"name":"steelstarsepaulets","type":"shoulders","affix":"diviner","weight":"light"},{"id":89632,"name":"heroicdragonsbloodaxe","type":"axe","affix":"diviner"},{"id":89645,"name":"steelstarsblade","type":"sword","affix":"diviner"},{"id":89647,"name":"heroicdragonsbloodpistol","type":"pistol","affix":"diviner"},{"id":89656,"name":"steelstarsgreaves","type":"boots","affix":"diviner","weight":"heavy"},{"id":89681,"name":"steelstarsgreatbow","type":"longbow","affix":"diviner"},{"id":89706,"name":"steelstarsclaymore","type":"greatsword","affix":"diviner"},{"id":89707,"name":"steelstarsflangedmace","type":"mace","affix":"diviner"},{"id":89716,"name":"steelstarsrevolver","type":"pistol","affix":"diviner"},{"id":89733,"name":"steelstarsbreastplate","type":"coat","affix":"diviner","weight":"heavy"},{"id":89736,"name":"steelstarsmusket","type":"rifle","affix":"diviner"},{"id":89741,"name":"heroicdragonsbloodtorch","type":"torch","affix":"diviner"},{"id":89759,"name":"frodakssteelstar","type":"amulet","affix":"diviner"},{"id":89768,"name":"steelstarsdoublet","type":"coat","affix":"diviner","weight":"light"},{"id":89773,"name":"steelstarswarhammer","type":"hammer","affix":"diviner"},{"id":89785,"name":"steelstarspauldrons","type":"shoulders","affix":"diviner","weight":"heavy"},{"id":89787,"name":"heroicdragonsblooddagger","type":"dagger","affix":"diviner"},{"id":89789,"name":"steelstarsshoulderguard","type":"shoulders","affix":"diviner","weight":"medium"},{"id":89791,"name":"heroicdragonsbloodrifle","type":"rifle","affix":"diviner"},{"id":89799,"name":"steelstarsreaver","type":"axe","affix":"diviner"},{"id":89810,"name":"steelstarsharpoongun","type":"speargun","affix":"diviner"},{"id":89821,"name":"heroicdragonsbloodfocus","type":"focus","affix":"diviner"},{"id":89822,"name":"steelstarswarfists","type":"gloves","affix":"diviner","weight":"heavy"},{"id":89826,"name":"heroicdragonsbloodshortbow","type":"shortbow","affix":"diviner"},{"id":89842,"name":"heroicdragonsbloodhammer","type":"hammer","affix":"diviner"},{"id":89846,"name":"steelstarsartifact","type":"focus","affix":"diviner"},{"id":89848,"name":"heroicdragonsbloodmace","type":"mace","affix":"diviner"},{"id":89879,"name":"heroicdragonsbloodgreatsword","type":"greatsword","affix":"diviner"},{"id":89893,"name":"steelstarsstriders","type":"boots","affix":"diviner","weight":"medium"},{"id":89904,"name":"steelstarstrident","type":"trident","affix":"diviner"},{"id":89906,"name":"steelstarsrazor","type":"dagger","affix":"diviner"},{"id":89912,"name":"steelstarsmasque","type":"helm","affix":"diviner","weight":"light"},{"id":89922,"name":"steelstarsbastion","type":"shield","affix":"diviner"},{"id":89924,"name":"steelstarsvisor","type":"helm","affix":"diviner","weight":"heavy"},{"id":89925,"name":"steelstarswristguards","type":"gloves","affix":"diviner","weight":"light"},{"id":89934,"name":"steelstarsleggings","type":"leggings","affix":"diviner","weight":"medium"},{"id":89940,"name":"steelstarsbreeches","type":"leggings","affix":"diviner","weight":"light"},{"id":89945,"name":"steelstarsspire","type":"staff","affix":"diviner"},{"id":89949,"name":"steelstarsshortbow","type":"shortbow","affix":"diviner"},{"id":89969,"name":"steelstarsvisage","type":"helm","affix":"diviner","weight":"medium"},{"id":89985,"name":"steelstarsgrips","type":"gloves","affix":"diviner","weight":"medium"},{"id":89999,"name":"fireworks","type":"rune"},{"id":91289,"name":"powerfulpotionofbrandedslaying","type":"utility"},{"id":91339,"name":"hologramslaying","type":"sigil"},{"id":91350,"name":"powerfulpotionofmordremslaying","type":"utility"},{"id":94709,"name":"vipersfierydragonslayerfocusoficebroodslaying","type":"focus","affix":"viper"},{"id":94711,"name":"vipersfierydragonslayertorchoficebroodslaying","type":"torch","affix":"viper"},{"id":94716,"name":"vipersfierydragonslayeraxeoficebroodslaying","type":"axe","affix":"viper"},{"id":94721,"name":"vipersfierydragonslayerpistoloficebroodslaying","type":"pistol","affix":"viper"},{"id":94724,"name":"maraudericydragonslayerwarhornofdestroyerslaying","type":"warhorn","affix":"marauder"},{"id":94733,"name":"vipersfierydragonslayerlongbowoficebroodslaying","type":"longbow","affix":"viper"},{"id":94736,"name":"maraudericydragonslayerpistolofdestroyerslaying","type":"pistol","affix":"marauder"},{"id":94738,"name":"maraudericydragonslayeraxeofdestroyerslaying","type":"axe","affix":"marauder"},{"id":94745,"name":"maraudericydragonslayerscepterofdestroyerslaying","type":"scepter","affix":"marauder"},{"id":94747,"name":"maraudericydragonslayerfocusofdestroyerslaying","type":"focus","affix":"marauder"},{"id":94754,"name":"vipersfierydragonslayershortbowoficebroodslaying","type":"shortbow","affix":"viper"},{"id":94763,"name":"vipersfierydragonslayershieldoficebroodslaying","type":"shield","affix":"viper"},{"id":94764,"name":"maraudericydragonslayerdaggerofdestroyerslaying","type":"dagger","affix":"marauder"},{"id":94775,"name":"vipersfierydragonslayerdaggeroficebroodslaying","type":"dagger","affix":"viper"},{"id":94781,"name":"maraudericydragonslayershieldofdestroyerslaying","type":"shield","affix":"marauder"},{"id":94785,"name":"vipersfierydragonslayerwarhornoficebroodslaying","type":"warhorn","affix":"viper"},{"id":94787,"name":"maraudericydragonslayerstaffofdestroyerslaying","type":"staff","affix":"marauder"},{"id":94788,"name":"vipersfierydragonslayerhammeroficebroodslaying","type":"hammer","affix":"viper"},{"id":94789,"name":"maraudericydragonslayermaceofdestroyerslaying","type":"mace","affix":"marauder"},{"id":94793,"name":"maraudericydragonslayerrifleofdestroyerslaying","type":"rifle","affix":"marauder"},{"id":94796,"name":"vipersfierydragonslayerrifleoficebroodslaying","type":"rifle","affix":"viper"},{"id":94812,"name":"maraudericydragonslayerswordofdestroyerslaying","type":"sword","affix":"marauder"},{"id":94815,"name":"maraudericydragonslayergreatswordofdestroyerslaying","type":"greatsword","affix":"marauder"},{"id":94818,"name":"vipersfierydragonslayerscepteroficebroodslaying","type":"scepter","affix":"viper"},{"id":94821,"name":"maraudericydragonslayershortbowofdestroyerslaying","type":"shortbow","affix":"marauder"},{"id":94822,"name":"maraudericydragonslayerhammerofdestroyerslaying","type":"hammer","affix":"marauder"},{"id":94826,"name":"maraudericydragonslayertorchofdestroyerslaying","type":"torch","affix":"marauder"},{"id":94841,"name":"vipersfierydragonslayermaceoficebroodslaying","type":"mace","affix":"viper"},{"id":94843,"name":"vipersfierydragonslayerswordoficebroodslaying","type":"sword","affix":"viper"},{"id":94857,"name":"vipersfierydragonslayergreatswordoficebroodslaying","type":"greatsword","affix":"viper"},{"id":94861,"name":"maraudericydragonslayerlongbowofdestroyerslaying","type":"longbow","affix":"marauder"},{"id":94865,"name":"vipersfierydragonslayerstaffoficebroodslaying","type":"staff","affix":"viper"},{"id":95013,"name":"fractaltroubleshootersstar","type":"accessory","affix":"berserkerandvalkyrie"},{"id":95071,"name":"plushprimo","type":"accessory","affix":"marauder"}]
+[
+  {
+    "id": 8664,
+    "name": "metalrod",
+    "type": "generic"
+  },
+  {
+    "id": 8678,
+    "name": "rock",
+    "type": "generic"
+  },
+  {
+    "id": 8686,
+    "name": "ashlegionspykit",
+    "type": "generic"
+  },
+  {
+    "id": 8732,
+    "name": "powermatrix",
+    "type": "generic"
+  },
+  {
+    "id": 8759,
+    "name": "woodenplank",
+    "type": "generic"
+  },
+  {
+    "id": 8764,
+    "name": "harpyfeathers",
+    "type": "generic"
+  },
+  {
+    "id": 8801,
+    "name": "orderofwhispersspykit",
+    "type": "generic"
+  },
+  {
+    "id": 8879,
+    "name": "powerfulpotionofflamelegionslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8880,
+    "name": "powerfulpotionofcentaurslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8881,
+    "name": "powerfulpotionofoutlawslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8882,
+    "name": "powerfulpotionofnightmarecourtslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8883,
+    "name": "powerfulpotionofsonsofsvanirslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8884,
+    "name": "powerfulpotionofdestroyerslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8885,
+    "name": "powerfulpotionofelementalslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8886,
+    "name": "powerfulpotionofdemonslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8887,
+    "name": "powerfulpotionofinquestslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8888,
+    "name": "powerfulpotionofogreslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8889,
+    "name": "powerfulpotionoficebroodslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8890,
+    "name": "powerfulpotionofgrawlslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8891,
+    "name": "powerfulpotionofkraitslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8892,
+    "name": "powerfulpotionofdredgeslaying",
+    "type": "utility"
+  },
+  {
+    "id": 8893,
+    "name": "powerfulpotionofundeadslaying",
+    "type": "utility"
+  },
+  {
+    "id": 9443,
+    "name": "superiorsharpeningstone",
+    "type": "utility"
+  },
+  {
+    "id": 9461,
+    "name": "mastermaintenanceoil",
+    "type": "utility"
+  },
+  {
+    "id": 9476,
+    "name": "mastertuningcrystal",
+    "type": "utility"
+  },
+  {
+    "id": 12452,
+    "name": "omnomberrybar",
+    "type": "food"
+  },
+  {
+    "id": 12453,
+    "name": "chocolateomnomberrycream",
+    "type": "food"
+  },
+  {
+    "id": 12454,
+    "name": "spicychocolatecookie",
+    "type": "food"
+  },
+  {
+    "id": 12455,
+    "name": "omnomberrycookie",
+    "type": "food"
+  },
+  {
+    "id": 12456,
+    "name": "mangopie",
+    "type": "food"
+  },
+  {
+    "id": 12457,
+    "name": "omnomberrypie",
+    "type": "food"
+  },
+  {
+    "id": 12458,
+    "name": "omnomberrycompote",
+    "type": "food"
+  },
+  {
+    "id": 12459,
+    "name": "omnomberrytart",
+    "type": "food"
+  },
+  {
+    "id": 12460,
+    "name": "chocolateomnomberrycake",
+    "type": "food"
+  },
+  {
+    "id": 12461,
+    "name": "bowloftruffleravioli",
+    "type": "food"
+  },
+  {
+    "id": 12462,
+    "name": "plateoflemongrasspoultry",
+    "type": "food"
+  },
+  {
+    "id": 12463,
+    "name": "fancytruffleburger",
+    "type": "food"
+  },
+  {
+    "id": 12464,
+    "name": "rareveggiepizza",
+    "type": "food"
+  },
+  {
+    "id": 12465,
+    "name": "bowloftrufflerisotto",
+    "type": "food"
+  },
+  {
+    "id": 12466,
+    "name": "plateoffireflanksteak",
+    "type": "food"
+  },
+  {
+    "id": 12467,
+    "name": "plateoftrufflesteak",
+    "type": "food"
+  },
+  {
+    "id": 12468,
+    "name": "plateoforriansteakfrittes",
+    "type": "food"
+  },
+  {
+    "id": 12469,
+    "name": "plateoftrufflesteakdinner",
+    "type": "food"
+  },
+  {
+    "id": 12470,
+    "name": "bowloflotusstirfry",
+    "type": "food"
+  },
+  {
+    "id": 12471,
+    "name": "bowlofseaweedsalad",
+    "type": "food"
+  },
+  {
+    "id": 12472,
+    "name": "cupoflotusfries",
+    "type": "food"
+  },
+  {
+    "id": 12473,
+    "name": "loafofomnomberrybread",
+    "type": "food"
+  },
+  {
+    "id": 12474,
+    "name": "loafofsaffronbread",
+    "type": "food"
+  },
+  {
+    "id": 12475,
+    "name": "bowlofroastedlotusroot",
+    "type": "food"
+  },
+  {
+    "id": 12476,
+    "name": "saffronstuffedmushroom",
+    "type": "food"
+  },
+  {
+    "id": 12477,
+    "name": "bowloffiresalsa",
+    "type": "food"
+  },
+  {
+    "id": 12478,
+    "name": "bowloftrufflesautee",
+    "type": "food"
+  },
+  {
+    "id": 12479,
+    "name": "ghostpepperpopper",
+    "type": "food"
+  },
+  {
+    "id": 12480,
+    "name": "bowlofsaffronscentedpoultrysoup",
+    "type": "food"
+  },
+  {
+    "id": 12481,
+    "name": "bowloflemongrasspoultrysoup",
+    "type": "food"
+  },
+  {
+    "id": 12482,
+    "name": "bowloforriantrufflesoup",
+    "type": "food"
+  },
+  {
+    "id": 12483,
+    "name": "bowloffireveggiechili",
+    "type": "food"
+  },
+  {
+    "id": 12484,
+    "name": "bowloffiremeatchili",
+    "type": "food"
+  },
+  {
+    "id": 12485,
+    "name": "bowloffancypotatoandleeksoup",
+    "type": "food"
+  },
+  {
+    "id": 12486,
+    "name": "bowlofcurrybutternutsquashsoup",
+    "type": "food"
+  },
+  {
+    "id": 12487,
+    "name": "bowlofcurrypumpkinsoup",
+    "type": "food"
+  },
+  {
+    "id": 12488,
+    "name": "bowloforriantruffleandmeatstew",
+    "type": "food"
+  },
+  {
+    "id": 24548,
+    "name": "fire",
+    "type": "sigil"
+  },
+  {
+    "id": 24551,
+    "name": "water",
+    "type": "sigil"
+  },
+  {
+    "id": 24554,
+    "name": "air",
+    "type": "sigil"
+  },
+  {
+    "id": 24555,
+    "name": "ice",
+    "type": "sigil"
+  },
+  {
+    "id": 24560,
+    "name": "earth",
+    "type": "sigil"
+  },
+  {
+    "id": 24561,
+    "name": "rage",
+    "type": "sigil"
+  },
+  {
+    "id": 24562,
+    "name": "strength",
+    "type": "sigil"
+  },
+  {
+    "id": 24567,
+    "name": "frailty",
+    "type": "sigil"
+  },
+  {
+    "id": 24570,
+    "name": "blood",
+    "type": "sigil"
+  },
+  {
+    "id": 24571,
+    "name": "purity",
+    "type": "sigil"
+  },
+  {
+    "id": 24572,
+    "name": "nullification",
+    "type": "sigil"
+  },
+  {
+    "id": 24575,
+    "name": "bloodlust",
+    "type": "sigil"
+  },
+  {
+    "id": 24578,
+    "name": "corruption",
+    "type": "sigil"
+  },
+  {
+    "id": 24580,
+    "name": "perception",
+    "type": "sigil"
+  },
+  {
+    "id": 24582,
+    "name": "life",
+    "type": "sigil"
+  },
+  {
+    "id": 24583,
+    "name": "demons",
+    "type": "sigil"
+  },
+  {
+    "id": 24584,
+    "name": "benevolence",
+    "type": "sigil"
+  },
+  {
+    "id": 24589,
+    "name": "speed",
+    "type": "sigil"
+  },
+  {
+    "id": 24591,
+    "name": "luck",
+    "type": "sigil"
+  },
+  {
+    "id": 24592,
+    "name": "stamina",
+    "type": "sigil"
+  },
+  {
+    "id": 24594,
+    "name": "restoration",
+    "type": "sigil"
+  },
+  {
+    "id": 24597,
+    "name": "hydromancy",
+    "type": "sigil"
+  },
+  {
+    "id": 24599,
+    "name": "leeching",
+    "type": "sigil"
+  },
+  {
+    "id": 24600,
+    "name": "vision",
+    "type": "sigil"
+  },
+  {
+    "id": 24601,
+    "name": "battle",
+    "type": "sigil"
+  },
+  {
+    "id": 24605,
+    "name": "geomancy",
+    "type": "sigil"
+  },
+  {
+    "id": 24607,
+    "name": "energy",
+    "type": "sigil"
+  },
+  {
+    "id": 24609,
+    "name": "doom",
+    "type": "sigil"
+  },
+  {
+    "id": 24612,
+    "name": "agony",
+    "type": "sigil"
+  },
+  {
+    "id": 24615,
+    "name": "force",
+    "type": "sigil"
+  },
+  {
+    "id": 24618,
+    "name": "accuracy",
+    "type": "sigil"
+  },
+  {
+    "id": 24621,
+    "name": "peril",
+    "type": "sigil"
+  },
+  {
+    "id": 24624,
+    "name": "smoldering",
+    "type": "sigil"
+  },
+  {
+    "id": 24627,
+    "name": "hobbling",
+    "type": "sigil"
+  },
+  {
+    "id": 24630,
+    "name": "chilling",
+    "type": "sigil"
+  },
+  {
+    "id": 24632,
+    "name": "venom",
+    "type": "sigil"
+  },
+  {
+    "id": 24636,
+    "name": "debility",
+    "type": "sigil"
+  },
+  {
+    "id": 24639,
+    "name": "paralyzation",
+    "type": "sigil"
+  },
+  {
+    "id": 24642,
+    "name": "undeadslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24645,
+    "name": "centaurslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24648,
+    "name": "grawlslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24651,
+    "name": "icebroodslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24654,
+    "name": "destroyerslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24655,
+    "name": "ogreslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24658,
+    "name": "serpentslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24661,
+    "name": "elementalslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24664,
+    "name": "demonslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24667,
+    "name": "wrath",
+    "type": "sigil"
+  },
+  {
+    "id": 24672,
+    "name": "madscientists",
+    "type": "sigil"
+  },
+  {
+    "id": 24675,
+    "name": "smoring",
+    "type": "sigil"
+  },
+  {
+    "id": 24678,
+    "name": "justice",
+    "type": "sigil"
+  },
+  {
+    "id": 24681,
+    "name": "dreams",
+    "type": "sigil"
+  },
+  {
+    "id": 24684,
+    "name": "sorrow",
+    "type": "sigil"
+  },
+  {
+    "id": 24687,
+    "name": "afflicted",
+    "type": "rune"
+  },
+  {
+    "id": 24688,
+    "name": "lich",
+    "type": "rune"
+  },
+  {
+    "id": 24691,
+    "name": "traveler",
+    "type": "rune"
+  },
+  {
+    "id": 24696,
+    "name": "flock",
+    "type": "rune"
+  },
+  {
+    "id": 24699,
+    "name": "dolyak",
+    "type": "rune"
+  },
+  {
+    "id": 24702,
+    "name": "pack",
+    "type": "rune"
+  },
+  {
+    "id": 24703,
+    "name": "infiltration",
+    "type": "rune"
+  },
+  {
+    "id": 24708,
+    "name": "mercy",
+    "type": "rune"
+  },
+  {
+    "id": 24711,
+    "name": "vampirism",
+    "type": "rune"
+  },
+  {
+    "id": 24714,
+    "name": "strength",
+    "type": "rune"
+  },
+  {
+    "id": 24717,
+    "name": "rage",
+    "type": "rune"
+  },
+  {
+    "id": 24720,
+    "name": "speed",
+    "type": "rune"
+  },
+  {
+    "id": 24723,
+    "name": "eagle",
+    "type": "rune"
+  },
+  {
+    "id": 24726,
+    "name": "ratasum",
+    "type": "rune"
+  },
+  {
+    "id": 24729,
+    "name": "hoelbrak",
+    "type": "rune"
+  },
+  {
+    "id": 24732,
+    "name": "divinity",
+    "type": "rune"
+  },
+  {
+    "id": 24735,
+    "name": "grove",
+    "type": "rune"
+  },
+  {
+    "id": 24738,
+    "name": "scavenging",
+    "type": "rune"
+  },
+  {
+    "id": 24741,
+    "name": "citadel",
+    "type": "rune"
+  },
+  {
+    "id": 24744,
+    "name": "earth",
+    "type": "rune"
+  },
+  {
+    "id": 24747,
+    "name": "fire",
+    "type": "rune"
+  },
+  {
+    "id": 24750,
+    "name": "air",
+    "type": "rune"
+  },
+  {
+    "id": 24753,
+    "name": "ice",
+    "type": "rune"
+  },
+  {
+    "id": 24756,
+    "name": "ogre",
+    "type": "rune"
+  },
+  {
+    "id": 24757,
+    "name": "undead",
+    "type": "rune"
+  },
+  {
+    "id": 24762,
+    "name": "krait",
+    "type": "rune"
+  },
+  {
+    "id": 24765,
+    "name": "balthazar",
+    "type": "rune"
+  },
+  {
+    "id": 24768,
+    "name": "dwayna",
+    "type": "rune"
+  },
+  {
+    "id": 24771,
+    "name": "melandru",
+    "type": "rune"
+  },
+  {
+    "id": 24776,
+    "name": "lyssa",
+    "type": "rune"
+  },
+  {
+    "id": 24779,
+    "name": "grenth",
+    "type": "rune"
+  },
+  {
+    "id": 24782,
+    "name": "privateer",
+    "type": "rune"
+  },
+  {
+    "id": 24785,
+    "name": "golemancer",
+    "type": "rune"
+  },
+  {
+    "id": 24788,
+    "name": "centaur",
+    "type": "rune"
+  },
+  {
+    "id": 24791,
+    "name": "wurm",
+    "type": "rune"
+  },
+  {
+    "id": 24794,
+    "name": "svanir",
+    "type": "rune"
+  },
+  {
+    "id": 24797,
+    "name": "flamelegion",
+    "type": "rune"
+  },
+  {
+    "id": 24800,
+    "name": "elementalist",
+    "type": "rune"
+  },
+  {
+    "id": 24803,
+    "name": "mesmer",
+    "type": "rune"
+  },
+  {
+    "id": 24806,
+    "name": "necromancer",
+    "type": "rune"
+  },
+  {
+    "id": 24809,
+    "name": "ghostslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 24812,
+    "name": "engineer",
+    "type": "rune"
+  },
+  {
+    "id": 24815,
+    "name": "ranger",
+    "type": "rune"
+  },
+  {
+    "id": 24818,
+    "name": "thief",
+    "type": "rune"
+  },
+  {
+    "id": 24821,
+    "name": "warrior",
+    "type": "rune"
+  },
+  {
+    "id": 24824,
+    "name": "guardian",
+    "type": "rune"
+  },
+  {
+    "id": 24827,
+    "name": "trooper",
+    "type": "rune"
+  },
+  {
+    "id": 24830,
+    "name": "adventurer",
+    "type": "rune"
+  },
+  {
+    "id": 24833,
+    "name": "brawler",
+    "type": "rune"
+  },
+  {
+    "id": 24836,
+    "name": "scholar",
+    "type": "rune"
+  },
+  {
+    "id": 24839,
+    "name": "water",
+    "type": "rune"
+  },
+  {
+    "id": 24842,
+    "name": "monk",
+    "type": "rune"
+  },
+  {
+    "id": 24845,
+    "name": "aristocracy",
+    "type": "rune"
+  },
+  {
+    "id": 24848,
+    "name": "nightmare",
+    "type": "rune"
+  },
+  {
+    "id": 24851,
+    "name": "forgeman",
+    "type": "rune"
+  },
+  {
+    "id": 24854,
+    "name": "baelfire",
+    "type": "rune"
+  },
+  {
+    "id": 24857,
+    "name": "sanctuary",
+    "type": "rune"
+  },
+  {
+    "id": 24860,
+    "name": "orr",
+    "type": "rune"
+  },
+  {
+    "id": 24865,
+    "name": "celerity",
+    "type": "sigil"
+  },
+  {
+    "id": 24868,
+    "name": "impact",
+    "type": "sigil"
+  },
+  {
+    "id": 36044,
+    "name": "madking",
+    "type": "rune"
+  },
+  {
+    "id": 36053,
+    "name": "night",
+    "type": "sigil"
+  },
+  {
+    "id": 36083,
+    "name": "omnomberryghost",
+    "type": "food"
+  },
+  {
+    "id": 36084,
+    "name": "spicypumpkincookie",
+    "type": "food"
+  },
+  {
+    "id": 36092,
+    "name": "powerfulpotionofhalloweenslaying",
+    "type": "utility"
+  },
+  {
+    "id": 36793,
+    "name": "bowloftropicalfruitsalad",
+    "type": "food"
+  },
+  {
+    "id": 36841,
+    "name": "bowloftropicalmousse",
+    "type": "food"
+  },
+  {
+    "id": 37039,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "berserker"
+  },
+  {
+    "id": 37062,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "cavalier"
+  },
+  {
+    "id": 37125,
+    "name": "healingagonyinfusion",
+    "type": "infusion"
+  },
+  {
+    "id": 37130,
+    "name": "malignagonyinfusion",
+    "type": "infusion"
+  },
+  {
+    "id": 37131,
+    "name": "mightyagonyinfusion",
+    "type": "infusion"
+  },
+  {
+    "id": 37132,
+    "name": "preciseagonyinfusion",
+    "type": "infusion"
+  },
+  {
+    "id": 37135,
+    "name": "resilientagonyinfusion",
+    "type": "infusion"
+  },
+  {
+    "id": 37136,
+    "name": "vitalagonyinfusion",
+    "type": "infusion"
+  },
+  {
+    "id": 37912,
+    "name": "karkaslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 38206,
+    "name": "altruism",
+    "type": "rune"
+  },
+  {
+    "id": 38210,
+    "name": "bowlofsaffronmangoicecream",
+    "type": "food"
+  },
+  {
+    "id": 38294,
+    "name": "generosity",
+    "type": "sigil"
+  },
+  {
+    "id": 39224,
+    "name": "durmandspen",
+    "type": "accessory",
+    "affix": "soldier"
+  },
+  {
+    "id": 39225,
+    "name": "goldenrelicofrin",
+    "type": "accessory",
+    "affix": "soldier"
+  },
+  {
+    "id": 39228,
+    "name": "halfmadsmug",
+    "type": "accessory",
+    "affix": "cavalier"
+  },
+  {
+    "id": 39229,
+    "name": "applesellersluckycog",
+    "type": "accessory",
+    "affix": "cavalier"
+  },
+  {
+    "id": 39230,
+    "name": "marrinersflask",
+    "type": "accessory",
+    "affix": "rabid"
+  },
+  {
+    "id": 39231,
+    "name": "fierceshotsarrowhead",
+    "type": "accessory",
+    "affix": "rabid"
+  },
+  {
+    "id": 39232,
+    "name": "magistersfieldjournal",
+    "type": "accessory",
+    "affix": "berserker"
+  },
+  {
+    "id": 39233,
+    "name": "altheasashes",
+    "type": "accessory",
+    "affix": "berserker"
+  },
+  {
+    "id": 39234,
+    "name": "plagueidol",
+    "type": "accessory",
+    "affix": "direandrabid"
+  },
+  {
+    "id": 39235,
+    "name": "matriarchsquill",
+    "type": "accessory",
+    "affix": "direandrabid"
+  },
+  {
+    "id": 39236,
+    "name": "zinnsdatacrystal",
+    "type": "accessory",
+    "affix": "berserkerandvalkyrie"
+  },
+  {
+    "id": 39237,
+    "name": "experimentzx",
+    "type": "accessory",
+    "affix": "berserkerandvalkyrie"
+  },
+  {
+    "id": 39238,
+    "name": "imperialchefyilengsgoldenspoon",
+    "type": "accessory",
+    "affix": "rabidandapothecary"
+  },
+  {
+    "id": 39239,
+    "name": "gargoyleskull",
+    "type": "accessory",
+    "affix": "rabidandapothecary"
+  },
+  {
+    "id": 39242,
+    "name": "celestialsigil",
+    "type": "accessory",
+    "affix": "celestial"
+  },
+  {
+    "id": 39243,
+    "name": "ancientmursaattoken",
+    "type": "accessory",
+    "affix": "celestial"
+  },
+  {
+    "id": 39264,
+    "name": "thackerayfamilycrest",
+    "type": "amulet",
+    "affix": "soldier"
+  },
+  {
+    "id": 39265,
+    "name": "markoftheimperialguard",
+    "type": "amulet",
+    "affix": "soldier"
+  },
+  {
+    "id": 39268,
+    "name": "collarofthefirstcommissar",
+    "type": "amulet",
+    "affix": "cavalier"
+  },
+  {
+    "id": 39269,
+    "name": "gwensnecklace",
+    "type": "amulet",
+    "affix": "cavalier"
+  },
+  {
+    "id": 39270,
+    "name": "thesleepingseed",
+    "type": "amulet",
+    "affix": "rabid"
+  },
+  {
+    "id": 39271,
+    "name": "hymntotheprophets",
+    "type": "amulet",
+    "affix": "rabid"
+  },
+  {
+    "id": 39272,
+    "name": "callofthewild",
+    "type": "amulet",
+    "affix": "berserker"
+  },
+  {
+    "id": 39273,
+    "name": "markofthetethyoshouses",
+    "type": "amulet",
+    "affix": "berserker"
+  },
+  {
+    "id": 39274,
+    "name": "jadewindorb",
+    "type": "amulet",
+    "affix": "direandrabid"
+  },
+  {
+    "id": 39275,
+    "name": "symbolofthedeceiver",
+    "type": "amulet",
+    "affix": "direandrabid"
+  },
+  {
+    "id": 39276,
+    "name": "godrockamulet",
+    "type": "amulet",
+    "affix": "berserkerandvalkyrie"
+  },
+  {
+    "id": 39277,
+    "name": "conundrumofmaut",
+    "type": "amulet",
+    "affix": "berserkerandvalkyrie"
+  },
+  {
+    "id": 39278,
+    "name": "theheartofmellaggan",
+    "type": "amulet",
+    "affix": "rabidandapothecary"
+  },
+  {
+    "id": 39279,
+    "name": "bloodofthekhanur",
+    "type": "amulet",
+    "affix": "rabidandapothecary"
+  },
+  {
+    "id": 39282,
+    "name": "theeyesofabaddon",
+    "type": "amulet",
+    "affix": "celestial"
+  },
+  {
+    "id": 39283,
+    "name": "eyeofjanthir",
+    "type": "amulet",
+    "affix": "celestial"
+  },
+  {
+    "id": 39304,
+    "name": "barradinfamilycrest",
+    "type": "amulet",
+    "affix": "soldier"
+  },
+  {
+    "id": 39306,
+    "name": "jalisironhammerscrest",
+    "type": "amulet",
+    "affix": "cavalier"
+  },
+  {
+    "id": 39307,
+    "name": "speakersdawncord",
+    "type": "amulet",
+    "affix": "rabid"
+  },
+  {
+    "id": 39308,
+    "name": "distinguishedcircleoflogic",
+    "type": "amulet",
+    "affix": "berserker"
+  },
+  {
+    "id": 39309,
+    "name": "themastersspecialserum",
+    "type": "amulet",
+    "affix": "direandrabid"
+  },
+  {
+    "id": 39310,
+    "name": "budofthepaletree",
+    "type": "amulet",
+    "affix": "berserkerandvalkyrie"
+  },
+  {
+    "id": 39311,
+    "name": "featheroftheowl",
+    "type": "amulet",
+    "affix": "rabidandapothecary"
+  },
+  {
+    "id": 39313,
+    "name": "syzygy",
+    "type": "amulet",
+    "affix": "celestial"
+  },
+  {
+    "id": 39341,
+    "name": "triforgependant",
+    "type": "amulet",
+    "affix": "celestial"
+  },
+  {
+    "id": 39546,
+    "name": "preservedredirisflower",
+    "type": "accessory",
+    "affix": "cleric"
+  },
+  {
+    "id": 39547,
+    "name": "kurzickbauble",
+    "type": "accessory",
+    "affix": "cleric"
+  },
+  {
+    "id": 39550,
+    "name": "warmastersfamilyheirloom",
+    "type": "accessory",
+    "affix": "knight"
+  },
+  {
+    "id": 39551,
+    "name": "totemofthegorilla",
+    "type": "accessory",
+    "affix": "knight"
+  },
+  {
+    "id": 39554,
+    "name": "fledglingcharm",
+    "type": "accessory",
+    "affix": "rampager"
+  },
+  {
+    "id": 39555,
+    "name": "antonssecret",
+    "type": "accessory",
+    "affix": "rampager"
+  },
+  {
+    "id": 39558,
+    "name": "passiflorakarkinata",
+    "type": "accessory",
+    "affix": "apothecary"
+  },
+  {
+    "id": 39559,
+    "name": "ancientkarkacarapace",
+    "type": "accessory",
+    "affix": "apothecary"
+  },
+  {
+    "id": 39562,
+    "name": "moltenore",
+    "type": "accessory",
+    "affix": "captain"
+  },
+  {
+    "id": 39563,
+    "name": "bigmamastooth",
+    "type": "accessory",
+    "affix": "captain"
+  },
+  {
+    "id": 39566,
+    "name": "amuletofprotection",
+    "type": "amulet",
+    "affix": "cleric"
+  },
+  {
+    "id": 39567,
+    "name": "salmasdiamondjubileenecklace",
+    "type": "amulet",
+    "affix": "cleric"
+  },
+  {
+    "id": 39570,
+    "name": "kodanprayerbeads",
+    "type": "amulet",
+    "affix": "knight"
+  },
+  {
+    "id": 39571,
+    "name": "amuletoftheskies",
+    "type": "amulet",
+    "affix": "knight"
+  },
+  {
+    "id": 39574,
+    "name": "petrifiedskulljuju",
+    "type": "amulet",
+    "affix": "rampager"
+  },
+  {
+    "id": 39575,
+    "name": "nornbearsremembrance",
+    "type": "amulet",
+    "affix": "rampager"
+  },
+  {
+    "id": 39578,
+    "name": "archaicgrawlnecklace",
+    "type": "amulet",
+    "affix": "apothecary"
+  },
+  {
+    "id": 39579,
+    "name": "thesouthsunrose",
+    "type": "amulet",
+    "affix": "apothecary"
+  },
+  {
+    "id": 39582,
+    "name": "charisma",
+    "type": "amulet",
+    "affix": "captain"
+  },
+  {
+    "id": 39583,
+    "name": "thirdplacemedal",
+    "type": "amulet",
+    "affix": "captain"
+  },
+  {
+    "id": 39586,
+    "name": "prayertootter",
+    "type": "amulet",
+    "affix": "cleric"
+  },
+  {
+    "id": 39587,
+    "name": "thequeensnecklace",
+    "type": "amulet",
+    "affix": "knight"
+  },
+  {
+    "id": 39588,
+    "name": "luxonpendant",
+    "type": "amulet",
+    "affix": "rampager"
+  },
+  {
+    "id": 39589,
+    "name": "thebeetlestonediamond",
+    "type": "amulet",
+    "affix": "apothecary"
+  },
+  {
+    "id": 39590,
+    "name": "protomatterchain",
+    "type": "amulet",
+    "affix": "captain"
+  },
+  {
+    "id": 41561,
+    "name": "carrotsouffl",
+    "type": "food"
+  },
+  {
+    "id": 41562,
+    "name": "bowlofrefugeesbeetsoup",
+    "type": "food"
+  },
+  {
+    "id": 41563,
+    "name": "spicymarinatedmushroom",
+    "type": "food"
+  },
+  {
+    "id": 41564,
+    "name": "plateoffrostgorgeclams",
+    "type": "food"
+  },
+  {
+    "id": 41565,
+    "name": "bowlofgarlickalesautee",
+    "type": "food"
+  },
+  {
+    "id": 41566,
+    "name": "mushroomloaf",
+    "type": "food"
+  },
+  {
+    "id": 41567,
+    "name": "plateofspicyherbedchicken",
+    "type": "food"
+  },
+  {
+    "id": 41568,
+    "name": "bowlofzestyturnipsoup",
+    "type": "food"
+  },
+  {
+    "id": 41569,
+    "name": "bowlofsweetandspicybutternutsquashsoup",
+    "type": "food"
+  },
+  {
+    "id": 42427,
+    "name": "potionofkarkaslaying",
+    "type": "utility"
+  },
+  {
+    "id": 42428,
+    "name": "potionofkarkatoughness",
+    "type": "utility"
+  },
+  {
+    "id": 43449,
+    "name": "potentmastertuningcrystal",
+    "type": "utility"
+  },
+  {
+    "id": 43450,
+    "name": "potentmastermaintenanceoil",
+    "type": "utility"
+  },
+  {
+    "id": 43451,
+    "name": "potentsuperiorsharpeningstone",
+    "type": "utility"
+  },
+  {
+    "id": 44642,
+    "name": "watchworkportaldevice",
+    "type": "generic"
+  },
+  {
+    "id": 44944,
+    "name": "bursting",
+    "type": "sigil"
+  },
+  {
+    "id": 44947,
+    "name": "renewal",
+    "type": "sigil"
+  },
+  {
+    "id": 44950,
+    "name": "malice",
+    "type": "sigil"
+  },
+  {
+    "id": 44951,
+    "name": "exuberance",
+    "type": "rune"
+  },
+  {
+    "id": 44956,
+    "name": "tormenting",
+    "type": "rune"
+  },
+  {
+    "id": 44957,
+    "name": "perplexity",
+    "type": "rune"
+  },
+  {
+    "id": 46759,
+    "name": "zojjasreaver",
+    "type": "axe",
+    "affix": "berserker"
+  },
+  {
+    "id": 46760,
+    "name": "zojjasrazor",
+    "type": "dagger",
+    "affix": "berserker"
+  },
+  {
+    "id": 46761,
+    "name": "zojjasartifact",
+    "type": "focus",
+    "affix": "berserker"
+  },
+  {
+    "id": 46762,
+    "name": "zojjasclaymore",
+    "type": "greatsword",
+    "affix": "berserker"
+  },
+  {
+    "id": 46763,
+    "name": "zojjaswarhammer",
+    "type": "hammer",
+    "affix": "berserker"
+  },
+  {
+    "id": 46764,
+    "name": "zojjasimpaler",
+    "type": "harpoon",
+    "affix": "berserker"
+  },
+  {
+    "id": 46765,
+    "name": "zojjasgreatbow",
+    "type": "longbow",
+    "affix": "berserker"
+  },
+  {
+    "id": 46766,
+    "name": "zojjasflangedmace",
+    "type": "mace",
+    "affix": "berserker"
+  },
+  {
+    "id": 46767,
+    "name": "zojjasrevolver",
+    "type": "pistol",
+    "affix": "berserker"
+  },
+  {
+    "id": 46768,
+    "name": "zojjasmusket",
+    "type": "rifle",
+    "affix": "berserker"
+  },
+  {
+    "id": 46769,
+    "name": "zojjaswand",
+    "type": "scepter",
+    "affix": "berserker"
+  },
+  {
+    "id": 46770,
+    "name": "zojjasbastion",
+    "type": "shield",
+    "affix": "berserker"
+  },
+  {
+    "id": 46771,
+    "name": "zojjasshortbow",
+    "type": "shortbow",
+    "affix": "berserker"
+  },
+  {
+    "id": 46772,
+    "name": "zojjasharpoongun",
+    "type": "speargun",
+    "affix": "berserker"
+  },
+  {
+    "id": 46773,
+    "name": "zojjasspire",
+    "type": "staff",
+    "affix": "berserker"
+  },
+  {
+    "id": 46774,
+    "name": "zojjasblade",
+    "type": "sword",
+    "affix": "berserker"
+  },
+  {
+    "id": 46775,
+    "name": "zojjasbrazier",
+    "type": "torch",
+    "affix": "berserker"
+  },
+  {
+    "id": 46776,
+    "name": "zojjastrident",
+    "type": "trident",
+    "affix": "berserker"
+  },
+  {
+    "id": 46777,
+    "name": "zojjasherald",
+    "type": "warhorn",
+    "affix": "berserker"
+  },
+  {
+    "id": 46778,
+    "name": "coalforgesreaver",
+    "type": "axe",
+    "affix": "rampager"
+  },
+  {
+    "id": 46779,
+    "name": "coalforgesrazor",
+    "type": "dagger",
+    "affix": "rampager"
+  },
+  {
+    "id": 46780,
+    "name": "coalforgesartifact",
+    "type": "focus",
+    "affix": "rampager"
+  },
+  {
+    "id": 46781,
+    "name": "coalforgesclaymore",
+    "type": "greatsword",
+    "affix": "rampager"
+  },
+  {
+    "id": 46782,
+    "name": "coalforgeswarhammer",
+    "type": "hammer",
+    "affix": "rampager"
+  },
+  {
+    "id": 46783,
+    "name": "coalforgesimpaler",
+    "type": "harpoon",
+    "affix": "rampager"
+  },
+  {
+    "id": 46784,
+    "name": "coalforgesgreatbow",
+    "type": "longbow",
+    "affix": "rampager"
+  },
+  {
+    "id": 46785,
+    "name": "coalforgesflangedmace",
+    "type": "mace",
+    "affix": "rampager"
+  },
+  {
+    "id": 46786,
+    "name": "coalforgesrevolver",
+    "type": "pistol",
+    "affix": "rampager"
+  },
+  {
+    "id": 46787,
+    "name": "coalforgesmusket",
+    "type": "rifle",
+    "affix": "rampager"
+  },
+  {
+    "id": 46788,
+    "name": "coalforgeswand",
+    "type": "scepter",
+    "affix": "rampager"
+  },
+  {
+    "id": 46789,
+    "name": "coalforgesbastion",
+    "type": "shield",
+    "affix": "rampager"
+  },
+  {
+    "id": 46790,
+    "name": "coalforgesshortbow",
+    "type": "shortbow",
+    "affix": "rampager"
+  },
+  {
+    "id": 46791,
+    "name": "coalforgesharpoongun",
+    "type": "speargun",
+    "affix": "rampager"
+  },
+  {
+    "id": 46792,
+    "name": "coalforgesspire",
+    "type": "staff",
+    "affix": "rampager"
+  },
+  {
+    "id": 46793,
+    "name": "coalforgesblade",
+    "type": "sword",
+    "affix": "rampager"
+  },
+  {
+    "id": 46794,
+    "name": "coalforgesbrazier",
+    "type": "torch",
+    "affix": "rampager"
+  },
+  {
+    "id": 46795,
+    "name": "coalforgestrident",
+    "type": "trident",
+    "affix": "rampager"
+  },
+  {
+    "id": 46796,
+    "name": "coalforgesherald",
+    "type": "warhorn",
+    "affix": "rampager"
+  },
+  {
+    "id": 46797,
+    "name": "stonecleaversreaver",
+    "type": "axe",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46798,
+    "name": "stonecleaversrazor",
+    "type": "dagger",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46799,
+    "name": "stonecleaversartifact",
+    "type": "focus",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46800,
+    "name": "stonecleaversclaymore",
+    "type": "greatsword",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46801,
+    "name": "stonecleaverswarhammer",
+    "type": "hammer",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46802,
+    "name": "stonecleaversimpaler",
+    "type": "harpoon",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46803,
+    "name": "stonecleaversgreatbow",
+    "type": "longbow",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46804,
+    "name": "stonecleaversflangedmace",
+    "type": "mace",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46805,
+    "name": "stonecleaversrevolver",
+    "type": "pistol",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46806,
+    "name": "stonecleaversmusket",
+    "type": "rifle",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46807,
+    "name": "stonecleaverswand",
+    "type": "scepter",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46808,
+    "name": "stonecleaversbastion",
+    "type": "shield",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46809,
+    "name": "stonecleaversshortbow",
+    "type": "shortbow",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46810,
+    "name": "stonecleaversharpoongun",
+    "type": "speargun",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46811,
+    "name": "stonecleaversspire",
+    "type": "staff",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46812,
+    "name": "stonecleaversblade",
+    "type": "sword",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46813,
+    "name": "stonecleaversbrazier",
+    "type": "torch",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46814,
+    "name": "stonecleaverstrident",
+    "type": "trident",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46815,
+    "name": "stonecleaversherald",
+    "type": "warhorn",
+    "affix": "valkyrie"
+  },
+  {
+    "id": 46816,
+    "name": "beigarthsreaver",
+    "type": "axe",
+    "affix": "knight"
+  },
+  {
+    "id": 46817,
+    "name": "beigarthsrazor",
+    "type": "dagger",
+    "affix": "knight"
+  },
+  {
+    "id": 46818,
+    "name": "beigarthsartifact",
+    "type": "focus",
+    "affix": "knight"
+  },
+  {
+    "id": 46819,
+    "name": "beigarthsclaymore",
+    "type": "greatsword",
+    "affix": "knight"
+  },
+  {
+    "id": 46820,
+    "name": "beigarthswarhammer",
+    "type": "hammer",
+    "affix": "knight"
+  },
+  {
+    "id": 46821,
+    "name": "beigarthsimpaler",
+    "type": "harpoon",
+    "affix": "knight"
+  },
+  {
+    "id": 46822,
+    "name": "beigarthsgreatbow",
+    "type": "longbow",
+    "affix": "knight"
+  },
+  {
+    "id": 46823,
+    "name": "beigarthsflangedmace",
+    "type": "mace",
+    "affix": "knight"
+  },
+  {
+    "id": 46824,
+    "name": "beigarthsrevolver",
+    "type": "pistol",
+    "affix": "knight"
+  },
+  {
+    "id": 46825,
+    "name": "beigarthsmusket",
+    "type": "rifle",
+    "affix": "knight"
+  },
+  {
+    "id": 46826,
+    "name": "beigarthswand",
+    "type": "scepter",
+    "affix": "knight"
+  },
+  {
+    "id": 46827,
+    "name": "beigarthsbastion",
+    "type": "shield",
+    "affix": "knight"
+  },
+  {
+    "id": 46828,
+    "name": "beigarthsshortbow",
+    "type": "shortbow",
+    "affix": "knight"
+  },
+  {
+    "id": 46829,
+    "name": "beigarthsharpoongun",
+    "type": "speargun",
+    "affix": "knight"
+  },
+  {
+    "id": 46830,
+    "name": "beigarthsspire",
+    "type": "staff",
+    "affix": "knight"
+  },
+  {
+    "id": 46831,
+    "name": "beigarthsblade",
+    "type": "sword",
+    "affix": "knight"
+  },
+  {
+    "id": 46832,
+    "name": "beigarthsbrazier",
+    "type": "torch",
+    "affix": "knight"
+  },
+  {
+    "id": 46833,
+    "name": "beigarthstrident",
+    "type": "trident",
+    "affix": "knight"
+  },
+  {
+    "id": 46834,
+    "name": "beigarthsherald",
+    "type": "warhorn",
+    "affix": "knight"
+  },
+  {
+    "id": 46835,
+    "name": "occamsreaver",
+    "type": "axe",
+    "affix": "carrion"
+  },
+  {
+    "id": 46836,
+    "name": "occamsrazor",
+    "type": "dagger",
+    "affix": "carrion"
+  },
+  {
+    "id": 46837,
+    "name": "occamsartifact",
+    "type": "focus",
+    "affix": "carrion"
+  },
+  {
+    "id": 46838,
+    "name": "occamsclaymore",
+    "type": "greatsword",
+    "affix": "carrion"
+  },
+  {
+    "id": 46839,
+    "name": "occamswarhammer",
+    "type": "hammer",
+    "affix": "carrion"
+  },
+  {
+    "id": 46840,
+    "name": "occamsimpaler",
+    "type": "harpoon",
+    "affix": "carrion"
+  },
+  {
+    "id": 46841,
+    "name": "occamsgreatbow",
+    "type": "longbow",
+    "affix": "carrion"
+  },
+  {
+    "id": 46842,
+    "name": "occamsflangedmace",
+    "type": "mace",
+    "affix": "carrion"
+  },
+  {
+    "id": 46843,
+    "name": "occamsrevolver",
+    "type": "pistol",
+    "affix": "carrion"
+  },
+  {
+    "id": 46844,
+    "name": "occamsmusket",
+    "type": "rifle",
+    "affix": "carrion"
+  },
+  {
+    "id": 46845,
+    "name": "occamswand",
+    "type": "scepter",
+    "affix": "carrion"
+  },
+  {
+    "id": 46846,
+    "name": "occamsbastion",
+    "type": "shield",
+    "affix": "carrion"
+  },
+  {
+    "id": 46847,
+    "name": "occamsshortbow",
+    "type": "shortbow",
+    "affix": "carrion"
+  },
+  {
+    "id": 46848,
+    "name": "occamsharpoongun",
+    "type": "speargun",
+    "affix": "carrion"
+  },
+  {
+    "id": 46849,
+    "name": "occamsspire",
+    "type": "staff",
+    "affix": "carrion"
+  },
+  {
+    "id": 46850,
+    "name": "occamsblade",
+    "type": "sword",
+    "affix": "carrion"
+  },
+  {
+    "id": 46851,
+    "name": "occamsbrazier",
+    "type": "torch",
+    "affix": "carrion"
+  },
+  {
+    "id": 46852,
+    "name": "occamstrident",
+    "type": "trident",
+    "affix": "carrion"
+  },
+  {
+    "id": 46853,
+    "name": "occamsherald",
+    "type": "warhorn",
+    "affix": "carrion"
+  },
+  {
+    "id": 46854,
+    "name": "zintlreaver",
+    "type": "axe",
+    "affix": "shaman"
+  },
+  {
+    "id": 46855,
+    "name": "zintlrazor",
+    "type": "dagger",
+    "affix": "shaman"
+  },
+  {
+    "id": 46856,
+    "name": "zintlartifact",
+    "type": "focus",
+    "affix": "shaman"
+  },
+  {
+    "id": 46857,
+    "name": "zintlclaymore",
+    "type": "greatsword",
+    "affix": "shaman"
+  },
+  {
+    "id": 46858,
+    "name": "zintlwarhammer",
+    "type": "hammer",
+    "affix": "shaman"
+  },
+  {
+    "id": 46859,
+    "name": "zintlimpaler",
+    "type": "harpoon",
+    "affix": "shaman"
+  },
+  {
+    "id": 46860,
+    "name": "zintlgreatbow",
+    "type": "longbow",
+    "affix": "shaman"
+  },
+  {
+    "id": 46861,
+    "name": "zintlflangedmace",
+    "type": "mace",
+    "affix": "shaman"
+  },
+  {
+    "id": 46862,
+    "name": "zintlrevolver",
+    "type": "pistol",
+    "affix": "shaman"
+  },
+  {
+    "id": 46863,
+    "name": "zintlmusket",
+    "type": "rifle",
+    "affix": "shaman"
+  },
+  {
+    "id": 46864,
+    "name": "zintlwand",
+    "type": "scepter",
+    "affix": "shaman"
+  },
+  {
+    "id": 46865,
+    "name": "zintlbastion",
+    "type": "shield",
+    "affix": "shaman"
+  },
+  {
+    "id": 46866,
+    "name": "zintlshortbow",
+    "type": "shortbow",
+    "affix": "shaman"
+  },
+  {
+    "id": 46867,
+    "name": "zintlharpoongun",
+    "type": "speargun",
+    "affix": "shaman"
+  },
+  {
+    "id": 46868,
+    "name": "zintlspire",
+    "type": "staff",
+    "affix": "shaman"
+  },
+  {
+    "id": 46869,
+    "name": "zintlblade",
+    "type": "sword",
+    "affix": "shaman"
+  },
+  {
+    "id": 46870,
+    "name": "zintlbrazier",
+    "type": "torch",
+    "affix": "shaman"
+  },
+  {
+    "id": 46871,
+    "name": "zintltrident",
+    "type": "trident",
+    "affix": "shaman"
+  },
+  {
+    "id": 46872,
+    "name": "zintlherald",
+    "type": "warhorn",
+    "affix": "shaman"
+  },
+  {
+    "id": 46873,
+    "name": "tonnsreaver",
+    "type": "axe",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46874,
+    "name": "tonnsrazor",
+    "type": "dagger",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46875,
+    "name": "tonnsartifact",
+    "type": "focus",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46876,
+    "name": "tonnsclaymore",
+    "type": "greatsword",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46877,
+    "name": "tonnswarhammer",
+    "type": "hammer",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46878,
+    "name": "tonnsimpaler",
+    "type": "harpoon",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46879,
+    "name": "tonnsgreatbow",
+    "type": "longbow",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46880,
+    "name": "tonnsflangedmace",
+    "type": "mace",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46881,
+    "name": "tonnsrevolver",
+    "type": "pistol",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46882,
+    "name": "tonnsmusket",
+    "type": "rifle",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46883,
+    "name": "tonnswand",
+    "type": "scepter",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46884,
+    "name": "tonnsbastion",
+    "type": "shield",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46885,
+    "name": "tonnsshortbow",
+    "type": "shortbow",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46886,
+    "name": "tonnsharpoongun",
+    "type": "speargun",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46887,
+    "name": "tonnsspire",
+    "type": "staff",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46888,
+    "name": "tonnsblade",
+    "type": "sword",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46889,
+    "name": "tonnsbrazier",
+    "type": "torch",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46890,
+    "name": "tonnstrident",
+    "type": "trident",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46891,
+    "name": "tonnsherald",
+    "type": "warhorn",
+    "affix": "sentinel"
+  },
+  {
+    "id": 46892,
+    "name": "ebonmanesreaver",
+    "type": "axe",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46893,
+    "name": "ebonmanesrazor",
+    "type": "dagger",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46894,
+    "name": "ebonmanesartifact",
+    "type": "focus",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46895,
+    "name": "ebonmanesclaymore",
+    "type": "greatsword",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46896,
+    "name": "ebonmaneswarhammer",
+    "type": "hammer",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46897,
+    "name": "ebonmanesimpaler",
+    "type": "harpoon",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46898,
+    "name": "ebonmanesgreatbow",
+    "type": "longbow",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46899,
+    "name": "ebonmanesflangedmace",
+    "type": "mace",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46900,
+    "name": "ebonmanesrevolver",
+    "type": "pistol",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46901,
+    "name": "ebonmanesmusket",
+    "type": "rifle",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46902,
+    "name": "ebonmaneswand",
+    "type": "scepter",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46903,
+    "name": "ebonmanesbastion",
+    "type": "shield",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46904,
+    "name": "ebonmanesshortbow",
+    "type": "shortbow",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46905,
+    "name": "ebonmanesharpoongun",
+    "type": "speargun",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46906,
+    "name": "ebonmanesspire",
+    "type": "staff",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46907,
+    "name": "ebonmanesblade",
+    "type": "sword",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46908,
+    "name": "ebonmanesbrazier",
+    "type": "torch",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46909,
+    "name": "ebonmanestrident",
+    "type": "trident",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46910,
+    "name": "ebonmanesherald",
+    "type": "warhorn",
+    "affix": "apothecary"
+  },
+  {
+    "id": 46911,
+    "name": "leftpawsreaver",
+    "type": "axe",
+    "affix": "settler"
+  },
+  {
+    "id": 46912,
+    "name": "leftpawsrazor",
+    "type": "dagger",
+    "affix": "settler"
+  },
+  {
+    "id": 46913,
+    "name": "leftpawsartifact",
+    "type": "focus",
+    "affix": "settler"
+  },
+  {
+    "id": 46914,
+    "name": "leftpawsclaymore",
+    "type": "greatsword",
+    "affix": "settler"
+  },
+  {
+    "id": 46915,
+    "name": "leftpawswarhammer",
+    "type": "hammer",
+    "affix": "settler"
+  },
+  {
+    "id": 46916,
+    "name": "leftpawsimpaler",
+    "type": "harpoon",
+    "affix": "settler"
+  },
+  {
+    "id": 46917,
+    "name": "leftpawsgreatbow",
+    "type": "longbow",
+    "affix": "settler"
+  },
+  {
+    "id": 46918,
+    "name": "leftpawsflangedmace",
+    "type": "mace",
+    "affix": "settler"
+  },
+  {
+    "id": 46919,
+    "name": "leftpawsrevolver",
+    "type": "pistol",
+    "affix": "settler"
+  },
+  {
+    "id": 46920,
+    "name": "leftpawsmusket",
+    "type": "rifle",
+    "affix": "settler"
+  },
+  {
+    "id": 46921,
+    "name": "leftpawswand",
+    "type": "scepter",
+    "affix": "settler"
+  },
+  {
+    "id": 46922,
+    "name": "leftpawsbastion",
+    "type": "shield",
+    "affix": "settler"
+  },
+  {
+    "id": 46923,
+    "name": "leftpawsshortbow",
+    "type": "shortbow",
+    "affix": "settler"
+  },
+  {
+    "id": 46924,
+    "name": "leftpawsharpoongun",
+    "type": "speargun",
+    "affix": "settler"
+  },
+  {
+    "id": 46925,
+    "name": "leftpawsspire",
+    "type": "staff",
+    "affix": "settler"
+  },
+  {
+    "id": 46926,
+    "name": "leftpawsblade",
+    "type": "sword",
+    "affix": "settler"
+  },
+  {
+    "id": 46927,
+    "name": "leftpawsbrazier",
+    "type": "torch",
+    "affix": "settler"
+  },
+  {
+    "id": 46928,
+    "name": "leftpawstrident",
+    "type": "trident",
+    "affix": "settler"
+  },
+  {
+    "id": 46929,
+    "name": "leftpawsherald",
+    "type": "warhorn",
+    "affix": "settler"
+  },
+  {
+    "id": 46930,
+    "name": "angchureaver",
+    "type": "axe",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46931,
+    "name": "angchurazor",
+    "type": "dagger",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46932,
+    "name": "angchuartifact",
+    "type": "focus",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46933,
+    "name": "angchuclaymore",
+    "type": "greatsword",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46934,
+    "name": "angchuwarhammer",
+    "type": "hammer",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46935,
+    "name": "angchuimpaler",
+    "type": "harpoon",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46936,
+    "name": "angchugreatbow",
+    "type": "longbow",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46937,
+    "name": "angchuflangedmace",
+    "type": "mace",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46938,
+    "name": "angchurevolver",
+    "type": "pistol",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46939,
+    "name": "angchumusket",
+    "type": "rifle",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46940,
+    "name": "angchuwand",
+    "type": "scepter",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46941,
+    "name": "angchubastion",
+    "type": "shield",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46942,
+    "name": "angchushortbow",
+    "type": "shortbow",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46943,
+    "name": "angchuharpoongun",
+    "type": "speargun",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46944,
+    "name": "angchuspire",
+    "type": "staff",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46945,
+    "name": "angchublade",
+    "type": "sword",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46946,
+    "name": "angchubrazier",
+    "type": "torch",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46947,
+    "name": "angchutrident",
+    "type": "trident",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46948,
+    "name": "angchuherald",
+    "type": "warhorn",
+    "affix": "cavalier"
+  },
+  {
+    "id": 46949,
+    "name": "grizzlemouthsreaver",
+    "type": "axe",
+    "affix": "rabid"
+  },
+  {
+    "id": 46950,
+    "name": "grizzlemouthsrazor",
+    "type": "dagger",
+    "affix": "rabid"
+  },
+  {
+    "id": 46951,
+    "name": "grizzlemouthsartifact",
+    "type": "focus",
+    "affix": "rabid"
+  },
+  {
+    "id": 46952,
+    "name": "grizzlemouthsclaymore",
+    "type": "greatsword",
+    "affix": "rabid"
+  },
+  {
+    "id": 46953,
+    "name": "grizzlemouthswarhammer",
+    "type": "hammer",
+    "affix": "rabid"
+  },
+  {
+    "id": 46954,
+    "name": "grizzlemouthsimpaler",
+    "type": "harpoon",
+    "affix": "rabid"
+  },
+  {
+    "id": 46955,
+    "name": "grizzlemouthsgreatbow",
+    "type": "longbow",
+    "affix": "rabid"
+  },
+  {
+    "id": 46956,
+    "name": "grizzlemouthsflangedmace",
+    "type": "mace",
+    "affix": "rabid"
+  },
+  {
+    "id": 46957,
+    "name": "grizzlemouthsrevolver",
+    "type": "pistol",
+    "affix": "rabid"
+  },
+  {
+    "id": 46958,
+    "name": "grizzlemouthsmusket",
+    "type": "rifle",
+    "affix": "rabid"
+  },
+  {
+    "id": 46959,
+    "name": "grizzlemouthswand",
+    "type": "scepter",
+    "affix": "rabid"
+  },
+  {
+    "id": 46960,
+    "name": "grizzlemouthsbastion",
+    "type": "shield",
+    "affix": "rabid"
+  },
+  {
+    "id": 46961,
+    "name": "grizzlemouthsshortbow",
+    "type": "shortbow",
+    "affix": "rabid"
+  },
+  {
+    "id": 46962,
+    "name": "grizzlemouthsharpoongun",
+    "type": "speargun",
+    "affix": "rabid"
+  },
+  {
+    "id": 46963,
+    "name": "grizzlemouthsspire",
+    "type": "staff",
+    "affix": "rabid"
+  },
+  {
+    "id": 46964,
+    "name": "grizzlemouthsblade",
+    "type": "sword",
+    "affix": "rabid"
+  },
+  {
+    "id": 46965,
+    "name": "grizzlemouthsbrazier",
+    "type": "torch",
+    "affix": "rabid"
+  },
+  {
+    "id": 46966,
+    "name": "grizzlemouthstrident",
+    "type": "trident",
+    "affix": "rabid"
+  },
+  {
+    "id": 46967,
+    "name": "grizzlemouthsherald",
+    "type": "warhorn",
+    "affix": "rabid"
+  },
+  {
+    "id": 46968,
+    "name": "hronksreaver",
+    "type": "axe",
+    "affix": "magi"
+  },
+  {
+    "id": 46969,
+    "name": "hronksrazor",
+    "type": "dagger",
+    "affix": "magi"
+  },
+  {
+    "id": 46970,
+    "name": "hronksartifact",
+    "type": "focus",
+    "affix": "magi"
+  },
+  {
+    "id": 46971,
+    "name": "hronksclaymore",
+    "type": "greatsword",
+    "affix": "magi"
+  },
+  {
+    "id": 46972,
+    "name": "hronkswarhammer",
+    "type": "hammer",
+    "affix": "magi"
+  },
+  {
+    "id": 46973,
+    "name": "hronksimpaler",
+    "type": "harpoon",
+    "affix": "magi"
+  },
+  {
+    "id": 46974,
+    "name": "hronksgreatbow",
+    "type": "longbow",
+    "affix": "magi"
+  },
+  {
+    "id": 46975,
+    "name": "hronksflangedmace",
+    "type": "mace",
+    "affix": "magi"
+  },
+  {
+    "id": 46976,
+    "name": "hronksrevolver",
+    "type": "pistol",
+    "affix": "magi"
+  },
+  {
+    "id": 46977,
+    "name": "hronksmusket",
+    "type": "rifle",
+    "affix": "magi"
+  },
+  {
+    "id": 46978,
+    "name": "hronkswand",
+    "type": "scepter",
+    "affix": "magi"
+  },
+  {
+    "id": 46979,
+    "name": "hronksbastion",
+    "type": "shield",
+    "affix": "magi"
+  },
+  {
+    "id": 46980,
+    "name": "hronksshortbow",
+    "type": "shortbow",
+    "affix": "magi"
+  },
+  {
+    "id": 46981,
+    "name": "hronksharpoongun",
+    "type": "speargun",
+    "affix": "magi"
+  },
+  {
+    "id": 46982,
+    "name": "hronksspire",
+    "type": "staff",
+    "affix": "magi"
+  },
+  {
+    "id": 46983,
+    "name": "hronksblade",
+    "type": "sword",
+    "affix": "magi"
+  },
+  {
+    "id": 46984,
+    "name": "hronksbrazier",
+    "type": "torch",
+    "affix": "magi"
+  },
+  {
+    "id": 46985,
+    "name": "hronkstrident",
+    "type": "trident",
+    "affix": "magi"
+  },
+  {
+    "id": 46986,
+    "name": "hronksherald",
+    "type": "warhorn",
+    "affix": "magi"
+  },
+  {
+    "id": 46987,
+    "name": "chorbensreaver",
+    "type": "axe",
+    "affix": "soldier"
+  },
+  {
+    "id": 46988,
+    "name": "chorbensrazor",
+    "type": "dagger",
+    "affix": "soldier"
+  },
+  {
+    "id": 46989,
+    "name": "chorbensartifact",
+    "type": "focus",
+    "affix": "soldier"
+  },
+  {
+    "id": 46990,
+    "name": "chorbensclaymore",
+    "type": "greatsword",
+    "affix": "soldier"
+  },
+  {
+    "id": 46991,
+    "name": "chorbenswarhammer",
+    "type": "hammer",
+    "affix": "soldier"
+  },
+  {
+    "id": 46992,
+    "name": "chorbensimpaler",
+    "type": "harpoon",
+    "affix": "soldier"
+  },
+  {
+    "id": 46993,
+    "name": "chorbensgreatbow",
+    "type": "longbow",
+    "affix": "soldier"
+  },
+  {
+    "id": 46994,
+    "name": "chorbensflangedmace",
+    "type": "mace",
+    "affix": "soldier"
+  },
+  {
+    "id": 46995,
+    "name": "chorbensrevolver",
+    "type": "pistol",
+    "affix": "soldier"
+  },
+  {
+    "id": 46996,
+    "name": "chorbensmusket",
+    "type": "rifle",
+    "affix": "soldier"
+  },
+  {
+    "id": 46997,
+    "name": "chorbenswand",
+    "type": "scepter",
+    "affix": "soldier"
+  },
+  {
+    "id": 46998,
+    "name": "chorbensbastion",
+    "type": "shield",
+    "affix": "soldier"
+  },
+  {
+    "id": 46999,
+    "name": "chorbensshortbow",
+    "type": "shortbow",
+    "affix": "soldier"
+  },
+  {
+    "id": 47000,
+    "name": "chorbensharpoongun",
+    "type": "speargun",
+    "affix": "soldier"
+  },
+  {
+    "id": 47001,
+    "name": "chorbensspire",
+    "type": "staff",
+    "affix": "soldier"
+  },
+  {
+    "id": 47002,
+    "name": "chorbensblade",
+    "type": "sword",
+    "affix": "soldier"
+  },
+  {
+    "id": 47003,
+    "name": "chorbensbrazier",
+    "type": "torch",
+    "affix": "soldier"
+  },
+  {
+    "id": 47004,
+    "name": "chorbenstrident",
+    "type": "trident",
+    "affix": "soldier"
+  },
+  {
+    "id": 47005,
+    "name": "chorbensherald",
+    "type": "warhorn",
+    "affix": "soldier"
+  },
+  {
+    "id": 47006,
+    "name": "wupwupreaver",
+    "type": "axe",
+    "affix": "celestial"
+  },
+  {
+    "id": 47007,
+    "name": "wupwuprazor",
+    "type": "dagger",
+    "affix": "celestial"
+  },
+  {
+    "id": 47008,
+    "name": "wupwupartifact",
+    "type": "focus",
+    "affix": "celestial"
+  },
+  {
+    "id": 47009,
+    "name": "wupwupclaymore",
+    "type": "greatsword",
+    "affix": "celestial"
+  },
+  {
+    "id": 47010,
+    "name": "wupwupwarhammer",
+    "type": "hammer",
+    "affix": "celestial"
+  },
+  {
+    "id": 47011,
+    "name": "wupwupimpaler",
+    "type": "harpoon",
+    "affix": "celestial"
+  },
+  {
+    "id": 47012,
+    "name": "wupwupgreatbow",
+    "type": "longbow",
+    "affix": "celestial"
+  },
+  {
+    "id": 47013,
+    "name": "wupwupflangedmace",
+    "type": "mace",
+    "affix": "celestial"
+  },
+  {
+    "id": 47014,
+    "name": "wupwuprevolver",
+    "type": "pistol",
+    "affix": "celestial"
+  },
+  {
+    "id": 47015,
+    "name": "wupwupmusket",
+    "type": "rifle",
+    "affix": "celestial"
+  },
+  {
+    "id": 47016,
+    "name": "wupwupwand",
+    "type": "scepter",
+    "affix": "celestial"
+  },
+  {
+    "id": 47017,
+    "name": "wupwupbastion",
+    "type": "shield",
+    "affix": "celestial"
+  },
+  {
+    "id": 47018,
+    "name": "wupwupshortbow",
+    "type": "shortbow",
+    "affix": "celestial"
+  },
+  {
+    "id": 47019,
+    "name": "wupwupharpoongun",
+    "type": "speargun",
+    "affix": "celestial"
+  },
+  {
+    "id": 47020,
+    "name": "wupwupspire",
+    "type": "staff",
+    "affix": "celestial"
+  },
+  {
+    "id": 47021,
+    "name": "wupwupblade",
+    "type": "sword",
+    "affix": "celestial"
+  },
+  {
+    "id": 47022,
+    "name": "wupwupbrazier",
+    "type": "torch",
+    "affix": "celestial"
+  },
+  {
+    "id": 47023,
+    "name": "wupwuptrident",
+    "type": "trident",
+    "affix": "celestial"
+  },
+  {
+    "id": 47024,
+    "name": "wupwupherald",
+    "type": "warhorn",
+    "affix": "celestial"
+  },
+  {
+    "id": 47025,
+    "name": "theodosussreaver",
+    "type": "axe",
+    "affix": "cleric"
+  },
+  {
+    "id": 47026,
+    "name": "theodosussrazor",
+    "type": "dagger",
+    "affix": "cleric"
+  },
+  {
+    "id": 47027,
+    "name": "theodosussartifact",
+    "type": "focus",
+    "affix": "cleric"
+  },
+  {
+    "id": 47028,
+    "name": "theodosussclaymore",
+    "type": "greatsword",
+    "affix": "cleric"
+  },
+  {
+    "id": 47029,
+    "name": "theodosusswarhammer",
+    "type": "hammer",
+    "affix": "cleric"
+  },
+  {
+    "id": 47030,
+    "name": "theodosussimpaler",
+    "type": "harpoon",
+    "affix": "cleric"
+  },
+  {
+    "id": 47031,
+    "name": "theodosussgreatbow",
+    "type": "longbow",
+    "affix": "cleric"
+  },
+  {
+    "id": 47032,
+    "name": "theodosussflangedmace",
+    "type": "mace",
+    "affix": "cleric"
+  },
+  {
+    "id": 47033,
+    "name": "theodosussrevolver",
+    "type": "pistol",
+    "affix": "cleric"
+  },
+  {
+    "id": 47034,
+    "name": "theodosussmusket",
+    "type": "rifle",
+    "affix": "cleric"
+  },
+  {
+    "id": 47035,
+    "name": "theodosusswand",
+    "type": "scepter",
+    "affix": "cleric"
+  },
+  {
+    "id": 47036,
+    "name": "theodosussbastion",
+    "type": "shield",
+    "affix": "cleric"
+  },
+  {
+    "id": 47037,
+    "name": "theodosussshortbow",
+    "type": "shortbow",
+    "affix": "cleric"
+  },
+  {
+    "id": 47038,
+    "name": "theodosussharpoongun",
+    "type": "speargun",
+    "affix": "cleric"
+  },
+  {
+    "id": 47039,
+    "name": "theodosussspire",
+    "type": "staff",
+    "affix": "cleric"
+  },
+  {
+    "id": 47040,
+    "name": "theodosussblade",
+    "type": "sword",
+    "affix": "cleric"
+  },
+  {
+    "id": 47041,
+    "name": "theodosussbrazier",
+    "type": "torch",
+    "affix": "cleric"
+  },
+  {
+    "id": 47042,
+    "name": "theodosusstrident",
+    "type": "trident",
+    "affix": "cleric"
+  },
+  {
+    "id": 47043,
+    "name": "theodosussherald",
+    "type": "warhorn",
+    "affix": "cleric"
+  },
+  {
+    "id": 47044,
+    "name": "sorossreaver",
+    "type": "axe",
+    "affix": "assassin"
+  },
+  {
+    "id": 47045,
+    "name": "sorossrazor",
+    "type": "dagger",
+    "affix": "assassin"
+  },
+  {
+    "id": 47046,
+    "name": "sorossartifact",
+    "type": "focus",
+    "affix": "assassin"
+  },
+  {
+    "id": 47047,
+    "name": "sorossclaymore",
+    "type": "greatsword",
+    "affix": "assassin"
+  },
+  {
+    "id": 47048,
+    "name": "sorosswarhammer",
+    "type": "hammer",
+    "affix": "assassin"
+  },
+  {
+    "id": 47049,
+    "name": "sorossimpaler",
+    "type": "harpoon",
+    "affix": "assassin"
+  },
+  {
+    "id": 47050,
+    "name": "sorossgreatbow",
+    "type": "longbow",
+    "affix": "assassin"
+  },
+  {
+    "id": 47051,
+    "name": "sorossflangedmace",
+    "type": "mace",
+    "affix": "assassin"
+  },
+  {
+    "id": 47052,
+    "name": "sorossrevolver",
+    "type": "pistol",
+    "affix": "assassin"
+  },
+  {
+    "id": 47053,
+    "name": "sorossmusket",
+    "type": "rifle",
+    "affix": "assassin"
+  },
+  {
+    "id": 47054,
+    "name": "sorosswand",
+    "type": "scepter",
+    "affix": "assassin"
+  },
+  {
+    "id": 47055,
+    "name": "sorossbastion",
+    "type": "shield",
+    "affix": "assassin"
+  },
+  {
+    "id": 47056,
+    "name": "sorossshortbow",
+    "type": "shortbow",
+    "affix": "assassin"
+  },
+  {
+    "id": 47057,
+    "name": "sorossharpoongun",
+    "type": "speargun",
+    "affix": "assassin"
+  },
+  {
+    "id": 47058,
+    "name": "sorossspire",
+    "type": "staff",
+    "affix": "assassin"
+  },
+  {
+    "id": 47059,
+    "name": "sorossblade",
+    "type": "sword",
+    "affix": "assassin"
+  },
+  {
+    "id": 47060,
+    "name": "sorossbrazier",
+    "type": "torch",
+    "affix": "assassin"
+  },
+  {
+    "id": 47061,
+    "name": "sorosstrident",
+    "type": "trident",
+    "affix": "assassin"
+  },
+  {
+    "id": 47062,
+    "name": "sorossherald",
+    "type": "warhorn",
+    "affix": "assassin"
+  },
+  {
+    "id": 47063,
+    "name": "mathildesreaver",
+    "type": "axe",
+    "affix": "dire"
+  },
+  {
+    "id": 47064,
+    "name": "mathildesrazor",
+    "type": "dagger",
+    "affix": "dire"
+  },
+  {
+    "id": 47065,
+    "name": "mathildesartifact",
+    "type": "focus",
+    "affix": "dire"
+  },
+  {
+    "id": 47066,
+    "name": "mathildesclaymore",
+    "type": "greatsword",
+    "affix": "dire"
+  },
+  {
+    "id": 47067,
+    "name": "mathildeswarhammer",
+    "type": "hammer",
+    "affix": "dire"
+  },
+  {
+    "id": 47068,
+    "name": "mathildesimpaler",
+    "type": "harpoon",
+    "affix": "dire"
+  },
+  {
+    "id": 47069,
+    "name": "mathildesgreatbow",
+    "type": "longbow",
+    "affix": "dire"
+  },
+  {
+    "id": 47070,
+    "name": "mathildesflangedmace",
+    "type": "mace",
+    "affix": "dire"
+  },
+  {
+    "id": 47071,
+    "name": "mathildesrevolver",
+    "type": "pistol",
+    "affix": "dire"
+  },
+  {
+    "id": 47072,
+    "name": "mathildesmusket",
+    "type": "rifle",
+    "affix": "dire"
+  },
+  {
+    "id": 47073,
+    "name": "mathildeswand",
+    "type": "scepter",
+    "affix": "dire"
+  },
+  {
+    "id": 47074,
+    "name": "mathildesbastion",
+    "type": "shield",
+    "affix": "dire"
+  },
+  {
+    "id": 47075,
+    "name": "mathildesshortbow",
+    "type": "shortbow",
+    "affix": "dire"
+  },
+  {
+    "id": 47076,
+    "name": "mathildesharpoongun",
+    "type": "speargun",
+    "affix": "dire"
+  },
+  {
+    "id": 47077,
+    "name": "mathildesspire",
+    "type": "staff",
+    "affix": "dire"
+  },
+  {
+    "id": 47078,
+    "name": "mathildesblade",
+    "type": "sword",
+    "affix": "dire"
+  },
+  {
+    "id": 47079,
+    "name": "mathildesbrazier",
+    "type": "torch",
+    "affix": "dire"
+  },
+  {
+    "id": 47080,
+    "name": "mathildestrident",
+    "type": "trident",
+    "affix": "dire"
+  },
+  {
+    "id": 47081,
+    "name": "mathildesherald",
+    "type": "warhorn",
+    "affix": "dire"
+  },
+  {
+    "id": 47851,
+    "name": "reaverofthesunless",
+    "type": "axe",
+    "affix": "rabid"
+  },
+  {
+    "id": 47852,
+    "name": "razorofthesunless",
+    "type": "dagger",
+    "affix": "rabid"
+  },
+  {
+    "id": 47853,
+    "name": "artifactofthesunless",
+    "type": "focus",
+    "affix": "rabid"
+  },
+  {
+    "id": 47854,
+    "name": "claymoreofthesunless",
+    "type": "greatsword",
+    "affix": "rabid"
+  },
+  {
+    "id": 47855,
+    "name": "warhammerofthesunless",
+    "type": "hammer",
+    "affix": "rabid"
+  },
+  {
+    "id": 47856,
+    "name": "impalerofthesunless",
+    "type": "harpoon",
+    "affix": "rabid"
+  },
+  {
+    "id": 47857,
+    "name": "greatbowofthesunless",
+    "type": "longbow",
+    "affix": "rabid"
+  },
+  {
+    "id": 47858,
+    "name": "flangedmaceofthesunless",
+    "type": "mace",
+    "affix": "rabid"
+  },
+  {
+    "id": 47859,
+    "name": "revolverofthesunless",
+    "type": "pistol",
+    "affix": "rabid"
+  },
+  {
+    "id": 47860,
+    "name": "musketofthesunless",
+    "type": "rifle",
+    "affix": "rabid"
+  },
+  {
+    "id": 47861,
+    "name": "wandofthesunless",
+    "type": "scepter",
+    "affix": "rabid"
+  },
+  {
+    "id": 47862,
+    "name": "bastionofthesunless",
+    "type": "shield",
+    "affix": "rabid"
+  },
+  {
+    "id": 47863,
+    "name": "shortbowofthesunless",
+    "type": "shortbow",
+    "affix": "rabid"
+  },
+  {
+    "id": 47864,
+    "name": "harpoongunofthesunless",
+    "type": "speargun",
+    "affix": "rabid"
+  },
+  {
+    "id": 47865,
+    "name": "spireofthesunless",
+    "type": "staff",
+    "affix": "rabid"
+  },
+  {
+    "id": 47866,
+    "name": "bladeofthesunless",
+    "type": "sword",
+    "affix": "rabid"
+  },
+  {
+    "id": 47867,
+    "name": "brazierofthesunless",
+    "type": "torch",
+    "affix": "rabid"
+  },
+  {
+    "id": 47868,
+    "name": "tridentofthesunless",
+    "type": "trident",
+    "affix": "rabid"
+  },
+  {
+    "id": 47869,
+    "name": "heraldofthesunless",
+    "type": "warhorn",
+    "affix": "rabid"
+  },
+  {
+    "id": 47908,
+    "name": "sunless",
+    "type": "rune"
+  },
+  {
+    "id": 47910,
+    "name": "beigarthsshoulderguard",
+    "type": "shoulders",
+    "affix": "knight",
+    "weight": "medium"
+  },
+  {
+    "id": 47911,
+    "name": "beigarthsleggings",
+    "type": "leggings",
+    "affix": "knight",
+    "weight": "medium"
+  },
+  {
+    "id": 47912,
+    "name": "beigarthsvisage",
+    "type": "helm",
+    "affix": "knight",
+    "weight": "medium"
+  },
+  {
+    "id": 47913,
+    "name": "beigarthsgrips",
+    "type": "gloves",
+    "affix": "knight",
+    "weight": "medium"
+  },
+  {
+    "id": 47914,
+    "name": "beigarthsguise",
+    "type": "coat",
+    "affix": "knight",
+    "weight": "medium"
+  },
+  {
+    "id": 47915,
+    "name": "beigarthsstriders",
+    "type": "boots",
+    "affix": "knight",
+    "weight": "medium"
+  },
+  {
+    "id": 47916,
+    "name": "beigarthsepaulets",
+    "type": "shoulders",
+    "affix": "knight",
+    "weight": "light"
+  },
+  {
+    "id": 47917,
+    "name": "beigarthsbreeches",
+    "type": "leggings",
+    "affix": "knight",
+    "weight": "light"
+  },
+  {
+    "id": 47918,
+    "name": "beigarthsmasque",
+    "type": "helm",
+    "affix": "knight",
+    "weight": "light"
+  },
+  {
+    "id": 47919,
+    "name": "beigarthswristguards",
+    "type": "gloves",
+    "affix": "knight",
+    "weight": "light"
+  },
+  {
+    "id": 47920,
+    "name": "beigarthsdoublet",
+    "type": "coat",
+    "affix": "knight",
+    "weight": "light"
+  },
+  {
+    "id": 47921,
+    "name": "beigarthsfootwear",
+    "type": "boots",
+    "affix": "knight",
+    "weight": "light"
+  },
+  {
+    "id": 47922,
+    "name": "beigarthspauldrons",
+    "type": "shoulders",
+    "affix": "knight",
+    "weight": "heavy"
+  },
+  {
+    "id": 47923,
+    "name": "beigarthstassets",
+    "type": "leggings",
+    "affix": "knight",
+    "weight": "heavy"
+  },
+  {
+    "id": 47924,
+    "name": "beigarthsvisor",
+    "type": "helm",
+    "affix": "knight",
+    "weight": "heavy"
+  },
+  {
+    "id": 47925,
+    "name": "beigarthswarfists",
+    "type": "gloves",
+    "affix": "knight",
+    "weight": "heavy"
+  },
+  {
+    "id": 47926,
+    "name": "beigarthsbreastplate",
+    "type": "coat",
+    "affix": "knight",
+    "weight": "heavy"
+  },
+  {
+    "id": 47927,
+    "name": "beigarthsgreaves",
+    "type": "boots",
+    "affix": "knight",
+    "weight": "heavy"
+  },
+  {
+    "id": 47928,
+    "name": "wupwupgreaves",
+    "type": "boots",
+    "affix": "celestial",
+    "weight": "heavy"
+  },
+  {
+    "id": 47929,
+    "name": "wupwupbreastplate",
+    "type": "coat",
+    "affix": "celestial",
+    "weight": "heavy"
+  },
+  {
+    "id": 47930,
+    "name": "wupwupwarfists",
+    "type": "gloves",
+    "affix": "celestial",
+    "weight": "heavy"
+  },
+  {
+    "id": 47931,
+    "name": "wupwupvisor",
+    "type": "helm",
+    "affix": "celestial",
+    "weight": "heavy"
+  },
+  {
+    "id": 47932,
+    "name": "wupwuptassets",
+    "type": "leggings",
+    "affix": "celestial",
+    "weight": "heavy"
+  },
+  {
+    "id": 47933,
+    "name": "wupwuppauldrons",
+    "type": "shoulders",
+    "affix": "celestial",
+    "weight": "heavy"
+  },
+  {
+    "id": 47934,
+    "name": "wupwupfootwear",
+    "type": "boots",
+    "affix": "celestial",
+    "weight": "light"
+  },
+  {
+    "id": 47935,
+    "name": "wupwupdoublet",
+    "type": "coat",
+    "affix": "celestial",
+    "weight": "light"
+  },
+  {
+    "id": 47936,
+    "name": "wupwupwristguards",
+    "type": "gloves",
+    "affix": "celestial",
+    "weight": "light"
+  },
+  {
+    "id": 47937,
+    "name": "wupwupmasque",
+    "type": "helm",
+    "affix": "celestial",
+    "weight": "light"
+  },
+  {
+    "id": 47938,
+    "name": "wupwupbreeches",
+    "type": "leggings",
+    "affix": "celestial",
+    "weight": "light"
+  },
+  {
+    "id": 47939,
+    "name": "wupwupepaulets",
+    "type": "shoulders",
+    "affix": "celestial",
+    "weight": "light"
+  },
+  {
+    "id": 47940,
+    "name": "wupwupstriders",
+    "type": "boots",
+    "affix": "celestial",
+    "weight": "medium"
+  },
+  {
+    "id": 47941,
+    "name": "wupwupguise",
+    "type": "coat",
+    "affix": "celestial",
+    "weight": "medium"
+  },
+  {
+    "id": 47942,
+    "name": "wupwupgrips",
+    "type": "gloves",
+    "affix": "celestial",
+    "weight": "medium"
+  },
+  {
+    "id": 47943,
+    "name": "wupwupvisage",
+    "type": "helm",
+    "affix": "celestial",
+    "weight": "medium"
+  },
+  {
+    "id": 47944,
+    "name": "wupwupleggings",
+    "type": "leggings",
+    "affix": "celestial",
+    "weight": "medium"
+  },
+  {
+    "id": 47945,
+    "name": "wupwupshoulderguard",
+    "type": "shoulders",
+    "affix": "celestial",
+    "weight": "medium"
+  },
+  {
+    "id": 47946,
+    "name": "occamsgreaves",
+    "type": "boots",
+    "affix": "carrion",
+    "weight": "heavy"
+  },
+  {
+    "id": 47947,
+    "name": "occamsbreastplate",
+    "type": "coat",
+    "affix": "carrion",
+    "weight": "heavy"
+  },
+  {
+    "id": 47948,
+    "name": "occamswarfists",
+    "type": "gloves",
+    "affix": "carrion",
+    "weight": "heavy"
+  },
+  {
+    "id": 47949,
+    "name": "occamsvisor",
+    "type": "helm",
+    "affix": "carrion",
+    "weight": "heavy"
+  },
+  {
+    "id": 47950,
+    "name": "occamstassets",
+    "type": "leggings",
+    "affix": "carrion",
+    "weight": "heavy"
+  },
+  {
+    "id": 47951,
+    "name": "occamspauldrons",
+    "type": "shoulders",
+    "affix": "carrion",
+    "weight": "heavy"
+  },
+  {
+    "id": 47952,
+    "name": "occamsfootwear",
+    "type": "boots",
+    "affix": "carrion",
+    "weight": "light"
+  },
+  {
+    "id": 47953,
+    "name": "occamsdoublet",
+    "type": "coat",
+    "affix": "carrion",
+    "weight": "light"
+  },
+  {
+    "id": 47954,
+    "name": "occamswristguards",
+    "type": "gloves",
+    "affix": "carrion",
+    "weight": "light"
+  },
+  {
+    "id": 47955,
+    "name": "occamsmasque",
+    "type": "helm",
+    "affix": "carrion",
+    "weight": "light"
+  },
+  {
+    "id": 47956,
+    "name": "occamsbreeches",
+    "type": "leggings",
+    "affix": "carrion",
+    "weight": "light"
+  },
+  {
+    "id": 47957,
+    "name": "occamsepaulets",
+    "type": "shoulders",
+    "affix": "carrion",
+    "weight": "light"
+  },
+  {
+    "id": 47958,
+    "name": "occamsstriders",
+    "type": "boots",
+    "affix": "carrion",
+    "weight": "medium"
+  },
+  {
+    "id": 47959,
+    "name": "occamsguise",
+    "type": "coat",
+    "affix": "carrion",
+    "weight": "medium"
+  },
+  {
+    "id": 47960,
+    "name": "occamsgrips",
+    "type": "gloves",
+    "affix": "carrion",
+    "weight": "medium"
+  },
+  {
+    "id": 47961,
+    "name": "occamsvisage",
+    "type": "helm",
+    "affix": "carrion",
+    "weight": "medium"
+  },
+  {
+    "id": 47962,
+    "name": "occamsleggings",
+    "type": "leggings",
+    "affix": "carrion",
+    "weight": "medium"
+  },
+  {
+    "id": 47963,
+    "name": "occamsshoulderguard",
+    "type": "shoulders",
+    "affix": "carrion",
+    "weight": "medium"
+  },
+  {
+    "id": 47964,
+    "name": "ferratussgreaves",
+    "type": "boots",
+    "affix": "rabid",
+    "weight": "heavy"
+  },
+  {
+    "id": 47965,
+    "name": "ferratussbreastplate",
+    "type": "coat",
+    "affix": "rabid",
+    "weight": "heavy"
+  },
+  {
+    "id": 47966,
+    "name": "ferratusswarfists",
+    "type": "gloves",
+    "affix": "rabid",
+    "weight": "heavy"
+  },
+  {
+    "id": 47967,
+    "name": "ferratussvisor",
+    "type": "helm",
+    "affix": "rabid",
+    "weight": "heavy"
+  },
+  {
+    "id": 47968,
+    "name": "ferratusstassets",
+    "type": "leggings",
+    "affix": "rabid",
+    "weight": "heavy"
+  },
+  {
+    "id": 47969,
+    "name": "ferratusspauldrons",
+    "type": "shoulders",
+    "affix": "rabid",
+    "weight": "heavy"
+  },
+  {
+    "id": 47970,
+    "name": "ferratussfootwear",
+    "type": "boots",
+    "affix": "rabid",
+    "weight": "light"
+  },
+  {
+    "id": 47971,
+    "name": "ferratussdoublet",
+    "type": "coat",
+    "affix": "rabid",
+    "weight": "light"
+  },
+  {
+    "id": 47972,
+    "name": "ferratusswristguards",
+    "type": "gloves",
+    "affix": "rabid",
+    "weight": "light"
+  },
+  {
+    "id": 47973,
+    "name": "ferratussmasque",
+    "type": "helm",
+    "affix": "rabid",
+    "weight": "light"
+  },
+  {
+    "id": 47974,
+    "name": "ferratussbreeches",
+    "type": "leggings",
+    "affix": "rabid",
+    "weight": "light"
+  },
+  {
+    "id": 47975,
+    "name": "ferratussepaulets",
+    "type": "shoulders",
+    "affix": "rabid",
+    "weight": "light"
+  },
+  {
+    "id": 47976,
+    "name": "ferratussstriders",
+    "type": "boots",
+    "affix": "rabid",
+    "weight": "medium"
+  },
+  {
+    "id": 47977,
+    "name": "ferratussguise",
+    "type": "coat",
+    "affix": "rabid",
+    "weight": "medium"
+  },
+  {
+    "id": 47978,
+    "name": "ferratussgrips",
+    "type": "gloves",
+    "affix": "rabid",
+    "weight": "medium"
+  },
+  {
+    "id": 47979,
+    "name": "ferratussvisage",
+    "type": "helm",
+    "affix": "rabid",
+    "weight": "medium"
+  },
+  {
+    "id": 47980,
+    "name": "ferratussleggings",
+    "type": "leggings",
+    "affix": "rabid",
+    "weight": "medium"
+  },
+  {
+    "id": 47981,
+    "name": "ferratussshoulderguard",
+    "type": "shoulders",
+    "affix": "rabid",
+    "weight": "medium"
+  },
+  {
+    "id": 47982,
+    "name": "morbachsgreaves",
+    "type": "boots",
+    "affix": "dire",
+    "weight": "heavy"
+  },
+  {
+    "id": 47983,
+    "name": "morbachsbreastplate",
+    "type": "coat",
+    "affix": "dire",
+    "weight": "heavy"
+  },
+  {
+    "id": 47984,
+    "name": "morbachswarfists",
+    "type": "gloves",
+    "affix": "dire",
+    "weight": "heavy"
+  },
+  {
+    "id": 47985,
+    "name": "morbachsvisor",
+    "type": "helm",
+    "affix": "dire",
+    "weight": "heavy"
+  },
+  {
+    "id": 47986,
+    "name": "morbachstassets",
+    "type": "leggings",
+    "affix": "dire",
+    "weight": "heavy"
+  },
+  {
+    "id": 47987,
+    "name": "morbachspauldrons",
+    "type": "shoulders",
+    "affix": "dire",
+    "weight": "heavy"
+  },
+  {
+    "id": 47988,
+    "name": "morbachsfootwear",
+    "type": "boots",
+    "affix": "dire",
+    "weight": "light"
+  },
+  {
+    "id": 47989,
+    "name": "morbachsdoublet",
+    "type": "coat",
+    "affix": "dire",
+    "weight": "light"
+  },
+  {
+    "id": 47990,
+    "name": "morbachswristguards",
+    "type": "gloves",
+    "affix": "dire",
+    "weight": "light"
+  },
+  {
+    "id": 47991,
+    "name": "morbachsmasque",
+    "type": "helm",
+    "affix": "dire",
+    "weight": "light"
+  },
+  {
+    "id": 47992,
+    "name": "morbachsbreeches",
+    "type": "leggings",
+    "affix": "dire",
+    "weight": "light"
+  },
+  {
+    "id": 47993,
+    "name": "morbachsepaulets",
+    "type": "shoulders",
+    "affix": "dire",
+    "weight": "light"
+  },
+  {
+    "id": 47994,
+    "name": "morbachsstriders",
+    "type": "boots",
+    "affix": "dire",
+    "weight": "medium"
+  },
+  {
+    "id": 47995,
+    "name": "morbachsguise",
+    "type": "coat",
+    "affix": "dire",
+    "weight": "medium"
+  },
+  {
+    "id": 47996,
+    "name": "morbachsgrips",
+    "type": "gloves",
+    "affix": "dire",
+    "weight": "medium"
+  },
+  {
+    "id": 47997,
+    "name": "morbachsvisage",
+    "type": "helm",
+    "affix": "dire",
+    "weight": "medium"
+  },
+  {
+    "id": 47998,
+    "name": "morbachsleggings",
+    "type": "leggings",
+    "affix": "dire",
+    "weight": "medium"
+  },
+  {
+    "id": 47999,
+    "name": "morbachsshoulderguard",
+    "type": "shoulders",
+    "affix": "dire",
+    "weight": "medium"
+  },
+  {
+    "id": 48000,
+    "name": "tateossgreaves",
+    "type": "boots",
+    "affix": "cleric",
+    "weight": "heavy"
+  },
+  {
+    "id": 48001,
+    "name": "tateossbreastplate",
+    "type": "coat",
+    "affix": "cleric",
+    "weight": "heavy"
+  },
+  {
+    "id": 48002,
+    "name": "tateosswarfists",
+    "type": "gloves",
+    "affix": "cleric",
+    "weight": "heavy"
+  },
+  {
+    "id": 48003,
+    "name": "tateossvisor",
+    "type": "helm",
+    "affix": "cleric",
+    "weight": "heavy"
+  },
+  {
+    "id": 48004,
+    "name": "tateosstassets",
+    "type": "leggings",
+    "affix": "cleric",
+    "weight": "heavy"
+  },
+  {
+    "id": 48005,
+    "name": "tateosspauldrons",
+    "type": "shoulders",
+    "affix": "cleric",
+    "weight": "heavy"
+  },
+  {
+    "id": 48006,
+    "name": "tateossfootwear",
+    "type": "boots",
+    "affix": "cleric",
+    "weight": "light"
+  },
+  {
+    "id": 48007,
+    "name": "tateossdoublet",
+    "type": "coat",
+    "affix": "cleric",
+    "weight": "light"
+  },
+  {
+    "id": 48008,
+    "name": "tateosswristguards",
+    "type": "gloves",
+    "affix": "cleric",
+    "weight": "light"
+  },
+  {
+    "id": 48009,
+    "name": "tateossmasque",
+    "type": "helm",
+    "affix": "cleric",
+    "weight": "light"
+  },
+  {
+    "id": 48010,
+    "name": "tateossbreeches",
+    "type": "leggings",
+    "affix": "cleric",
+    "weight": "light"
+  },
+  {
+    "id": 48011,
+    "name": "tateossepaulets",
+    "type": "shoulders",
+    "affix": "cleric",
+    "weight": "light"
+  },
+  {
+    "id": 48012,
+    "name": "tateossstriders",
+    "type": "boots",
+    "affix": "cleric",
+    "weight": "medium"
+  },
+  {
+    "id": 48013,
+    "name": "tateossguise",
+    "type": "coat",
+    "affix": "cleric",
+    "weight": "medium"
+  },
+  {
+    "id": 48014,
+    "name": "tateossgrips",
+    "type": "gloves",
+    "affix": "cleric",
+    "weight": "medium"
+  },
+  {
+    "id": 48015,
+    "name": "tateossvisage",
+    "type": "helm",
+    "affix": "cleric",
+    "weight": "medium"
+  },
+  {
+    "id": 48016,
+    "name": "tateossleggings",
+    "type": "leggings",
+    "affix": "cleric",
+    "weight": "medium"
+  },
+  {
+    "id": 48017,
+    "name": "tateossshoulderguard",
+    "type": "shoulders",
+    "affix": "cleric",
+    "weight": "medium"
+  },
+  {
+    "id": 48018,
+    "name": "hronksgreaves",
+    "type": "boots",
+    "affix": "magi",
+    "weight": "heavy"
+  },
+  {
+    "id": 48019,
+    "name": "hronksbreastplate",
+    "type": "coat",
+    "affix": "magi",
+    "weight": "heavy"
+  },
+  {
+    "id": 48020,
+    "name": "hronkswarfists",
+    "type": "gloves",
+    "affix": "magi",
+    "weight": "heavy"
+  },
+  {
+    "id": 48021,
+    "name": "hronksvisor",
+    "type": "helm",
+    "affix": "magi",
+    "weight": "heavy"
+  },
+  {
+    "id": 48022,
+    "name": "hronkstassets",
+    "type": "leggings",
+    "affix": "magi",
+    "weight": "heavy"
+  },
+  {
+    "id": 48023,
+    "name": "hronkspauldrons",
+    "type": "shoulders",
+    "affix": "magi",
+    "weight": "heavy"
+  },
+  {
+    "id": 48024,
+    "name": "hronksfootwear",
+    "type": "boots",
+    "affix": "magi",
+    "weight": "light"
+  },
+  {
+    "id": 48025,
+    "name": "hronksdoublet",
+    "type": "coat",
+    "affix": "magi",
+    "weight": "light"
+  },
+  {
+    "id": 48026,
+    "name": "hronkswristguards",
+    "type": "gloves",
+    "affix": "magi",
+    "weight": "light"
+  },
+  {
+    "id": 48027,
+    "name": "hronksmasque",
+    "type": "helm",
+    "affix": "magi",
+    "weight": "light"
+  },
+  {
+    "id": 48028,
+    "name": "hronksbreeches",
+    "type": "leggings",
+    "affix": "magi",
+    "weight": "light"
+  },
+  {
+    "id": 48029,
+    "name": "hronksepaulets",
+    "type": "shoulders",
+    "affix": "magi",
+    "weight": "light"
+  },
+  {
+    "id": 48030,
+    "name": "hronksstriders",
+    "type": "boots",
+    "affix": "magi",
+    "weight": "medium"
+  },
+  {
+    "id": 48031,
+    "name": "hronksguise",
+    "type": "coat",
+    "affix": "magi",
+    "weight": "medium"
+  },
+  {
+    "id": 48032,
+    "name": "hronksgrips",
+    "type": "gloves",
+    "affix": "magi",
+    "weight": "medium"
+  },
+  {
+    "id": 48033,
+    "name": "hronksvisage",
+    "type": "helm",
+    "affix": "magi",
+    "weight": "medium"
+  },
+  {
+    "id": 48034,
+    "name": "hronksleggings",
+    "type": "leggings",
+    "affix": "magi",
+    "weight": "medium"
+  },
+  {
+    "id": 48035,
+    "name": "hronksshoulderguard",
+    "type": "shoulders",
+    "affix": "magi",
+    "weight": "medium"
+  },
+  {
+    "id": 48036,
+    "name": "veldrunnergreaves",
+    "type": "boots",
+    "affix": "apothecary",
+    "weight": "heavy"
+  },
+  {
+    "id": 48037,
+    "name": "veldrunnerbreastplate",
+    "type": "coat",
+    "affix": "apothecary",
+    "weight": "heavy"
+  },
+  {
+    "id": 48038,
+    "name": "veldrunnerwarfists",
+    "type": "gloves",
+    "affix": "apothecary",
+    "weight": "heavy"
+  },
+  {
+    "id": 48039,
+    "name": "veldrunnervisor",
+    "type": "helm",
+    "affix": "apothecary",
+    "weight": "heavy"
+  },
+  {
+    "id": 48040,
+    "name": "veldrunnertassets",
+    "type": "leggings",
+    "affix": "apothecary",
+    "weight": "heavy"
+  },
+  {
+    "id": 48041,
+    "name": "veldrunnerpauldrons",
+    "type": "shoulders",
+    "affix": "apothecary",
+    "weight": "heavy"
+  },
+  {
+    "id": 48042,
+    "name": "veldrunnerfootwear",
+    "type": "boots",
+    "affix": "apothecary",
+    "weight": "light"
+  },
+  {
+    "id": 48043,
+    "name": "veldrunnerdoublet",
+    "type": "coat",
+    "affix": "apothecary",
+    "weight": "light"
+  },
+  {
+    "id": 48044,
+    "name": "veldrunnerwristguards",
+    "type": "gloves",
+    "affix": "apothecary",
+    "weight": "light"
+  },
+  {
+    "id": 48045,
+    "name": "veldrunnermasque",
+    "type": "helm",
+    "affix": "apothecary",
+    "weight": "light"
+  },
+  {
+    "id": 48046,
+    "name": "veldrunnerbreeches",
+    "type": "leggings",
+    "affix": "apothecary",
+    "weight": "light"
+  },
+  {
+    "id": 48047,
+    "name": "veldrunnerepaulets",
+    "type": "shoulders",
+    "affix": "apothecary",
+    "weight": "light"
+  },
+  {
+    "id": 48048,
+    "name": "veldrunnerstriders",
+    "type": "boots",
+    "affix": "apothecary",
+    "weight": "medium"
+  },
+  {
+    "id": 48049,
+    "name": "veldrunnerguise",
+    "type": "coat",
+    "affix": "apothecary",
+    "weight": "medium"
+  },
+  {
+    "id": 48050,
+    "name": "veldrunnergrips",
+    "type": "gloves",
+    "affix": "apothecary",
+    "weight": "medium"
+  },
+  {
+    "id": 48051,
+    "name": "veldrunnervisage",
+    "type": "helm",
+    "affix": "apothecary",
+    "weight": "medium"
+  },
+  {
+    "id": 48052,
+    "name": "veldrunnerleggings",
+    "type": "leggings",
+    "affix": "apothecary",
+    "weight": "medium"
+  },
+  {
+    "id": 48053,
+    "name": "veldrunnershoulderguard",
+    "type": "shoulders",
+    "affix": "apothecary",
+    "weight": "medium"
+  },
+  {
+    "id": 48054,
+    "name": "gobrechsgreaves",
+    "type": "boots",
+    "affix": "valkyrie",
+    "weight": "heavy"
+  },
+  {
+    "id": 48055,
+    "name": "gobrechsbreastplate",
+    "type": "coat",
+    "affix": "valkyrie",
+    "weight": "heavy"
+  },
+  {
+    "id": 48056,
+    "name": "gobrechswarfists",
+    "type": "gloves",
+    "affix": "valkyrie",
+    "weight": "heavy"
+  },
+  {
+    "id": 48057,
+    "name": "gobrechsvisor",
+    "type": "helm",
+    "affix": "valkyrie",
+    "weight": "heavy"
+  },
+  {
+    "id": 48058,
+    "name": "gobrechstassets",
+    "type": "leggings",
+    "affix": "valkyrie",
+    "weight": "heavy"
+  },
+  {
+    "id": 48059,
+    "name": "gobrechspauldrons",
+    "type": "shoulders",
+    "affix": "valkyrie",
+    "weight": "heavy"
+  },
+  {
+    "id": 48060,
+    "name": "gobrechsfootwear",
+    "type": "boots",
+    "affix": "valkyrie",
+    "weight": "light"
+  },
+  {
+    "id": 48061,
+    "name": "gobrechsdoublet",
+    "type": "coat",
+    "affix": "valkyrie",
+    "weight": "light"
+  },
+  {
+    "id": 48062,
+    "name": "gobrechswristguards",
+    "type": "gloves",
+    "affix": "valkyrie",
+    "weight": "light"
+  },
+  {
+    "id": 48063,
+    "name": "gobrechsmasque",
+    "type": "helm",
+    "affix": "valkyrie",
+    "weight": "light"
+  },
+  {
+    "id": 48064,
+    "name": "gobrechsbreeches",
+    "type": "leggings",
+    "affix": "valkyrie",
+    "weight": "light"
+  },
+  {
+    "id": 48065,
+    "name": "gobrechsepaulets",
+    "type": "shoulders",
+    "affix": "valkyrie",
+    "weight": "light"
+  },
+  {
+    "id": 48066,
+    "name": "gobrechsstriders",
+    "type": "boots",
+    "affix": "valkyrie",
+    "weight": "medium"
+  },
+  {
+    "id": 48067,
+    "name": "gobrechsguise",
+    "type": "coat",
+    "affix": "valkyrie",
+    "weight": "medium"
+  },
+  {
+    "id": 48068,
+    "name": "gobrechsgrips",
+    "type": "gloves",
+    "affix": "valkyrie",
+    "weight": "medium"
+  },
+  {
+    "id": 48069,
+    "name": "gobrechsvisage",
+    "type": "helm",
+    "affix": "valkyrie",
+    "weight": "medium"
+  },
+  {
+    "id": 48070,
+    "name": "gobrechsleggings",
+    "type": "leggings",
+    "affix": "valkyrie",
+    "weight": "medium"
+  },
+  {
+    "id": 48071,
+    "name": "gobrechsshoulderguard",
+    "type": "shoulders",
+    "affix": "valkyrie",
+    "weight": "medium"
+  },
+  {
+    "id": 48072,
+    "name": "zojjasgreaves",
+    "type": "boots",
+    "affix": "berserker",
+    "weight": "heavy"
+  },
+  {
+    "id": 48073,
+    "name": "zojjasbreastplate",
+    "type": "coat",
+    "affix": "berserker",
+    "weight": "heavy"
+  },
+  {
+    "id": 48074,
+    "name": "zojjaswarfists",
+    "type": "gloves",
+    "affix": "berserker",
+    "weight": "heavy"
+  },
+  {
+    "id": 48075,
+    "name": "zojjasvisor",
+    "type": "helm",
+    "affix": "berserker",
+    "weight": "heavy"
+  },
+  {
+    "id": 48076,
+    "name": "zojjastassets",
+    "type": "leggings",
+    "affix": "berserker",
+    "weight": "heavy"
+  },
+  {
+    "id": 48077,
+    "name": "zojjaspauldrons",
+    "type": "shoulders",
+    "affix": "berserker",
+    "weight": "heavy"
+  },
+  {
+    "id": 48078,
+    "name": "zojjasfootwear",
+    "type": "boots",
+    "affix": "berserker",
+    "weight": "light"
+  },
+  {
+    "id": 48079,
+    "name": "zojjasdoublet",
+    "type": "coat",
+    "affix": "berserker",
+    "weight": "light"
+  },
+  {
+    "id": 48080,
+    "name": "zojjaswristguards",
+    "type": "gloves",
+    "affix": "berserker",
+    "weight": "light"
+  },
+  {
+    "id": 48081,
+    "name": "zojjasmasque",
+    "type": "helm",
+    "affix": "berserker",
+    "weight": "light"
+  },
+  {
+    "id": 48082,
+    "name": "zojjasbreeches",
+    "type": "leggings",
+    "affix": "berserker",
+    "weight": "light"
+  },
+  {
+    "id": 48083,
+    "name": "zojjasepaulets",
+    "type": "shoulders",
+    "affix": "berserker",
+    "weight": "light"
+  },
+  {
+    "id": 48084,
+    "name": "zojjasstriders",
+    "type": "boots",
+    "affix": "berserker",
+    "weight": "medium"
+  },
+  {
+    "id": 48085,
+    "name": "zojjasguise",
+    "type": "coat",
+    "affix": "berserker",
+    "weight": "medium"
+  },
+  {
+    "id": 48086,
+    "name": "zojjasgrips",
+    "type": "gloves",
+    "affix": "berserker",
+    "weight": "medium"
+  },
+  {
+    "id": 48087,
+    "name": "zojjasvisage",
+    "type": "helm",
+    "affix": "berserker",
+    "weight": "medium"
+  },
+  {
+    "id": 48088,
+    "name": "zojjasleggings",
+    "type": "leggings",
+    "affix": "berserker",
+    "weight": "medium"
+  },
+  {
+    "id": 48089,
+    "name": "zojjasshoulderguard",
+    "type": "shoulders",
+    "affix": "berserker",
+    "weight": "medium"
+  },
+  {
+    "id": 48090,
+    "name": "ahamidsgreaves",
+    "type": "boots",
+    "affix": "soldier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48091,
+    "name": "ahamidsbreastplate",
+    "type": "coat",
+    "affix": "soldier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48092,
+    "name": "ahamidswarfists",
+    "type": "gloves",
+    "affix": "soldier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48093,
+    "name": "ahamidsvisor",
+    "type": "helm",
+    "affix": "soldier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48094,
+    "name": "ahamidstassets",
+    "type": "leggings",
+    "affix": "soldier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48095,
+    "name": "ahamidspauldrons",
+    "type": "shoulders",
+    "affix": "soldier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48096,
+    "name": "ahamidsfootwear",
+    "type": "boots",
+    "affix": "soldier",
+    "weight": "light"
+  },
+  {
+    "id": 48097,
+    "name": "ahamidsdoublet",
+    "type": "coat",
+    "affix": "soldier",
+    "weight": "light"
+  },
+  {
+    "id": 48098,
+    "name": "ahamidswristguards",
+    "type": "gloves",
+    "affix": "soldier",
+    "weight": "light"
+  },
+  {
+    "id": 48099,
+    "name": "ahamidsmasque",
+    "type": "helm",
+    "affix": "soldier",
+    "weight": "light"
+  },
+  {
+    "id": 48100,
+    "name": "ahamidsbreeches",
+    "type": "leggings",
+    "affix": "soldier",
+    "weight": "light"
+  },
+  {
+    "id": 48101,
+    "name": "ahamidsepaulets",
+    "type": "shoulders",
+    "affix": "soldier",
+    "weight": "light"
+  },
+  {
+    "id": 48102,
+    "name": "ahamidsstriders",
+    "type": "boots",
+    "affix": "soldier",
+    "weight": "medium"
+  },
+  {
+    "id": 48103,
+    "name": "ahamidsguise",
+    "type": "coat",
+    "affix": "soldier",
+    "weight": "medium"
+  },
+  {
+    "id": 48104,
+    "name": "ahamidsgrips",
+    "type": "gloves",
+    "affix": "soldier",
+    "weight": "medium"
+  },
+  {
+    "id": 48105,
+    "name": "ahamidsvisage",
+    "type": "helm",
+    "affix": "soldier",
+    "weight": "medium"
+  },
+  {
+    "id": 48106,
+    "name": "ahamidsleggings",
+    "type": "leggings",
+    "affix": "soldier",
+    "weight": "medium"
+  },
+  {
+    "id": 48107,
+    "name": "ahamidsshoulderguard",
+    "type": "shoulders",
+    "affix": "soldier",
+    "weight": "medium"
+  },
+  {
+    "id": 48108,
+    "name": "forgemastersgreaves",
+    "type": "boots",
+    "affix": "rampager",
+    "weight": "heavy"
+  },
+  {
+    "id": 48109,
+    "name": "forgemastersbreastplate",
+    "type": "coat",
+    "affix": "rampager",
+    "weight": "heavy"
+  },
+  {
+    "id": 48110,
+    "name": "forgemasterswarfists",
+    "type": "gloves",
+    "affix": "rampager",
+    "weight": "heavy"
+  },
+  {
+    "id": 48111,
+    "name": "forgemastersvisor",
+    "type": "helm",
+    "affix": "rampager",
+    "weight": "heavy"
+  },
+  {
+    "id": 48112,
+    "name": "forgemasterstassets",
+    "type": "leggings",
+    "affix": "rampager",
+    "weight": "heavy"
+  },
+  {
+    "id": 48113,
+    "name": "forgemasterspauldrons",
+    "type": "shoulders",
+    "affix": "rampager",
+    "weight": "heavy"
+  },
+  {
+    "id": 48114,
+    "name": "forgemastersfootwear",
+    "type": "boots",
+    "affix": "rampager",
+    "weight": "light"
+  },
+  {
+    "id": 48115,
+    "name": "forgemastersdoublet",
+    "type": "coat",
+    "affix": "rampager",
+    "weight": "light"
+  },
+  {
+    "id": 48116,
+    "name": "forgemasterswristguards",
+    "type": "gloves",
+    "affix": "rampager",
+    "weight": "light"
+  },
+  {
+    "id": 48117,
+    "name": "forgemastersmasque",
+    "type": "helm",
+    "affix": "rampager",
+    "weight": "light"
+  },
+  {
+    "id": 48118,
+    "name": "forgemastersbreeches",
+    "type": "leggings",
+    "affix": "rampager",
+    "weight": "light"
+  },
+  {
+    "id": 48119,
+    "name": "forgemastersepaulets",
+    "type": "shoulders",
+    "affix": "rampager",
+    "weight": "light"
+  },
+  {
+    "id": 48120,
+    "name": "forgemastersstriders",
+    "type": "boots",
+    "affix": "rampager",
+    "weight": "medium"
+  },
+  {
+    "id": 48121,
+    "name": "forgemastersguise",
+    "type": "coat",
+    "affix": "rampager",
+    "weight": "medium"
+  },
+  {
+    "id": 48122,
+    "name": "forgemastersgrips",
+    "type": "gloves",
+    "affix": "rampager",
+    "weight": "medium"
+  },
+  {
+    "id": 48123,
+    "name": "forgemastersvisage",
+    "type": "helm",
+    "affix": "rampager",
+    "weight": "medium"
+  },
+  {
+    "id": 48124,
+    "name": "forgemastersleggings",
+    "type": "leggings",
+    "affix": "rampager",
+    "weight": "medium"
+  },
+  {
+    "id": 48125,
+    "name": "forgemastersshoulderguard",
+    "type": "shoulders",
+    "affix": "rampager",
+    "weight": "medium"
+  },
+  {
+    "id": 48126,
+    "name": "saphirsgreaves",
+    "type": "boots",
+    "affix": "assassin",
+    "weight": "heavy"
+  },
+  {
+    "id": 48127,
+    "name": "saphirsbreastplate",
+    "type": "coat",
+    "affix": "assassin",
+    "weight": "heavy"
+  },
+  {
+    "id": 48128,
+    "name": "saphirswarfists",
+    "type": "gloves",
+    "affix": "assassin",
+    "weight": "heavy"
+  },
+  {
+    "id": 48129,
+    "name": "saphirsvisor",
+    "type": "helm",
+    "affix": "assassin",
+    "weight": "heavy"
+  },
+  {
+    "id": 48130,
+    "name": "saphirstassets",
+    "type": "leggings",
+    "affix": "assassin",
+    "weight": "heavy"
+  },
+  {
+    "id": 48131,
+    "name": "saphirspauldrons",
+    "type": "shoulders",
+    "affix": "assassin",
+    "weight": "heavy"
+  },
+  {
+    "id": 48132,
+    "name": "saphirsfootwear",
+    "type": "boots",
+    "affix": "assassin",
+    "weight": "light"
+  },
+  {
+    "id": 48133,
+    "name": "saphirsdoublet",
+    "type": "coat",
+    "affix": "assassin",
+    "weight": "light"
+  },
+  {
+    "id": 48134,
+    "name": "saphirswristguards",
+    "type": "gloves",
+    "affix": "assassin",
+    "weight": "light"
+  },
+  {
+    "id": 48135,
+    "name": "saphirsmasque",
+    "type": "helm",
+    "affix": "assassin",
+    "weight": "light"
+  },
+  {
+    "id": 48136,
+    "name": "saphirsbreeches",
+    "type": "leggings",
+    "affix": "assassin",
+    "weight": "light"
+  },
+  {
+    "id": 48137,
+    "name": "saphirsepaulets",
+    "type": "shoulders",
+    "affix": "assassin",
+    "weight": "light"
+  },
+  {
+    "id": 48138,
+    "name": "saphirsstriders",
+    "type": "boots",
+    "affix": "assassin",
+    "weight": "medium"
+  },
+  {
+    "id": 48139,
+    "name": "saphirsguise",
+    "type": "coat",
+    "affix": "assassin",
+    "weight": "medium"
+  },
+  {
+    "id": 48140,
+    "name": "saphirsgrips",
+    "type": "gloves",
+    "affix": "assassin",
+    "weight": "medium"
+  },
+  {
+    "id": 48141,
+    "name": "saphirsvisage",
+    "type": "helm",
+    "affix": "assassin",
+    "weight": "medium"
+  },
+  {
+    "id": 48142,
+    "name": "saphirsleggings",
+    "type": "leggings",
+    "affix": "assassin",
+    "weight": "medium"
+  },
+  {
+    "id": 48143,
+    "name": "saphirsshoulderguard",
+    "type": "shoulders",
+    "affix": "assassin",
+    "weight": "medium"
+  },
+  {
+    "id": 48144,
+    "name": "leftpawsgreaves",
+    "type": "boots",
+    "affix": "settler",
+    "weight": "heavy"
+  },
+  {
+    "id": 48145,
+    "name": "leftpawsbreastplate",
+    "type": "coat",
+    "affix": "settler",
+    "weight": "heavy"
+  },
+  {
+    "id": 48146,
+    "name": "leftpawswarfists",
+    "type": "gloves",
+    "affix": "settler",
+    "weight": "heavy"
+  },
+  {
+    "id": 48147,
+    "name": "leftpawsvisor",
+    "type": "helm",
+    "affix": "settler",
+    "weight": "heavy"
+  },
+  {
+    "id": 48148,
+    "name": "leftpawstassets",
+    "type": "leggings",
+    "affix": "settler",
+    "weight": "heavy"
+  },
+  {
+    "id": 48149,
+    "name": "leftpawspauldrons",
+    "type": "shoulders",
+    "affix": "settler",
+    "weight": "heavy"
+  },
+  {
+    "id": 48150,
+    "name": "leftpawsfootwear",
+    "type": "boots",
+    "affix": "settler",
+    "weight": "light"
+  },
+  {
+    "id": 48151,
+    "name": "leftpawsdoublet",
+    "type": "coat",
+    "affix": "settler",
+    "weight": "light"
+  },
+  {
+    "id": 48152,
+    "name": "leftpawswristguards",
+    "type": "gloves",
+    "affix": "settler",
+    "weight": "light"
+  },
+  {
+    "id": 48153,
+    "name": "leftpawsmasque",
+    "type": "helm",
+    "affix": "settler",
+    "weight": "light"
+  },
+  {
+    "id": 48154,
+    "name": "leftpawsbreeches",
+    "type": "leggings",
+    "affix": "settler",
+    "weight": "light"
+  },
+  {
+    "id": 48155,
+    "name": "leftpawsepaulets",
+    "type": "shoulders",
+    "affix": "settler",
+    "weight": "light"
+  },
+  {
+    "id": 48156,
+    "name": "leftpawsstriders",
+    "type": "boots",
+    "affix": "settler",
+    "weight": "medium"
+  },
+  {
+    "id": 48157,
+    "name": "leftpawsguise",
+    "type": "coat",
+    "affix": "settler",
+    "weight": "medium"
+  },
+  {
+    "id": 48158,
+    "name": "leftpawsgrips",
+    "type": "gloves",
+    "affix": "settler",
+    "weight": "medium"
+  },
+  {
+    "id": 48159,
+    "name": "leftpawsvisage",
+    "type": "helm",
+    "affix": "settler",
+    "weight": "medium"
+  },
+  {
+    "id": 48160,
+    "name": "leftpawsleggings",
+    "type": "leggings",
+    "affix": "settler",
+    "weight": "medium"
+  },
+  {
+    "id": 48161,
+    "name": "leftpawsshoulderguard",
+    "type": "shoulders",
+    "affix": "settler",
+    "weight": "medium"
+  },
+  {
+    "id": 48162,
+    "name": "angchugreaves",
+    "type": "boots",
+    "affix": "cavalier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48163,
+    "name": "angchubreastplate",
+    "type": "coat",
+    "affix": "cavalier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48164,
+    "name": "angchuwarfists",
+    "type": "gloves",
+    "affix": "cavalier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48165,
+    "name": "angchuvisor",
+    "type": "helm",
+    "affix": "cavalier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48166,
+    "name": "angchutassets",
+    "type": "leggings",
+    "affix": "cavalier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48167,
+    "name": "angchupauldrons",
+    "type": "shoulders",
+    "affix": "cavalier",
+    "weight": "heavy"
+  },
+  {
+    "id": 48168,
+    "name": "angchufootwear",
+    "type": "boots",
+    "affix": "cavalier",
+    "weight": "light"
+  },
+  {
+    "id": 48169,
+    "name": "angchudoublet",
+    "type": "coat",
+    "affix": "cavalier",
+    "weight": "light"
+  },
+  {
+    "id": 48170,
+    "name": "angchuwristguards",
+    "type": "gloves",
+    "affix": "cavalier",
+    "weight": "light"
+  },
+  {
+    "id": 48171,
+    "name": "angchumasque",
+    "type": "helm",
+    "affix": "cavalier",
+    "weight": "light"
+  },
+  {
+    "id": 48172,
+    "name": "angchubreeches",
+    "type": "leggings",
+    "affix": "cavalier",
+    "weight": "light"
+  },
+  {
+    "id": 48173,
+    "name": "angchuepaulets",
+    "type": "shoulders",
+    "affix": "cavalier",
+    "weight": "light"
+  },
+  {
+    "id": 48174,
+    "name": "angchustriders",
+    "type": "boots",
+    "affix": "cavalier",
+    "weight": "medium"
+  },
+  {
+    "id": 48175,
+    "name": "angchuguise",
+    "type": "coat",
+    "affix": "cavalier",
+    "weight": "medium"
+  },
+  {
+    "id": 48176,
+    "name": "angchugrips",
+    "type": "gloves",
+    "affix": "cavalier",
+    "weight": "medium"
+  },
+  {
+    "id": 48177,
+    "name": "angchuvisage",
+    "type": "helm",
+    "affix": "cavalier",
+    "weight": "medium"
+  },
+  {
+    "id": 48178,
+    "name": "angchuleggings",
+    "type": "leggings",
+    "affix": "cavalier",
+    "weight": "medium"
+  },
+  {
+    "id": 48179,
+    "name": "angchushoulderguard",
+    "type": "shoulders",
+    "affix": "cavalier",
+    "weight": "medium"
+  },
+  {
+    "id": 48180,
+    "name": "zintlgreaves",
+    "type": "boots",
+    "affix": "shaman",
+    "weight": "heavy"
+  },
+  {
+    "id": 48181,
+    "name": "zintlbreastplate",
+    "type": "coat",
+    "affix": "shaman",
+    "weight": "heavy"
+  },
+  {
+    "id": 48182,
+    "name": "zintlwarfists",
+    "type": "gloves",
+    "affix": "shaman",
+    "weight": "heavy"
+  },
+  {
+    "id": 48183,
+    "name": "zintlvisor",
+    "type": "helm",
+    "affix": "shaman",
+    "weight": "heavy"
+  },
+  {
+    "id": 48184,
+    "name": "zintltassets",
+    "type": "leggings",
+    "affix": "shaman",
+    "weight": "heavy"
+  },
+  {
+    "id": 48185,
+    "name": "zintlpauldrons",
+    "type": "shoulders",
+    "affix": "shaman",
+    "weight": "heavy"
+  },
+  {
+    "id": 48186,
+    "name": "zintlfootwear",
+    "type": "boots",
+    "affix": "shaman",
+    "weight": "light"
+  },
+  {
+    "id": 48187,
+    "name": "zintldoublet",
+    "type": "coat",
+    "affix": "shaman",
+    "weight": "light"
+  },
+  {
+    "id": 48188,
+    "name": "zintlwristguards",
+    "type": "gloves",
+    "affix": "shaman",
+    "weight": "light"
+  },
+  {
+    "id": 48189,
+    "name": "zintlmasque",
+    "type": "helm",
+    "affix": "shaman",
+    "weight": "light"
+  },
+  {
+    "id": 48190,
+    "name": "zintlbreeches",
+    "type": "leggings",
+    "affix": "shaman",
+    "weight": "light"
+  },
+  {
+    "id": 48191,
+    "name": "zintlepaulets",
+    "type": "shoulders",
+    "affix": "shaman",
+    "weight": "light"
+  },
+  {
+    "id": 48192,
+    "name": "zintlstriders",
+    "type": "boots",
+    "affix": "shaman",
+    "weight": "medium"
+  },
+  {
+    "id": 48193,
+    "name": "zintlguise",
+    "type": "coat",
+    "affix": "shaman",
+    "weight": "medium"
+  },
+  {
+    "id": 48194,
+    "name": "zintlgrips",
+    "type": "gloves",
+    "affix": "shaman",
+    "weight": "medium"
+  },
+  {
+    "id": 48195,
+    "name": "zintlvisage",
+    "type": "helm",
+    "affix": "shaman",
+    "weight": "medium"
+  },
+  {
+    "id": 48196,
+    "name": "zintlleggings",
+    "type": "leggings",
+    "affix": "shaman",
+    "weight": "medium"
+  },
+  {
+    "id": 48197,
+    "name": "zintlshoulderguard",
+    "type": "shoulders",
+    "affix": "shaman",
+    "weight": "medium"
+  },
+  {
+    "id": 48198,
+    "name": "weiqisgreaves",
+    "type": "boots",
+    "affix": "sentinel",
+    "weight": "heavy"
+  },
+  {
+    "id": 48199,
+    "name": "weiqisbreastplate",
+    "type": "coat",
+    "affix": "sentinel",
+    "weight": "heavy"
+  },
+  {
+    "id": 48200,
+    "name": "weiqiswarfists",
+    "type": "gloves",
+    "affix": "sentinel",
+    "weight": "heavy"
+  },
+  {
+    "id": 48201,
+    "name": "weiqisvisor",
+    "type": "helm",
+    "affix": "sentinel",
+    "weight": "heavy"
+  },
+  {
+    "id": 48202,
+    "name": "weiqistassets",
+    "type": "leggings",
+    "affix": "sentinel",
+    "weight": "heavy"
+  },
+  {
+    "id": 48203,
+    "name": "weiqispauldrons",
+    "type": "shoulders",
+    "affix": "sentinel",
+    "weight": "heavy"
+  },
+  {
+    "id": 48204,
+    "name": "weiqisfootwear",
+    "type": "boots",
+    "affix": "sentinel",
+    "weight": "light"
+  },
+  {
+    "id": 48205,
+    "name": "weiqisdoublet",
+    "type": "coat",
+    "affix": "sentinel",
+    "weight": "light"
+  },
+  {
+    "id": 48206,
+    "name": "weiqiswristguards",
+    "type": "gloves",
+    "affix": "sentinel",
+    "weight": "light"
+  },
+  {
+    "id": 48207,
+    "name": "weiqismasque",
+    "type": "helm",
+    "affix": "sentinel",
+    "weight": "light"
+  },
+  {
+    "id": 48208,
+    "name": "weiqisbreeches",
+    "type": "leggings",
+    "affix": "sentinel",
+    "weight": "light"
+  },
+  {
+    "id": 48209,
+    "name": "weiqisepaulets",
+    "type": "shoulders",
+    "affix": "sentinel",
+    "weight": "light"
+  },
+  {
+    "id": 48210,
+    "name": "weiqisstriders",
+    "type": "boots",
+    "affix": "sentinel",
+    "weight": "medium"
+  },
+  {
+    "id": 48211,
+    "name": "weiqisguise",
+    "type": "coat",
+    "affix": "sentinel",
+    "weight": "medium"
+  },
+  {
+    "id": 48212,
+    "name": "weiqisgrips",
+    "type": "gloves",
+    "affix": "sentinel",
+    "weight": "medium"
+  },
+  {
+    "id": 48213,
+    "name": "weiqisvisage",
+    "type": "helm",
+    "affix": "sentinel",
+    "weight": "medium"
+  },
+  {
+    "id": 48214,
+    "name": "weiqisleggings",
+    "type": "leggings",
+    "affix": "sentinel",
+    "weight": "medium"
+  },
+  {
+    "id": 48215,
+    "name": "weiqisshoulderguard",
+    "type": "shoulders",
+    "affix": "sentinel",
+    "weight": "medium"
+  },
+  {
+    "id": 48907,
+    "name": "antitoxin",
+    "type": "rune"
+  },
+  {
+    "id": 48911,
+    "name": "torment",
+    "type": "sigil"
+  },
+  {
+    "id": 48915,
+    "name": "toxicsharpeningstone",
+    "type": "utility"
+  },
+  {
+    "id": 48916,
+    "name": "toxicmaintenanceoil",
+    "type": "utility"
+  },
+  {
+    "id": 48917,
+    "name": "toxicfocusingcrystal",
+    "type": "utility"
+  },
+  {
+    "id": 48921,
+    "name": "bowlofmarjorysexperimentalchili",
+    "type": "food"
+  },
+  {
+    "id": 49372,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "soldier"
+  },
+  {
+    "id": 49373,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "soldier"
+  },
+  {
+    "id": 49376,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "cavalier"
+  },
+  {
+    "id": 49377,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "cavalier"
+  },
+  {
+    "id": 49378,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "rabid"
+  },
+  {
+    "id": 49379,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "rabid"
+  },
+  {
+    "id": 49380,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "berserker"
+  },
+  {
+    "id": 49381,
+    "name": "betafractalcapacitorinfused",
+    "type": "backitem",
+    "affix": "berserker"
+  },
+  {
+    "id": 49457,
+    "name": "momentum",
+    "type": "sigil"
+  },
+  {
+    "id": 49460,
+    "name": "resistance",
+    "type": "rune"
+  },
+  {
+    "id": 49611,
+    "name": "keeperswarfists",
+    "type": "gloves",
+    "affix": "zealot",
+    "weight": "heavy"
+  },
+  {
+    "id": 49612,
+    "name": "keepersshoulderguard",
+    "type": "shoulders",
+    "affix": "zealot",
+    "weight": "medium"
+  },
+  {
+    "id": 49613,
+    "name": "keepersleggings",
+    "type": "leggings",
+    "affix": "zealot",
+    "weight": "medium"
+  },
+  {
+    "id": 49614,
+    "name": "keepersvisage",
+    "type": "helm",
+    "affix": "zealot",
+    "weight": "medium"
+  },
+  {
+    "id": 49615,
+    "name": "keepersgrips",
+    "type": "gloves",
+    "affix": "zealot",
+    "weight": "medium"
+  },
+  {
+    "id": 49616,
+    "name": "keepersguise",
+    "type": "coat",
+    "affix": "zealot",
+    "weight": "medium"
+  },
+  {
+    "id": 49617,
+    "name": "keepersstriders",
+    "type": "boots",
+    "affix": "zealot",
+    "weight": "medium"
+  },
+  {
+    "id": 49618,
+    "name": "keepersepaulets",
+    "type": "shoulders",
+    "affix": "zealot",
+    "weight": "light"
+  },
+  {
+    "id": 49619,
+    "name": "keepersbreeches",
+    "type": "leggings",
+    "affix": "zealot",
+    "weight": "light"
+  },
+  {
+    "id": 49620,
+    "name": "keepersmasque",
+    "type": "helm",
+    "affix": "zealot",
+    "weight": "light"
+  },
+  {
+    "id": 49621,
+    "name": "keeperswristguards",
+    "type": "gloves",
+    "affix": "zealot",
+    "weight": "light"
+  },
+  {
+    "id": 49622,
+    "name": "keepersdoublet",
+    "type": "coat",
+    "affix": "zealot",
+    "weight": "light"
+  },
+  {
+    "id": 49623,
+    "name": "keepersfootwear",
+    "type": "boots",
+    "affix": "zealot",
+    "weight": "light"
+  },
+  {
+    "id": 49624,
+    "name": "keeperspauldrons",
+    "type": "shoulders",
+    "affix": "zealot",
+    "weight": "heavy"
+  },
+  {
+    "id": 49625,
+    "name": "keeperstassets",
+    "type": "leggings",
+    "affix": "zealot",
+    "weight": "heavy"
+  },
+  {
+    "id": 49626,
+    "name": "keepersvisor",
+    "type": "helm",
+    "affix": "zealot",
+    "weight": "heavy"
+  },
+  {
+    "id": 49627,
+    "name": "keepersbreastplate",
+    "type": "coat",
+    "affix": "zealot",
+    "weight": "heavy"
+  },
+  {
+    "id": 49628,
+    "name": "keepersgreaves",
+    "type": "boots",
+    "affix": "zealot",
+    "weight": "heavy"
+  },
+  {
+    "id": 49874,
+    "name": "keepersartifact",
+    "type": "focus",
+    "affix": "zealot"
+  },
+  {
+    "id": 49875,
+    "name": "keepersbastion",
+    "type": "shield",
+    "affix": "zealot"
+  },
+  {
+    "id": 49876,
+    "name": "keepersshortbow",
+    "type": "shortbow",
+    "affix": "zealot"
+  },
+  {
+    "id": 49877,
+    "name": "keepersharpoongun",
+    "type": "speargun",
+    "affix": "zealot"
+  },
+  {
+    "id": 49878,
+    "name": "keepersspire",
+    "type": "staff",
+    "affix": "zealot"
+  },
+  {
+    "id": 49879,
+    "name": "keepersblade",
+    "type": "sword",
+    "affix": "zealot"
+  },
+  {
+    "id": 49880,
+    "name": "keepersreaver",
+    "type": "axe",
+    "affix": "zealot"
+  },
+  {
+    "id": 49881,
+    "name": "keepersbrazier",
+    "type": "torch",
+    "affix": "zealot"
+  },
+  {
+    "id": 49882,
+    "name": "keepersrazor",
+    "type": "dagger",
+    "affix": "zealot"
+  },
+  {
+    "id": 49883,
+    "name": "keepersherald",
+    "type": "warhorn",
+    "affix": "zealot"
+  },
+  {
+    "id": 49884,
+    "name": "keepersclaymore",
+    "type": "greatsword",
+    "affix": "zealot"
+  },
+  {
+    "id": 49885,
+    "name": "keeperswarhammer",
+    "type": "hammer",
+    "affix": "zealot"
+  },
+  {
+    "id": 49886,
+    "name": "keepersimpaler",
+    "type": "harpoon",
+    "affix": "zealot"
+  },
+  {
+    "id": 49887,
+    "name": "keepersgreatbow",
+    "type": "longbow",
+    "affix": "zealot"
+  },
+  {
+    "id": 49888,
+    "name": "keepersflangedmace",
+    "type": "mace",
+    "affix": "zealot"
+  },
+  {
+    "id": 49889,
+    "name": "keepersrevolver",
+    "type": "pistol",
+    "affix": "zealot"
+  },
+  {
+    "id": 49890,
+    "name": "keepersmusket",
+    "type": "rifle",
+    "affix": "zealot"
+  },
+  {
+    "id": 49891,
+    "name": "keeperswand",
+    "type": "scepter",
+    "affix": "zealot"
+  },
+  {
+    "id": 49892,
+    "name": "keeperstrident",
+    "type": "trident",
+    "affix": "zealot"
+  },
+  {
+    "id": 49940,
+    "name": "executioneraxetoy",
+    "type": "gizmo"
+  },
+  {
+    "id": 50082,
+    "name": "powerfulpotionofslayingscarletsarmies",
+    "type": "utility"
+  },
+  {
+    "id": 63366,
+    "type": "rune"
+  },
+  {
+    "id": 66359,
+    "name": "ventariswristguards",
+    "type": "gloves",
+    "affix": "nomad",
+    "weight": "light"
+  },
+  {
+    "id": 66360,
+    "name": "ventarisshoulderguard",
+    "type": "shoulders",
+    "affix": "nomad",
+    "weight": "medium"
+  },
+  {
+    "id": 66361,
+    "name": "ventarisleggings",
+    "type": "leggings",
+    "affix": "nomad",
+    "weight": "medium"
+  },
+  {
+    "id": 66362,
+    "name": "ventarisvisage",
+    "type": "helm",
+    "affix": "nomad",
+    "weight": "medium"
+  },
+  {
+    "id": 66363,
+    "name": "ventarisgrips",
+    "type": "gloves",
+    "affix": "nomad",
+    "weight": "medium"
+  },
+  {
+    "id": 66364,
+    "name": "ventarisguise",
+    "type": "coat",
+    "affix": "nomad",
+    "weight": "medium"
+  },
+  {
+    "id": 66365,
+    "name": "ventarisstriders",
+    "type": "boots",
+    "affix": "nomad",
+    "weight": "medium"
+  },
+  {
+    "id": 66366,
+    "name": "ventarisepaulets",
+    "type": "shoulders",
+    "affix": "nomad",
+    "weight": "light"
+  },
+  {
+    "id": 66367,
+    "name": "ventarisbreeches",
+    "type": "leggings",
+    "affix": "nomad",
+    "weight": "light"
+  },
+  {
+    "id": 66368,
+    "name": "ventarisgreaves",
+    "type": "boots",
+    "affix": "nomad",
+    "weight": "heavy"
+  },
+  {
+    "id": 66369,
+    "name": "ventarisvisor",
+    "type": "helm",
+    "affix": "nomad",
+    "weight": "heavy"
+  },
+  {
+    "id": 66370,
+    "name": "ventarisdoublet",
+    "type": "coat",
+    "affix": "nomad",
+    "weight": "light"
+  },
+  {
+    "id": 66371,
+    "name": "ventarisfootwear",
+    "type": "boots",
+    "affix": "nomad",
+    "weight": "light"
+  },
+  {
+    "id": 66372,
+    "name": "ventarispauldrons",
+    "type": "shoulders",
+    "affix": "nomad",
+    "weight": "heavy"
+  },
+  {
+    "id": 66373,
+    "name": "ventaristassets",
+    "type": "leggings",
+    "affix": "nomad",
+    "weight": "heavy"
+  },
+  {
+    "id": 66374,
+    "name": "ventariswarfists",
+    "type": "gloves",
+    "affix": "nomad",
+    "weight": "heavy"
+  },
+  {
+    "id": 66375,
+    "name": "ventarisbreastplate",
+    "type": "coat",
+    "affix": "nomad",
+    "weight": "heavy"
+  },
+  {
+    "id": 66376,
+    "name": "ventarismasque",
+    "type": "helm",
+    "affix": "nomad",
+    "weight": "light"
+  },
+  {
+    "id": 66523,
+    "name": "bowlofcactusfruitsalad",
+    "type": "food"
+  },
+  {
+    "id": 66526,
+    "name": "pricklypearstuffednopal",
+    "type": "food"
+  },
+  {
+    "id": 66527,
+    "name": "loafofcandycactuscornbread",
+    "type": "food"
+  },
+  {
+    "id": 66528,
+    "name": "bowlofsweetandspicybeans",
+    "type": "food"
+  },
+  {
+    "id": 66529,
+    "name": "bowlofblackpeppercactussalad",
+    "type": "food"
+  },
+  {
+    "id": 66530,
+    "name": "bowlofnopalitossaut",
+    "type": "food"
+  },
+  {
+    "id": 66531,
+    "name": "bowlofcactussoup",
+    "type": "food"
+  },
+  {
+    "id": 66536,
+    "name": "plateofroastedcactus",
+    "type": "food"
+  },
+  {
+    "id": 66538,
+    "name": "pricklypearpie",
+    "type": "food"
+  },
+  {
+    "id": 66539,
+    "name": "bowlofpricklypearsorbet",
+    "type": "food"
+  },
+  {
+    "id": 66672,
+    "name": "ventarisblade",
+    "type": "sword",
+    "affix": "nomad"
+  },
+  {
+    "id": 66673,
+    "name": "ventarisreaver",
+    "type": "axe",
+    "affix": "nomad"
+  },
+  {
+    "id": 66674,
+    "name": "ventariswand",
+    "type": "scepter",
+    "affix": "nomad"
+  },
+  {
+    "id": 66675,
+    "name": "ventarisbastion",
+    "type": "shield",
+    "affix": "nomad"
+  },
+  {
+    "id": 66676,
+    "name": "ventarisshortbow",
+    "type": "shortbow",
+    "affix": "nomad"
+  },
+  {
+    "id": 66677,
+    "name": "ventarisharpoongun",
+    "type": "speargun",
+    "affix": "nomad"
+  },
+  {
+    "id": 66678,
+    "name": "ventarisherald",
+    "type": "warhorn",
+    "affix": "nomad"
+  },
+  {
+    "id": 66679,
+    "name": "ventarismusket",
+    "type": "rifle",
+    "affix": "nomad"
+  },
+  {
+    "id": 66680,
+    "name": "ventarisspire",
+    "type": "staff",
+    "affix": "nomad"
+  },
+  {
+    "id": 66681,
+    "name": "ventarisflangedmace",
+    "type": "mace",
+    "affix": "nomad"
+  },
+  {
+    "id": 66682,
+    "name": "ventarisgreatbow",
+    "type": "longbow",
+    "affix": "nomad"
+  },
+  {
+    "id": 66683,
+    "name": "ventarisimpaler",
+    "type": "harpoon",
+    "affix": "nomad"
+  },
+  {
+    "id": 66684,
+    "name": "ventariswarhammer",
+    "type": "hammer",
+    "affix": "nomad"
+  },
+  {
+    "id": 66685,
+    "name": "ventarisclaymore",
+    "type": "greatsword",
+    "affix": "nomad"
+  },
+  {
+    "id": 66686,
+    "name": "ventarisartifact",
+    "type": "focus",
+    "affix": "nomad"
+  },
+  {
+    "id": 66687,
+    "name": "ventarisrazor",
+    "type": "dagger",
+    "affix": "nomad"
+  },
+  {
+    "id": 66688,
+    "name": "ventarisbrazier",
+    "type": "torch",
+    "affix": "nomad"
+  },
+  {
+    "id": 66689,
+    "name": "ventarisrevolver",
+    "type": "pistol",
+    "affix": "nomad"
+  },
+  {
+    "id": 66690,
+    "name": "ventaristrident",
+    "type": "trident",
+    "affix": "nomad"
+  },
+  {
+    "id": 67294,
+    "name": "adelbernsburden",
+    "type": "accessory",
+    "affix": "sentinel"
+  },
+  {
+    "id": 67295,
+    "name": "kudusphasingmatrix",
+    "type": "accessory",
+    "affix": "sentinel"
+  },
+  {
+    "id": 67298,
+    "name": "delanascoinpurse",
+    "type": "accessory",
+    "affix": "assassin"
+  },
+  {
+    "id": 67299,
+    "name": "baelfiresember",
+    "type": "accessory",
+    "affix": "carrion"
+  },
+  {
+    "id": 67301,
+    "name": "forgemansgear",
+    "type": "accessory",
+    "affix": "carrion"
+  },
+  {
+    "id": 67302,
+    "name": "zhaitansclaw",
+    "type": "accessory",
+    "affix": "assassin"
+  },
+  {
+    "id": 67306,
+    "name": "banestooth",
+    "type": "accessory",
+    "affix": "magi"
+  },
+  {
+    "id": 67307,
+    "name": "faolainsblossom",
+    "type": "accessory",
+    "affix": "magi"
+  },
+  {
+    "id": 67339,
+    "name": "trapper",
+    "type": "rune"
+  },
+  {
+    "id": 67340,
+    "name": "cleansing",
+    "type": "sigil"
+  },
+  {
+    "id": 67341,
+    "name": "cruelty",
+    "type": "sigil"
+  },
+  {
+    "id": 67342,
+    "name": "radiance",
+    "type": "rune"
+  },
+  {
+    "id": 67343,
+    "name": "incapacitation",
+    "type": "sigil"
+  },
+  {
+    "id": 67344,
+    "name": "evasion",
+    "type": "rune"
+  },
+  {
+    "id": 67442,
+    "name": "veratasmasque",
+    "type": "helm",
+    "affix": "sinister",
+    "weight": "light"
+  },
+  {
+    "id": 67443,
+    "name": "veratasshoulderguard",
+    "type": "shoulders",
+    "affix": "sinister",
+    "weight": "medium"
+  },
+  {
+    "id": 67444,
+    "name": "veratasleggings",
+    "type": "leggings",
+    "affix": "sinister",
+    "weight": "medium"
+  },
+  {
+    "id": 67445,
+    "name": "veratasvisage",
+    "type": "helm",
+    "affix": "sinister",
+    "weight": "medium"
+  },
+  {
+    "id": 67446,
+    "name": "veratasgrips",
+    "type": "gloves",
+    "affix": "sinister",
+    "weight": "medium"
+  },
+  {
+    "id": 67447,
+    "name": "veratasguise",
+    "type": "coat",
+    "affix": "sinister",
+    "weight": "medium"
+  },
+  {
+    "id": 67448,
+    "name": "veratasstriders",
+    "type": "boots",
+    "affix": "sinister",
+    "weight": "medium"
+  },
+  {
+    "id": 67449,
+    "name": "veratasepaulets",
+    "type": "shoulders",
+    "affix": "sinister",
+    "weight": "light"
+  },
+  {
+    "id": 67450,
+    "name": "veratasbreeches",
+    "type": "leggings",
+    "affix": "sinister",
+    "weight": "light"
+  },
+  {
+    "id": 67451,
+    "name": "veratasgreaves",
+    "type": "boots",
+    "affix": "sinister",
+    "weight": "heavy"
+  },
+  {
+    "id": 67452,
+    "name": "verataswristguards",
+    "type": "gloves",
+    "affix": "sinister",
+    "weight": "light"
+  },
+  {
+    "id": 67453,
+    "name": "veratasdoublet",
+    "type": "coat",
+    "affix": "sinister",
+    "weight": "light"
+  },
+  {
+    "id": 67454,
+    "name": "veratasfootwear",
+    "type": "boots",
+    "affix": "sinister",
+    "weight": "light"
+  },
+  {
+    "id": 67455,
+    "name": "verataspauldrons",
+    "type": "shoulders",
+    "affix": "sinister",
+    "weight": "heavy"
+  },
+  {
+    "id": 67456,
+    "name": "veratastassets",
+    "type": "leggings",
+    "affix": "sinister",
+    "weight": "heavy"
+  },
+  {
+    "id": 67457,
+    "name": "veratasvisor",
+    "type": "helm",
+    "affix": "sinister",
+    "weight": "heavy"
+  },
+  {
+    "id": 67458,
+    "name": "verataswarfists",
+    "type": "gloves",
+    "affix": "sinister",
+    "weight": "heavy"
+  },
+  {
+    "id": 67459,
+    "name": "veratasbreastplate",
+    "type": "coat",
+    "affix": "sinister",
+    "weight": "heavy"
+  },
+  {
+    "id": 67894,
+    "name": "caithesremorse",
+    "type": "accessory",
+    "affix": "sinister"
+  },
+  {
+    "id": 67895,
+    "name": "quetzalcrest",
+    "type": "accessory",
+    "affix": "nomad"
+  },
+  {
+    "id": 67896,
+    "name": "caithesblossom",
+    "type": "accessory",
+    "affix": "sinister"
+  },
+  {
+    "id": 67897,
+    "name": "ventarischisel",
+    "type": "accessory",
+    "affix": "nomad"
+  },
+  {
+    "id": 67898,
+    "name": "wynneslocket",
+    "type": "amulet",
+    "affix": "sinister"
+  },
+  {
+    "id": 67899,
+    "name": "ogdensankh",
+    "type": "amulet",
+    "affix": "nomad"
+  },
+  {
+    "id": 67900,
+    "name": "jurahsjewel",
+    "type": "amulet",
+    "affix": "sinister"
+  },
+  {
+    "id": 67901,
+    "name": "aspectamulet",
+    "type": "amulet",
+    "affix": "nomad"
+  },
+  {
+    "id": 67912,
+    "name": "defender",
+    "type": "rune"
+  },
+  {
+    "id": 67913,
+    "name": "blight",
+    "type": "sigil"
+  },
+  {
+    "id": 67934,
+    "name": "veratasimpaler",
+    "type": "harpoon",
+    "affix": "sinister"
+  },
+  {
+    "id": 67935,
+    "name": "veratastrident",
+    "type": "trident",
+    "affix": "sinister"
+  },
+  {
+    "id": 67936,
+    "name": "veratasherald",
+    "type": "warhorn",
+    "affix": "sinister"
+  },
+  {
+    "id": 67937,
+    "name": "veratasbrazier",
+    "type": "torch",
+    "affix": "sinister"
+  },
+  {
+    "id": 67938,
+    "name": "veratasblade",
+    "type": "sword",
+    "affix": "sinister"
+  },
+  {
+    "id": 67939,
+    "name": "veratasspire",
+    "type": "staff",
+    "affix": "sinister"
+  },
+  {
+    "id": 67940,
+    "name": "veratasharpoongun",
+    "type": "speargun",
+    "affix": "sinister"
+  },
+  {
+    "id": 67941,
+    "name": "veratasshortbow",
+    "type": "shortbow",
+    "affix": "sinister"
+  },
+  {
+    "id": 67942,
+    "name": "veratasbastion",
+    "type": "shield",
+    "affix": "sinister"
+  },
+  {
+    "id": 67943,
+    "name": "verataswand",
+    "type": "scepter",
+    "affix": "sinister"
+  },
+  {
+    "id": 67944,
+    "name": "veratasreaver",
+    "type": "axe",
+    "affix": "sinister"
+  },
+  {
+    "id": 67945,
+    "name": "veratasrevolver",
+    "type": "pistol",
+    "affix": "sinister"
+  },
+  {
+    "id": 67946,
+    "name": "veratasflangedmace",
+    "type": "mace",
+    "affix": "sinister"
+  },
+  {
+    "id": 67947,
+    "name": "veratasgreatbow",
+    "type": "longbow",
+    "affix": "sinister"
+  },
+  {
+    "id": 67948,
+    "name": "veratasrazor",
+    "type": "dagger",
+    "affix": "sinister"
+  },
+  {
+    "id": 67949,
+    "name": "verataswarhammer",
+    "type": "hammer",
+    "affix": "sinister"
+  },
+  {
+    "id": 67950,
+    "name": "veratasclaymore",
+    "type": "greatsword",
+    "affix": "sinister"
+  },
+  {
+    "id": 67951,
+    "name": "veratasartifact",
+    "type": "focus",
+    "affix": "sinister"
+  },
+  {
+    "id": 67952,
+    "name": "veratasmusket",
+    "type": "rifle",
+    "affix": "sinister"
+  },
+  {
+    "id": 68436,
+    "name": "mischief",
+    "type": "sigil"
+  },
+  {
+    "id": 68437,
+    "name": "snowfall",
+    "type": "rune"
+  },
+  {
+    "id": 68633,
+    "name": "friedgoldendumpling",
+    "type": "food"
+  },
+  {
+    "id": 68634,
+    "name": "deliciousriceball",
+    "type": "food"
+  },
+  {
+    "id": 69370,
+    "name": "revenant",
+    "type": "rune"
+  },
+  {
+    "id": 70165,
+    "name": "weiqisguise",
+    "type": "coat",
+    "affix": "sentinel",
+    "weight": "medium"
+  },
+  {
+    "id": 70414,
+    "name": "maklainsbreeches",
+    "type": "leggings",
+    "affix": "minstrel",
+    "weight": "light"
+  },
+  {
+    "id": 70416,
+    "name": "ossasspire",
+    "type": "staff",
+    "affix": "crusader"
+  },
+  {
+    "id": 70442,
+    "name": "svaardsharpoongun",
+    "type": "speargun",
+    "affix": "marauder"
+  },
+  {
+    "id": 70450,
+    "name": "druid",
+    "type": "rune"
+  },
+  {
+    "id": 70456,
+    "name": "leftpawsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "settler",
+    "weight": "medium"
+  },
+  {
+    "id": 70470,
+    "name": "rukasstriders",
+    "type": "boots",
+    "affix": "wanderer",
+    "weight": "medium"
+  },
+  {
+    "id": 70471,
+    "name": "tizlaksvisage",
+    "type": "helm",
+    "affix": "commander",
+    "weight": "medium"
+  },
+  {
+    "id": 70482,
+    "name": "svaardsrevolver",
+    "type": "pistol",
+    "affix": "marauder"
+  },
+  {
+    "id": 70504,
+    "name": "yassithsgreatbow",
+    "type": "longbow",
+    "affix": "viper"
+  },
+  {
+    "id": 70508,
+    "name": "rukasvisor",
+    "type": "helm",
+    "affix": "wanderer",
+    "weight": "heavy"
+  },
+  {
+    "id": 70538,
+    "name": "saphirsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "assassin",
+    "weight": "heavy"
+  },
+  {
+    "id": 70554,
+    "name": "attunedkhilbronsphylacteryinfused",
+    "type": "ring",
+    "affix": "rabid"
+  },
+  {
+    "id": 70555,
+    "name": "tizlaksepaulets",
+    "type": "shoulders",
+    "affix": "commander",
+    "weight": "light"
+  },
+  {
+    "id": 70574,
+    "name": "keepersmetalbreather",
+    "type": "helmaquatic",
+    "affix": "zealot",
+    "weight": "heavy"
+  },
+  {
+    "id": 70593,
+    "name": "svaardsgreaves",
+    "type": "boots",
+    "affix": "marauder",
+    "weight": "heavy"
+  },
+  {
+    "id": 70600,
+    "name": "leadership",
+    "type": "rune"
+  },
+  {
+    "id": 70630,
+    "name": "pahuaspauldrons",
+    "type": "shoulders",
+    "affix": "trailblazer",
+    "weight": "heavy"
+  },
+  {
+    "id": 70641,
+    "name": "yassithsleggings",
+    "type": "leggings",
+    "affix": "viper",
+    "weight": "medium"
+  },
+  {
+    "id": 70671,
+    "name": "sunmoonandstars",
+    "type": "amulet",
+    "affix": "marauder"
+  },
+  {
+    "id": 70685,
+    "name": "laranthirstrident",
+    "type": "trident",
+    "affix": "vigilant"
+  },
+  {
+    "id": 70687,
+    "name": "yassithstrident",
+    "type": "trident",
+    "affix": "viper"
+  },
+  {
+    "id": 70695,
+    "name": "attunedplaguesignetinfused",
+    "type": "ring",
+    "affix": "sinister"
+  },
+  {
+    "id": 70699,
+    "name": "rukaswristguards",
+    "type": "gloves",
+    "affix": "wanderer",
+    "weight": "light"
+  },
+  {
+    "id": 70712,
+    "name": "wupwupleatherbreather",
+    "type": "helmaquatic",
+    "affix": "celestial",
+    "weight": "medium"
+  },
+  {
+    "id": 70720,
+    "name": "rukasgrips",
+    "type": "gloves",
+    "affix": "wanderer",
+    "weight": "medium"
+  },
+  {
+    "id": 70729,
+    "name": "ossasmusket",
+    "type": "rifle",
+    "affix": "crusader"
+  },
+  {
+    "id": 70794,
+    "name": "maklainsbreastplate",
+    "type": "coat",
+    "affix": "minstrel",
+    "weight": "heavy"
+  },
+  {
+    "id": 70825,
+    "name": "draining",
+    "type": "sigil"
+  },
+  {
+    "id": 70829,
+    "name": "reaper",
+    "type": "rune"
+  },
+  {
+    "id": 70834,
+    "name": "maklainsguise",
+    "type": "coat",
+    "affix": "minstrel",
+    "weight": "medium"
+  },
+  {
+    "id": 70838,
+    "name": "yassithsblade",
+    "type": "sword",
+    "affix": "viper"
+  },
+  {
+    "id": 70839,
+    "name": "beigarthsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "knight",
+    "weight": "medium"
+  },
+  {
+    "id": 70848,
+    "name": "svaardsleggings",
+    "type": "leggings",
+    "affix": "marauder",
+    "weight": "medium"
+  },
+  {
+    "id": 70889,
+    "name": "abaddonscowl",
+    "type": "amulet",
+    "affix": "marauder"
+  },
+  {
+    "id": 70924,
+    "name": "pahuasvisor",
+    "type": "helm",
+    "affix": "trailblazer",
+    "weight": "heavy"
+  },
+  {
+    "id": 70966,
+    "name": "occamsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "carrion",
+    "weight": "medium"
+  },
+  {
+    "id": 70993,
+    "name": "pahuaswristguards",
+    "type": "gloves",
+    "affix": "trailblazer",
+    "weight": "light"
+  },
+  {
+    "id": 71005,
+    "name": "ossasherald",
+    "type": "warhorn",
+    "affix": "crusader"
+  },
+  {
+    "id": 71007,
+    "name": "yassithsclaymore",
+    "type": "greatsword",
+    "affix": "viper"
+  },
+  {
+    "id": 71014,
+    "name": "tizlaksimpaler",
+    "type": "harpoon",
+    "affix": "commander"
+  },
+  {
+    "id": 71065,
+    "name": "attunedmellagganswhorlinfused",
+    "type": "ring",
+    "affix": "rabidandapothecary"
+  },
+  {
+    "id": 71094,
+    "name": "rukasguise",
+    "type": "coat",
+    "affix": "wanderer",
+    "weight": "medium"
+  },
+  {
+    "id": 71114,
+    "name": "rukasgreatbow",
+    "type": "longbow",
+    "affix": "wanderer"
+  },
+  {
+    "id": 71116,
+    "name": "maklainsherald",
+    "type": "warhorn",
+    "affix": "minstrel"
+  },
+  {
+    "id": 71117,
+    "name": "tizlaksherald",
+    "type": "warhorn",
+    "affix": "commander"
+  },
+  {
+    "id": 71130,
+    "name": "ruthlessness",
+    "type": "sigil"
+  },
+  {
+    "id": 71161,
+    "name": "laranthirsbrazier",
+    "type": "torch",
+    "affix": "vigilant"
+  },
+  {
+    "id": 71205,
+    "name": "saphirsclothbreather",
+    "type": "helmaquatic",
+    "affix": "assassin",
+    "weight": "light"
+  },
+  {
+    "id": 71219,
+    "name": "tizlaksmusket",
+    "type": "rifle",
+    "affix": "commander"
+  },
+  {
+    "id": 71242,
+    "name": "rukasfootwear",
+    "type": "boots",
+    "affix": "wanderer",
+    "weight": "light"
+  },
+  {
+    "id": 71249,
+    "name": "tizlakstassets",
+    "type": "leggings",
+    "affix": "commander",
+    "weight": "heavy"
+  },
+  {
+    "id": 71256,
+    "name": "morbachsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "dire",
+    "weight": "medium"
+  },
+  {
+    "id": 71276,
+    "name": "scrapper",
+    "type": "rune"
+  },
+  {
+    "id": 71308,
+    "name": "rukasepaulets",
+    "type": "shoulders",
+    "affix": "wanderer",
+    "weight": "light"
+  },
+  {
+    "id": 71346,
+    "name": "attunedroyalsignetofdoricinfused",
+    "type": "ring",
+    "affix": "soldier"
+  },
+  {
+    "id": 71361,
+    "name": "pahuasreaver",
+    "type": "axe",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 71381,
+    "name": "zintlleatherbreather",
+    "type": "helmaquatic",
+    "affix": "shaman",
+    "weight": "medium"
+  },
+  {
+    "id": 71387,
+    "name": "yassithsspire",
+    "type": "staff",
+    "affix": "viper"
+  },
+  {
+    "id": 71406,
+    "name": "tateossmetalbreather",
+    "type": "helmaquatic",
+    "affix": "cleric",
+    "weight": "heavy"
+  },
+  {
+    "id": 71423,
+    "name": "ahamidsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "soldier",
+    "weight": "medium"
+  },
+  {
+    "id": 71424,
+    "name": "laranthirsvisor",
+    "type": "helm",
+    "affix": "vigilant",
+    "weight": "heavy"
+  },
+  {
+    "id": 71425,
+    "name": "berserker",
+    "type": "rune"
+  },
+  {
+    "id": 71436,
+    "name": "yassithsdoublet",
+    "type": "coat",
+    "affix": "viper",
+    "weight": "light"
+  },
+  {
+    "id": 71450,
+    "name": "zintlmetalbreather",
+    "type": "helmaquatic",
+    "affix": "shaman",
+    "weight": "heavy"
+  },
+  {
+    "id": 71456,
+    "name": "maklainsgreaves",
+    "type": "boots",
+    "affix": "minstrel",
+    "weight": "heavy"
+  },
+  {
+    "id": 71457,
+    "name": "maklainsflangedmace",
+    "type": "mace",
+    "affix": "minstrel"
+  },
+  {
+    "id": 71472,
+    "name": "pahuasflangedmace",
+    "type": "mace",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 71478,
+    "name": "svaardsmusket",
+    "type": "rifle",
+    "affix": "marauder"
+  },
+  {
+    "id": 71570,
+    "name": "laranthirsbreeches",
+    "type": "leggings",
+    "affix": "vigilant",
+    "weight": "light"
+  },
+  {
+    "id": 71576,
+    "name": "leftpawsclothbreather",
+    "type": "helmaquatic",
+    "affix": "settler",
+    "weight": "light"
+  },
+  {
+    "id": 71584,
+    "name": "yassithsartifact",
+    "type": "focus",
+    "affix": "viper"
+  },
+  {
+    "id": 71606,
+    "name": "rukastrident",
+    "type": "trident",
+    "affix": "wanderer"
+  },
+  {
+    "id": 71607,
+    "name": "pahuasimpaler",
+    "type": "harpoon",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 71645,
+    "name": "ossasshortbow",
+    "type": "shortbow",
+    "affix": "crusader"
+  },
+  {
+    "id": 71691,
+    "name": "writofmasterfulspeed",
+    "type": "utility"
+  },
+  {
+    "id": 71698,
+    "name": "svaardsimpaler",
+    "type": "harpoon",
+    "affix": "marauder"
+  },
+  {
+    "id": 71726,
+    "name": "attunedveratassearedringinfused",
+    "type": "ring",
+    "affix": "sinister"
+  },
+  {
+    "id": 71735,
+    "name": "pahuastassets",
+    "type": "leggings",
+    "affix": "trailblazer",
+    "weight": "heavy"
+  },
+  {
+    "id": 71740,
+    "name": "ossasvisor",
+    "type": "helm",
+    "affix": "crusader",
+    "weight": "heavy"
+  },
+  {
+    "id": 71817,
+    "name": "ossasgrips",
+    "type": "gloves",
+    "affix": "crusader",
+    "weight": "medium"
+  },
+  {
+    "id": 71870,
+    "name": "angchumetalbreather",
+    "type": "helmaquatic",
+    "affix": "cavalier",
+    "weight": "heavy"
+  },
+  {
+    "id": 71917,
+    "name": "ossasrazor",
+    "type": "dagger",
+    "affix": "crusader"
+  },
+  {
+    "id": 71925,
+    "name": "gobrechsclothbreather",
+    "type": "helmaquatic",
+    "affix": "valkyrie",
+    "weight": "light"
+  },
+  {
+    "id": 71941,
+    "name": "laranthirsshoulderguard",
+    "type": "shoulders",
+    "affix": "vigilant",
+    "weight": "medium"
+  },
+  {
+    "id": 71944,
+    "name": "yassithsbastion",
+    "type": "shield",
+    "affix": "viper"
+  },
+  {
+    "id": 71968,
+    "name": "svaardsdoublet",
+    "type": "coat",
+    "affix": "marauder",
+    "weight": "light"
+  },
+  {
+    "id": 72004,
+    "name": "ossasbrazier",
+    "type": "torch",
+    "affix": "crusader"
+  },
+  {
+    "id": 72005,
+    "name": "ossasartifact",
+    "type": "focus",
+    "affix": "crusader"
+  },
+  {
+    "id": 72079,
+    "name": "rukasblade",
+    "type": "sword",
+    "affix": "wanderer"
+  },
+  {
+    "id": 72092,
+    "name": "agility",
+    "type": "sigil"
+  },
+  {
+    "id": 72108,
+    "name": "rukasrevolver",
+    "type": "pistol",
+    "affix": "wanderer"
+  },
+  {
+    "id": 72139,
+    "name": "laranthirstassets",
+    "type": "leggings",
+    "affix": "vigilant",
+    "weight": "heavy"
+  },
+  {
+    "id": 72182,
+    "name": "tizlaksdoublet",
+    "type": "coat",
+    "affix": "commander",
+    "weight": "light"
+  },
+  {
+    "id": 72188,
+    "name": "maklainsartifact",
+    "type": "focus",
+    "affix": "minstrel"
+  },
+  {
+    "id": 72190,
+    "name": "laranthirsgreaves",
+    "type": "boots",
+    "affix": "vigilant",
+    "weight": "heavy"
+  },
+  {
+    "id": 72214,
+    "name": "rukaspauldrons",
+    "type": "shoulders",
+    "affix": "wanderer",
+    "weight": "heavy"
+  },
+  {
+    "id": 72221,
+    "name": "wupwupmetalbreather",
+    "type": "helmaquatic",
+    "affix": "celestial",
+    "weight": "heavy"
+  },
+  {
+    "id": 72239,
+    "name": "yassithsrevolver",
+    "type": "pistol",
+    "affix": "viper"
+  },
+  {
+    "id": 72249,
+    "name": "angchuleatherbreather",
+    "type": "helmaquatic",
+    "affix": "cavalier",
+    "weight": "medium"
+  },
+  {
+    "id": 72251,
+    "name": "svaardsfootwear",
+    "type": "boots",
+    "affix": "marauder",
+    "weight": "light"
+  },
+  {
+    "id": 72256,
+    "name": "pahuasbrazier",
+    "type": "torch",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 72259,
+    "name": "yassithsshoulderguard",
+    "type": "shoulders",
+    "affix": "viper",
+    "weight": "medium"
+  },
+  {
+    "id": 72279,
+    "name": "yassithsmusket",
+    "type": "rifle",
+    "affix": "viper"
+  },
+  {
+    "id": 72280,
+    "name": "zojjasleatherbreather",
+    "type": "helmaquatic",
+    "affix": "berserker",
+    "weight": "medium"
+  },
+  {
+    "id": 72314,
+    "name": "tizlaksclaymore",
+    "type": "greatsword",
+    "affix": "commander"
+  },
+  {
+    "id": 72339,
+    "name": "concentration",
+    "type": "sigil"
+  },
+  {
+    "id": 72341,
+    "name": "pahuasguise",
+    "type": "coat",
+    "affix": "trailblazer",
+    "weight": "medium"
+  },
+  {
+    "id": 72359,
+    "name": "rukasrazor",
+    "type": "dagger",
+    "affix": "wanderer"
+  },
+  {
+    "id": 72369,
+    "name": "laranthirsfootwear",
+    "type": "boots",
+    "affix": "vigilant",
+    "weight": "light"
+  },
+  {
+    "id": 72423,
+    "name": "attunedlostsealofusokuinfused",
+    "type": "ring",
+    "affix": "soldier"
+  },
+  {
+    "id": 72452,
+    "name": "ossastrident",
+    "type": "trident",
+    "affix": "crusader"
+  },
+  {
+    "id": 72456,
+    "name": "pahuasgrips",
+    "type": "gloves",
+    "affix": "trailblazer",
+    "weight": "medium"
+  },
+  {
+    "id": 72466,
+    "name": "tizlaksgreaves",
+    "type": "boots",
+    "affix": "commander",
+    "weight": "heavy"
+  },
+  {
+    "id": 72476,
+    "name": "tizlaksreaver",
+    "type": "axe",
+    "affix": "commander"
+  },
+  {
+    "id": 72486,
+    "name": "ferratussleatherbreather",
+    "type": "helmaquatic",
+    "affix": "rabid",
+    "weight": "medium"
+  },
+  {
+    "id": 72494,
+    "name": "rukasdoublet",
+    "type": "coat",
+    "affix": "wanderer",
+    "weight": "light"
+  },
+  {
+    "id": 72496,
+    "name": "rukastassets",
+    "type": "leggings",
+    "affix": "wanderer",
+    "weight": "heavy"
+  },
+  {
+    "id": 72509,
+    "name": "forgemastersleatherbreather",
+    "type": "helmaquatic",
+    "affix": "rampager",
+    "weight": "medium"
+  },
+  {
+    "id": 72510,
+    "name": "writofmasterfulmalice",
+    "type": "utility"
+  },
+  {
+    "id": 72529,
+    "name": "vigilshonor",
+    "type": "amulet",
+    "affix": "crusader"
+  },
+  {
+    "id": 72532,
+    "name": "thesisonstudiedspeed",
+    "type": "utility"
+  },
+  {
+    "id": 72546,
+    "name": "laranthirsrazor",
+    "type": "dagger",
+    "affix": "vigilant"
+  },
+  {
+    "id": 72548,
+    "name": "yassithsgreaves",
+    "type": "boots",
+    "affix": "viper",
+    "weight": "heavy"
+  },
+  {
+    "id": 72557,
+    "name": "yassithspauldrons",
+    "type": "shoulders",
+    "affix": "viper",
+    "weight": "heavy"
+  },
+  {
+    "id": 72562,
+    "name": "laranthirsbastion",
+    "type": "shield",
+    "affix": "vigilant"
+  },
+  {
+    "id": 72567,
+    "name": "veratasleatherbreather",
+    "type": "helmaquatic",
+    "affix": "sinister",
+    "weight": "medium"
+  },
+  {
+    "id": 72584,
+    "name": "weiqisleatherbreather",
+    "type": "helmaquatic",
+    "affix": "sentinel",
+    "weight": "medium"
+  },
+  {
+    "id": 72591,
+    "name": "attunedossafamilysignetringinfused",
+    "type": "ring",
+    "affix": "knight"
+  },
+  {
+    "id": 72642,
+    "name": "laranthirsimpaler",
+    "type": "harpoon",
+    "affix": "vigilant"
+  },
+  {
+    "id": 72663,
+    "name": "tizlaksfootwear",
+    "type": "boots",
+    "affix": "commander",
+    "weight": "light"
+  },
+  {
+    "id": 72690,
+    "name": "ossasgreaves",
+    "type": "boots",
+    "affix": "crusader",
+    "weight": "heavy"
+  },
+  {
+    "id": 72698,
+    "name": "maklainsvisor",
+    "type": "helm",
+    "affix": "minstrel",
+    "weight": "heavy"
+  },
+  {
+    "id": 72719,
+    "name": "rukasbreeches",
+    "type": "leggings",
+    "affix": "wanderer",
+    "weight": "light"
+  },
+  {
+    "id": 72765,
+    "name": "rukasleggings",
+    "type": "leggings",
+    "affix": "wanderer",
+    "weight": "medium"
+  },
+  {
+    "id": 72816,
+    "name": "pahuasfootwear",
+    "type": "boots",
+    "affix": "trailblazer",
+    "weight": "light"
+  },
+  {
+    "id": 72852,
+    "name": "daredevil",
+    "type": "rune"
+  },
+  {
+    "id": 72860,
+    "name": "pahuasrevolver",
+    "type": "pistol",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 72872,
+    "name": "absorption",
+    "type": "sigil"
+  },
+  {
+    "id": 72882,
+    "name": "svaardsreaver",
+    "type": "axe",
+    "affix": "marauder"
+  },
+  {
+    "id": 72893,
+    "name": "rukasbrazier",
+    "type": "torch",
+    "affix": "wanderer"
+  },
+  {
+    "id": 72912,
+    "name": "thorns",
+    "type": "rune"
+  },
+  {
+    "id": 72919,
+    "name": "veratasclothbreather",
+    "type": "helmaquatic",
+    "affix": "sinister",
+    "weight": "light"
+  },
+  {
+    "id": 72927,
+    "name": "pahuasspire",
+    "type": "staff",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 72932,
+    "name": "attunedhealingsignetinfused",
+    "type": "ring",
+    "affix": "cleric"
+  },
+  {
+    "id": 72950,
+    "name": "morbachsclothbreather",
+    "type": "helmaquatic",
+    "affix": "dire",
+    "weight": "light"
+  },
+  {
+    "id": 72998,
+    "name": "laranthirsstriders",
+    "type": "boots",
+    "affix": "vigilant",
+    "weight": "medium"
+  },
+  {
+    "id": 73009,
+    "name": "maklainspauldrons",
+    "type": "shoulders",
+    "affix": "minstrel",
+    "weight": "heavy"
+  },
+  {
+    "id": 73059,
+    "name": "tizlaksrazor",
+    "type": "dagger",
+    "affix": "commander"
+  },
+  {
+    "id": 73068,
+    "name": "rukasartifact",
+    "type": "focus",
+    "affix": "wanderer"
+  },
+  {
+    "id": 73090,
+    "name": "laranthirsgrips",
+    "type": "gloves",
+    "affix": "vigilant",
+    "weight": "medium"
+  },
+  {
+    "id": 73127,
+    "name": "forgemastersmetalbreather",
+    "type": "helmaquatic",
+    "affix": "rampager",
+    "weight": "heavy"
+  },
+  {
+    "id": 73191,
+    "name": "writofmasterfulstrength",
+    "type": "utility"
+  },
+  {
+    "id": 73220,
+    "name": "maklainswand",
+    "type": "scepter",
+    "affix": "minstrel"
+  },
+  {
+    "id": 73225,
+    "name": "yassithsepaulets",
+    "type": "shoulders",
+    "affix": "viper",
+    "weight": "light"
+  },
+  {
+    "id": 73233,
+    "name": "veldrunnerclothbreather",
+    "type": "helmaquatic",
+    "affix": "apothecary",
+    "weight": "light"
+  },
+  {
+    "id": 73234,
+    "name": "ossasbreeches",
+    "type": "leggings",
+    "affix": "crusader",
+    "weight": "light"
+  },
+  {
+    "id": 73280,
+    "name": "svaardsshortbow",
+    "type": "shortbow",
+    "affix": "marauder"
+  },
+  {
+    "id": 73281,
+    "name": "attunedouroborosloopinfused",
+    "type": "ring",
+    "affix": "rabid"
+  },
+  {
+    "id": 73287,
+    "name": "pahuaswand",
+    "type": "scepter",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 73298,
+    "name": "ossaswarhammer",
+    "type": "hammer",
+    "affix": "crusader"
+  },
+  {
+    "id": 73339,
+    "name": "svaardsguise",
+    "type": "coat",
+    "affix": "marauder",
+    "weight": "medium"
+  },
+  {
+    "id": 73343,
+    "name": "svaardsrazor",
+    "type": "dagger",
+    "affix": "marauder"
+  },
+  {
+    "id": 73357,
+    "name": "laranthirsmusket",
+    "type": "rifle",
+    "affix": "vigilant"
+  },
+  {
+    "id": 73364,
+    "name": "keepersclothbreather",
+    "type": "helmaquatic",
+    "affix": "zealot",
+    "weight": "light"
+  },
+  {
+    "id": 73365,
+    "name": "maklainsharpoongun",
+    "type": "speargun",
+    "affix": "minstrel"
+  },
+  {
+    "id": 73373,
+    "name": "ossasblade",
+    "type": "sword",
+    "affix": "crusader"
+  },
+  {
+    "id": 73392,
+    "name": "pahuasbreeches",
+    "type": "leggings",
+    "affix": "trailblazer",
+    "weight": "light"
+  },
+  {
+    "id": 73395,
+    "name": "pahuasleggings",
+    "type": "leggings",
+    "affix": "trailblazer",
+    "weight": "medium"
+  },
+  {
+    "id": 73399,
+    "name": "chronomancer",
+    "type": "rune"
+  },
+  {
+    "id": 73403,
+    "name": "ventarisclothbreather",
+    "type": "helmaquatic",
+    "affix": "nomad",
+    "weight": "light"
+  },
+  {
+    "id": 73479,
+    "name": "maklainstrident",
+    "type": "trident",
+    "affix": "minstrel"
+  },
+  {
+    "id": 73487,
+    "name": "rukasflangedmace",
+    "type": "mace",
+    "affix": "wanderer"
+  },
+  {
+    "id": 73497,
+    "name": "maklainsmusket",
+    "type": "rifle",
+    "affix": "minstrel"
+  },
+  {
+    "id": 73514,
+    "name": "svaardsclaymore",
+    "type": "greatsword",
+    "affix": "marauder"
+  },
+  {
+    "id": 73521,
+    "name": "rukasmasque",
+    "type": "helm",
+    "affix": "wanderer",
+    "weight": "light"
+  },
+  {
+    "id": 73532,
+    "name": "rending",
+    "type": "sigil"
+  },
+  {
+    "id": 73549,
+    "name": "maklainsrevolver",
+    "type": "pistol",
+    "affix": "minstrel"
+  },
+  {
+    "id": 73560,
+    "name": "attunedvineofthepaletreeinfused",
+    "type": "ring",
+    "affix": "berserkerandvalkyrie"
+  },
+  {
+    "id": 73580,
+    "name": "yassithsimpaler",
+    "type": "harpoon",
+    "affix": "viper"
+  },
+  {
+    "id": 73613,
+    "name": "rukasshoulderguard",
+    "type": "shoulders",
+    "affix": "wanderer",
+    "weight": "medium"
+  },
+  {
+    "id": 73614,
+    "name": "tizlaksrevolver",
+    "type": "pistol",
+    "affix": "commander"
+  },
+  {
+    "id": 73631,
+    "name": "laranthirsflangedmace",
+    "type": "mace",
+    "affix": "vigilant"
+  },
+  {
+    "id": 73649,
+    "name": "tizlaksleggings",
+    "type": "leggings",
+    "affix": "commander",
+    "weight": "medium"
+  },
+  {
+    "id": 73652,
+    "name": "laranthirsguise",
+    "type": "coat",
+    "affix": "vigilant",
+    "weight": "medium"
+  },
+  {
+    "id": 73653,
+    "name": "durability",
+    "type": "rune"
+  },
+  {
+    "id": 73662,
+    "name": "gobrechsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "valkyrie",
+    "weight": "heavy"
+  },
+  {
+    "id": 73670,
+    "name": "maklainsepaulets",
+    "type": "shoulders",
+    "affix": "minstrel",
+    "weight": "light"
+  },
+  {
+    "id": 73687,
+    "name": "ossasbastion",
+    "type": "shield",
+    "affix": "crusader"
+  },
+  {
+    "id": 73697,
+    "name": "pahuaswarfists",
+    "type": "gloves",
+    "affix": "trailblazer",
+    "weight": "heavy"
+  },
+  {
+    "id": 73719,
+    "name": "ossastassets",
+    "type": "leggings",
+    "affix": "crusader",
+    "weight": "heavy"
+  },
+  {
+    "id": 73723,
+    "name": "ahamidsclothbreather",
+    "type": "helmaquatic",
+    "affix": "soldier",
+    "weight": "light"
+  },
+  {
+    "id": 73724,
+    "name": "tizlaksblade",
+    "type": "sword",
+    "affix": "commander"
+  },
+  {
+    "id": 73756,
+    "name": "attuneddruidscircleinfused",
+    "type": "ring",
+    "affix": "cleric"
+  },
+  {
+    "id": 73766,
+    "name": "ossasfootwear",
+    "type": "boots",
+    "affix": "crusader",
+    "weight": "light"
+  },
+  {
+    "id": 73782,
+    "name": "rukaswarfists",
+    "type": "gloves",
+    "affix": "wanderer",
+    "weight": "heavy"
+  },
+  {
+    "id": 73813,
+    "name": "attunedsolariacircleofthesuninfused",
+    "type": "ring",
+    "affix": "celestial"
+  },
+  {
+    "id": 73835,
+    "name": "tizlaksstriders",
+    "type": "boots",
+    "affix": "commander",
+    "weight": "medium"
+  },
+  {
+    "id": 73852,
+    "name": "yassithswristguards",
+    "type": "gloves",
+    "affix": "viper",
+    "weight": "light"
+  },
+  {
+    "id": 73854,
+    "name": "yassithsstriders",
+    "type": "boots",
+    "affix": "viper",
+    "weight": "medium"
+  },
+  {
+    "id": 73859,
+    "name": "morbachsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "dire",
+    "weight": "heavy"
+  },
+  {
+    "id": 73882,
+    "name": "laranthirsdoublet",
+    "type": "coat",
+    "affix": "vigilant",
+    "weight": "light"
+  },
+  {
+    "id": 73925,
+    "name": "ossasrevolver",
+    "type": "pistol",
+    "affix": "crusader"
+  },
+  {
+    "id": 73932,
+    "name": "ossasshoulderguard",
+    "type": "shoulders",
+    "affix": "crusader",
+    "weight": "medium"
+  },
+  {
+    "id": 73948,
+    "name": "maklainsgreatbow",
+    "type": "longbow",
+    "affix": "minstrel"
+  },
+  {
+    "id": 73970,
+    "name": "maklainsmasque",
+    "type": "helm",
+    "affix": "minstrel",
+    "weight": "light"
+  },
+  {
+    "id": 73971,
+    "name": "tizlaksshoulderguard",
+    "type": "shoulders",
+    "affix": "commander",
+    "weight": "medium"
+  },
+  {
+    "id": 73984,
+    "name": "pahuasblade",
+    "type": "sword",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 73996,
+    "name": "laranthirsclaymore",
+    "type": "greatsword",
+    "affix": "vigilant"
+  },
+  {
+    "id": 74004,
+    "name": "ossasvisage",
+    "type": "helm",
+    "affix": "crusader",
+    "weight": "medium"
+  },
+  {
+    "id": 74034,
+    "name": "yassithsharpoongun",
+    "type": "speargun",
+    "affix": "viper"
+  },
+  {
+    "id": 74056,
+    "name": "laranthirswand",
+    "type": "scepter",
+    "affix": "vigilant"
+  },
+  {
+    "id": 74064,
+    "name": "laranthirsblade",
+    "type": "sword",
+    "affix": "vigilant"
+  },
+  {
+    "id": 74083,
+    "name": "tizlaksshortbow",
+    "type": "shortbow",
+    "affix": "commander"
+  },
+  {
+    "id": 74117,
+    "name": "ferratussmetalbreather",
+    "type": "helmaquatic",
+    "affix": "rabid",
+    "weight": "heavy"
+  },
+  {
+    "id": 74119,
+    "name": "ferratussclothbreather",
+    "type": "helmaquatic",
+    "affix": "rabid",
+    "weight": "light"
+  },
+  {
+    "id": 74124,
+    "name": "ossaswand",
+    "type": "scepter",
+    "affix": "crusader"
+  },
+  {
+    "id": 74172,
+    "name": "svaardstrident",
+    "type": "trident",
+    "affix": "marauder"
+  },
+  {
+    "id": 74179,
+    "name": "yassithsrazor",
+    "type": "dagger",
+    "affix": "viper"
+  },
+  {
+    "id": 74197,
+    "name": "rukasharpoongun",
+    "type": "speargun",
+    "affix": "wanderer"
+  },
+  {
+    "id": 74264,
+    "name": "yassithsfootwear",
+    "type": "boots",
+    "affix": "viper",
+    "weight": "light"
+  },
+  {
+    "id": 74326,
+    "name": "transference",
+    "type": "sigil"
+  },
+  {
+    "id": 74331,
+    "name": "rukasvisage",
+    "type": "helm",
+    "affix": "wanderer",
+    "weight": "medium"
+  },
+  {
+    "id": 74332,
+    "name": "nightfury",
+    "type": "shoulders",
+    "affix": "sinister",
+    "weight": "light"
+  },
+  {
+    "id": 74333,
+    "name": "tateossleatherbreather",
+    "type": "helmaquatic",
+    "affix": "cleric",
+    "weight": "medium"
+  },
+  {
+    "id": 74343,
+    "name": "attunedbarbedsignetinfused",
+    "type": "ring",
+    "affix": "rampager"
+  },
+  {
+    "id": 74353,
+    "name": "zojjasmetalbreather",
+    "type": "helmaquatic",
+    "affix": "berserker",
+    "weight": "heavy"
+  },
+  {
+    "id": 74357,
+    "name": "yassithsvisage",
+    "type": "helm",
+    "affix": "viper",
+    "weight": "medium"
+  },
+  {
+    "id": 74363,
+    "name": "yassithswarhammer",
+    "type": "hammer",
+    "affix": "viper"
+  },
+  {
+    "id": 74412,
+    "name": "yassithsvisor",
+    "type": "helm",
+    "affix": "viper",
+    "weight": "heavy"
+  },
+  {
+    "id": 74425,
+    "name": "svaardsbastion",
+    "type": "shield",
+    "affix": "marauder"
+  },
+  {
+    "id": 74448,
+    "name": "maklainsdoublet",
+    "type": "coat",
+    "affix": "minstrel",
+    "weight": "light"
+  },
+  {
+    "id": 74500,
+    "name": "svaardsbrazier",
+    "type": "torch",
+    "affix": "marauder"
+  },
+  {
+    "id": 74512,
+    "name": "laranthirswristguards",
+    "type": "gloves",
+    "affix": "vigilant",
+    "weight": "light"
+  },
+  {
+    "id": 74516,
+    "name": "svaardsartifact",
+    "type": "focus",
+    "affix": "marauder"
+  },
+  {
+    "id": 74518,
+    "name": "svaardswristguards",
+    "type": "gloves",
+    "affix": "marauder",
+    "weight": "light"
+  },
+  {
+    "id": 74522,
+    "name": "laranthirsmasque",
+    "type": "helm",
+    "affix": "vigilant",
+    "weight": "light"
+  },
+  {
+    "id": 74524,
+    "name": "pahuasdoublet",
+    "type": "coat",
+    "affix": "trailblazer",
+    "weight": "light"
+  },
+  {
+    "id": 74547,
+    "name": "nightfury",
+    "type": "shoulders",
+    "affix": "sinister",
+    "weight": "medium"
+  },
+  {
+    "id": 74569,
+    "name": "yassithsshortbow",
+    "type": "shortbow",
+    "affix": "viper"
+  },
+  {
+    "id": 74612,
+    "name": "laranthirsrevolver",
+    "type": "pistol",
+    "affix": "vigilant"
+  },
+  {
+    "id": 74645,
+    "name": "laranthirspauldrons",
+    "type": "shoulders",
+    "affix": "vigilant",
+    "weight": "heavy"
+  },
+  {
+    "id": 74667,
+    "name": "laranthirsvisage",
+    "type": "helm",
+    "affix": "vigilant",
+    "weight": "medium"
+  },
+  {
+    "id": 74679,
+    "name": "rukasreaver",
+    "type": "axe",
+    "affix": "wanderer"
+  },
+  {
+    "id": 74680,
+    "name": "zintlclothbreather",
+    "type": "helmaquatic",
+    "affix": "shaman",
+    "weight": "light"
+  },
+  {
+    "id": 74691,
+    "name": "leftpawsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "settler",
+    "weight": "heavy"
+  },
+  {
+    "id": 74695,
+    "name": "whisperssecret",
+    "type": "amulet",
+    "affix": "crusader"
+  },
+  {
+    "id": 74735,
+    "name": "rukasspire",
+    "type": "staff",
+    "affix": "wanderer"
+  },
+  {
+    "id": 74737,
+    "name": "svaardsstriders",
+    "type": "boots",
+    "affix": "marauder",
+    "weight": "medium"
+  },
+  {
+    "id": 74744,
+    "name": "attunedsealofthekhanurinfused",
+    "type": "ring",
+    "affix": "rabidandapothecary"
+  },
+  {
+    "id": 74748,
+    "name": "maklainsbastion",
+    "type": "shield",
+    "affix": "minstrel"
+  },
+  {
+    "id": 74751,
+    "name": "ossasstriders",
+    "type": "boots",
+    "affix": "crusader",
+    "weight": "medium"
+  },
+  {
+    "id": 74776,
+    "name": "pahuaswarhammer",
+    "type": "hammer",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 74824,
+    "name": "beigarthsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "knight",
+    "weight": "heavy"
+  },
+  {
+    "id": 74836,
+    "name": "ossaswristguards",
+    "type": "gloves",
+    "affix": "crusader",
+    "weight": "light"
+  },
+  {
+    "id": 74905,
+    "name": "maklainsreaver",
+    "type": "axe",
+    "affix": "minstrel"
+  },
+  {
+    "id": 74921,
+    "name": "weiqismetalbreather",
+    "type": "helmaquatic",
+    "affix": "sentinel",
+    "weight": "heavy"
+  },
+  {
+    "id": 74929,
+    "name": "svaardsvisor",
+    "type": "helm",
+    "affix": "marauder",
+    "weight": "heavy"
+  },
+  {
+    "id": 74935,
+    "name": "ossasgreatbow",
+    "type": "longbow",
+    "affix": "crusader"
+  },
+  {
+    "id": 74953,
+    "name": "tizlaksgreatbow",
+    "type": "longbow",
+    "affix": "commander"
+  },
+  {
+    "id": 74962,
+    "name": "svaardstassets",
+    "type": "leggings",
+    "affix": "marauder",
+    "weight": "heavy"
+  },
+  {
+    "id": 74978,
+    "name": "dragonhunter",
+    "type": "rune"
+  },
+  {
+    "id": 74979,
+    "name": "veldrunnerleatherbreather",
+    "type": "helmaquatic",
+    "affix": "apothecary",
+    "weight": "medium"
+  },
+  {
+    "id": 75009,
+    "name": "ossasclaymore",
+    "type": "greatsword",
+    "affix": "crusader"
+  },
+  {
+    "id": 75022,
+    "name": "maklainsvisage",
+    "type": "helm",
+    "affix": "minstrel",
+    "weight": "medium"
+  },
+  {
+    "id": 75023,
+    "name": "laranthirsepaulets",
+    "type": "shoulders",
+    "affix": "vigilant",
+    "weight": "light"
+  },
+  {
+    "id": 75025,
+    "name": "laranthirsgreatbow",
+    "type": "longbow",
+    "affix": "vigilant"
+  },
+  {
+    "id": 75029,
+    "name": "attunedpurgesignetinfused",
+    "type": "ring",
+    "affix": "apothecary"
+  },
+  {
+    "id": 75030,
+    "name": "occamsclothbreather",
+    "type": "helmaquatic",
+    "affix": "carrion",
+    "weight": "light"
+  },
+  {
+    "id": 75042,
+    "name": "rukasherald",
+    "type": "warhorn",
+    "affix": "wanderer"
+  },
+  {
+    "id": 75103,
+    "name": "laranthirsharpoongun",
+    "type": "speargun",
+    "affix": "vigilant"
+  },
+  {
+    "id": 75107,
+    "name": "tizlaksbreastplate",
+    "type": "coat",
+    "affix": "commander",
+    "weight": "heavy"
+  },
+  {
+    "id": 75135,
+    "name": "ossasimpaler",
+    "type": "harpoon",
+    "affix": "crusader"
+  },
+  {
+    "id": 75142,
+    "name": "maklainswarfists",
+    "type": "gloves",
+    "affix": "minstrel",
+    "weight": "heavy"
+  },
+  {
+    "id": 75156,
+    "name": "attunedruriksroyalsignetringinfused",
+    "type": "ring",
+    "affix": "cavalier"
+  },
+  {
+    "id": 75174,
+    "name": "laranthirswarhammer",
+    "type": "hammer",
+    "affix": "vigilant"
+  },
+  {
+    "id": 75175,
+    "name": "attunedralenasbandinfused",
+    "type": "ring",
+    "affix": "direandrabid"
+  },
+  {
+    "id": 75183,
+    "name": "svaardsbreeches",
+    "type": "leggings",
+    "affix": "marauder",
+    "weight": "light"
+  },
+  {
+    "id": 75200,
+    "name": "maklainsspire",
+    "type": "staff",
+    "affix": "minstrel"
+  },
+  {
+    "id": 75201,
+    "name": "svaardsherald",
+    "type": "warhorn",
+    "affix": "marauder"
+  },
+  {
+    "id": 75203,
+    "name": "ossasharpoongun",
+    "type": "speargun",
+    "affix": "crusader"
+  },
+  {
+    "id": 75224,
+    "name": "laranthirsreaver",
+    "type": "axe",
+    "affix": "vigilant"
+  },
+  {
+    "id": 75231,
+    "name": "hronksclothbreather",
+    "type": "helmaquatic",
+    "affix": "magi",
+    "weight": "light"
+  },
+  {
+    "id": 75248,
+    "name": "pahuasstriders",
+    "type": "boots",
+    "affix": "trailblazer",
+    "weight": "medium"
+  },
+  {
+    "id": 75269,
+    "name": "svaardswand",
+    "type": "scepter",
+    "affix": "marauder"
+  },
+  {
+    "id": 75277,
+    "name": "attunedvassarsbandinfused",
+    "type": "ring",
+    "affix": "direandrabid"
+  },
+  {
+    "id": 75285,
+    "name": "pahuasvisage",
+    "type": "helm",
+    "affix": "trailblazer",
+    "weight": "medium"
+  },
+  {
+    "id": 75307,
+    "name": "rukasclaymore",
+    "type": "greatsword",
+    "affix": "wanderer"
+  },
+  {
+    "id": 75312,
+    "name": "attunedsandfordfamilyringinfused",
+    "type": "ring",
+    "affix": "nomad"
+  },
+  {
+    "id": 75315,
+    "name": "attunedbaghnakhinfused",
+    "type": "ring",
+    "affix": "berserkerandvalkyrie"
+  },
+  {
+    "id": 75325,
+    "name": "yassithsherald",
+    "type": "warhorn",
+    "affix": "viper"
+  },
+  {
+    "id": 75331,
+    "name": "pahuasartifact",
+    "type": "focus",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 75340,
+    "name": "maklainsleggings",
+    "type": "leggings",
+    "affix": "minstrel",
+    "weight": "medium"
+  },
+  {
+    "id": 75349,
+    "name": "maklainsfootwear",
+    "type": "boots",
+    "affix": "minstrel",
+    "weight": "light"
+  },
+  {
+    "id": 75355,
+    "name": "attunedbandofthebrotherhoodinfused",
+    "type": "ring",
+    "affix": "captain"
+  },
+  {
+    "id": 75356,
+    "name": "tizlaksartifact",
+    "type": "focus",
+    "affix": "commander"
+  },
+  {
+    "id": 75378,
+    "name": "yassithsbreeches",
+    "type": "leggings",
+    "affix": "viper",
+    "weight": "light"
+  },
+  {
+    "id": 75388,
+    "name": "maklainsrazor",
+    "type": "dagger",
+    "affix": "minstrel"
+  },
+  {
+    "id": 75413,
+    "name": "rukasimpaler",
+    "type": "harpoon",
+    "affix": "wanderer"
+  },
+  {
+    "id": 75422,
+    "name": "pahuasrazor",
+    "type": "dagger",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 75425,
+    "name": "beigarthsclothbreather",
+    "type": "helmaquatic",
+    "affix": "knight",
+    "weight": "light"
+  },
+  {
+    "id": 75438,
+    "name": "attunedcirqueofarahinfused",
+    "type": "ring",
+    "affix": "captain"
+  },
+  {
+    "id": 75521,
+    "name": "rukaswarhammer",
+    "type": "hammer",
+    "affix": "wanderer"
+  },
+  {
+    "id": 75554,
+    "name": "laranthirswarfists",
+    "type": "gloves",
+    "affix": "vigilant",
+    "weight": "heavy"
+  },
+  {
+    "id": 75559,
+    "name": "svaardsflangedmace",
+    "type": "mace",
+    "affix": "marauder"
+  },
+  {
+    "id": 75572,
+    "name": "pahuasshoulderguard",
+    "type": "shoulders",
+    "affix": "trailblazer",
+    "weight": "medium"
+  },
+  {
+    "id": 75573,
+    "name": "zojjasclothbreather",
+    "type": "helmaquatic",
+    "affix": "berserker",
+    "weight": "light"
+  },
+  {
+    "id": 75581,
+    "name": "ossasflangedmace",
+    "type": "mace",
+    "affix": "crusader"
+  },
+  {
+    "id": 75583,
+    "name": "ossasleggings",
+    "type": "leggings",
+    "affix": "crusader",
+    "weight": "medium"
+  },
+  {
+    "id": 75589,
+    "name": "svaardsshoulderguard",
+    "type": "shoulders",
+    "affix": "marauder",
+    "weight": "medium"
+  },
+  {
+    "id": 75611,
+    "name": "tizlaksbrazier",
+    "type": "torch",
+    "affix": "commander"
+  },
+  {
+    "id": 75626,
+    "name": "yassithsgrips",
+    "type": "gloves",
+    "affix": "viper",
+    "weight": "medium"
+  },
+  {
+    "id": 75642,
+    "name": "pahuasgreatbow",
+    "type": "longbow",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 75644,
+    "name": "maklainsshortbow",
+    "type": "shortbow",
+    "affix": "minstrel"
+  },
+  {
+    "id": 75667,
+    "name": "ossasreaver",
+    "type": "axe",
+    "affix": "crusader"
+  },
+  {
+    "id": 75668,
+    "name": "laranthirsartifact",
+    "type": "focus",
+    "affix": "vigilant"
+  },
+  {
+    "id": 75669,
+    "name": "attunedringofreddeathinfused",
+    "type": "ring",
+    "affix": "berserker"
+  },
+  {
+    "id": 75697,
+    "name": "pahuasherald",
+    "type": "warhorn",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 75718,
+    "name": "svaardsgrips",
+    "type": "gloves",
+    "affix": "marauder",
+    "weight": "medium"
+  },
+  {
+    "id": 75727,
+    "name": "tizlaksmasque",
+    "type": "helm",
+    "affix": "commander",
+    "weight": "light"
+  },
+  {
+    "id": 75743,
+    "name": "rukasshortbow",
+    "type": "shortbow",
+    "affix": "wanderer"
+  },
+  {
+    "id": 75747,
+    "name": "svaardsgreatbow",
+    "type": "longbow",
+    "affix": "marauder"
+  },
+  {
+    "id": 75765,
+    "name": "hronksleatherbreather",
+    "type": "helmaquatic",
+    "affix": "magi",
+    "weight": "medium"
+  },
+  {
+    "id": 75770,
+    "name": "yassithsmasque",
+    "type": "helm",
+    "affix": "viper",
+    "weight": "light"
+  },
+  {
+    "id": 75795,
+    "name": "janthirsgaze",
+    "type": "amulet",
+    "affix": "marauder"
+  },
+  {
+    "id": 75820,
+    "name": "maklainsbrazier",
+    "type": "torch",
+    "affix": "minstrel"
+  },
+  {
+    "id": 75858,
+    "name": "svaardswarfists",
+    "type": "gloves",
+    "affix": "marauder",
+    "weight": "heavy"
+  },
+  {
+    "id": 75866,
+    "name": "maklainswristguards",
+    "type": "gloves",
+    "affix": "minstrel",
+    "weight": "light"
+  },
+  {
+    "id": 75897,
+    "name": "svaardswarhammer",
+    "type": "hammer",
+    "affix": "marauder"
+  },
+  {
+    "id": 75912,
+    "name": "ossasguise",
+    "type": "coat",
+    "affix": "crusader",
+    "weight": "medium"
+  },
+  {
+    "id": 75940,
+    "name": "svaardsmasque",
+    "type": "helm",
+    "affix": "marauder",
+    "weight": "light"
+  },
+  {
+    "id": 75943,
+    "name": "attunedpalawajokosfingercuffinfused",
+    "type": "ring",
+    "affix": "rampager"
+  },
+  {
+    "id": 75954,
+    "name": "ahamidsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "soldier",
+    "weight": "heavy"
+  },
+  {
+    "id": 75987,
+    "name": "ossaspauldrons",
+    "type": "shoulders",
+    "affix": "crusader",
+    "weight": "heavy"
+  },
+  {
+    "id": 76007,
+    "name": "gobrechsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "valkyrie",
+    "weight": "medium"
+  },
+  {
+    "id": 76024,
+    "name": "attunedcrystallinebandinfused",
+    "type": "ring",
+    "affix": "berserker"
+  },
+  {
+    "id": 76049,
+    "name": "rukaswand",
+    "type": "scepter",
+    "affix": "wanderer"
+  },
+  {
+    "id": 76055,
+    "name": "pahuasclaymore",
+    "type": "greatsword",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 76075,
+    "name": "tizlaksbastion",
+    "type": "shield",
+    "affix": "commander"
+  },
+  {
+    "id": 76089,
+    "name": "tizlaksspire",
+    "type": "staff",
+    "affix": "commander"
+  },
+  {
+    "id": 76092,
+    "name": "ossaswarfists",
+    "type": "gloves",
+    "affix": "crusader",
+    "weight": "heavy"
+  },
+  {
+    "id": 76100,
+    "name": "herald",
+    "type": "rune"
+  },
+  {
+    "id": 76110,
+    "name": "tizlaksguise",
+    "type": "coat",
+    "affix": "commander",
+    "weight": "medium"
+  },
+  {
+    "id": 76139,
+    "name": "tizlaksbreeches",
+    "type": "leggings",
+    "affix": "commander",
+    "weight": "light"
+  },
+  {
+    "id": 76166,
+    "name": "tempest",
+    "type": "rune"
+  },
+  {
+    "id": 76184,
+    "name": "keepersleatherbreather",
+    "type": "helmaquatic",
+    "affix": "zealot",
+    "weight": "medium"
+  },
+  {
+    "id": 76186,
+    "name": "ossasepaulets",
+    "type": "shoulders",
+    "affix": "crusader",
+    "weight": "light"
+  },
+  {
+    "id": 76198,
+    "name": "rukasbastion",
+    "type": "shield",
+    "affix": "wanderer"
+  },
+  {
+    "id": 76207,
+    "name": "pahuastrident",
+    "type": "trident",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 76212,
+    "name": "maklainsimpaler",
+    "type": "harpoon",
+    "affix": "minstrel"
+  },
+  {
+    "id": 76245,
+    "name": "svaardsbreastplate",
+    "type": "coat",
+    "affix": "marauder",
+    "weight": "heavy"
+  },
+  {
+    "id": 76253,
+    "name": "hronksmetalbreather",
+    "type": "helmaquatic",
+    "affix": "magi",
+    "weight": "heavy"
+  },
+  {
+    "id": 76256,
+    "name": "pahuasshortbow",
+    "type": "shortbow",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 76262,
+    "name": "maklainswarhammer",
+    "type": "hammer",
+    "affix": "minstrel"
+  },
+  {
+    "id": 76263,
+    "name": "pahuasgreaves",
+    "type": "boots",
+    "affix": "trailblazer",
+    "weight": "heavy"
+  },
+  {
+    "id": 76271,
+    "name": "yassithsbrazier",
+    "type": "torch",
+    "affix": "viper"
+  },
+  {
+    "id": 76324,
+    "name": "angchuclothbreather",
+    "type": "helmaquatic",
+    "affix": "cavalier",
+    "weight": "light"
+  },
+  {
+    "id": 76377,
+    "name": "yassithsbreastplate",
+    "type": "coat",
+    "affix": "viper",
+    "weight": "heavy"
+  },
+  {
+    "id": 76403,
+    "name": "tateossclothbreather",
+    "type": "helmaquatic",
+    "affix": "cleric",
+    "weight": "light"
+  },
+  {
+    "id": 76406,
+    "name": "pahuasepaulets",
+    "type": "shoulders",
+    "affix": "trailblazer",
+    "weight": "light"
+  },
+  {
+    "id": 76420,
+    "name": "ossasbreastplate",
+    "type": "coat",
+    "affix": "crusader",
+    "weight": "heavy"
+  },
+  {
+    "id": 76436,
+    "name": "pahuasharpoongun",
+    "type": "speargun",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 76501,
+    "name": "maklainsclaymore",
+    "type": "greatsword",
+    "affix": "minstrel"
+  },
+  {
+    "id": 76504,
+    "name": "attunedforgottenbandinfused",
+    "type": "ring",
+    "affix": "nomad"
+  },
+  {
+    "id": 76551,
+    "name": "svaardspauldrons",
+    "type": "shoulders",
+    "affix": "marauder",
+    "weight": "heavy"
+  },
+  {
+    "id": 76557,
+    "name": "attunedettinbandinfused",
+    "type": "ring",
+    "affix": "knight"
+  },
+  {
+    "id": 76599,
+    "name": "thesisonmasterfulaccuracy",
+    "type": "utility"
+  },
+  {
+    "id": 76631,
+    "name": "laranthirsspire",
+    "type": "staff",
+    "affix": "vigilant"
+  },
+  {
+    "id": 76648,
+    "name": "tizlaksharpoongun",
+    "type": "speargun",
+    "affix": "commander"
+  },
+  {
+    "id": 76658,
+    "name": "maklainsshoulderguard",
+    "type": "shoulders",
+    "affix": "minstrel",
+    "weight": "medium"
+  },
+  {
+    "id": 76660,
+    "name": "prioryshistory",
+    "type": "amulet",
+    "affix": "crusader"
+  },
+  {
+    "id": 76671,
+    "name": "svaardsepaulets",
+    "type": "shoulders",
+    "affix": "marauder",
+    "weight": "light"
+  },
+  {
+    "id": 76688,
+    "name": "yassithswand",
+    "type": "scepter",
+    "affix": "viper"
+  },
+  {
+    "id": 76698,
+    "name": "tizlaksgrips",
+    "type": "gloves",
+    "affix": "commander",
+    "weight": "medium"
+  },
+  {
+    "id": 76710,
+    "name": "yassithsguise",
+    "type": "coat",
+    "affix": "viper",
+    "weight": "medium"
+  },
+  {
+    "id": 76717,
+    "name": "pahuasbastion",
+    "type": "shield",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 76729,
+    "name": "maklainsgrips",
+    "type": "gloves",
+    "affix": "minstrel",
+    "weight": "medium"
+  },
+  {
+    "id": 76730,
+    "name": "maklainsblade",
+    "type": "sword",
+    "affix": "minstrel"
+  },
+  {
+    "id": 76738,
+    "name": "thesisonmasterfulmalice",
+    "type": "utility"
+  },
+  {
+    "id": 76768,
+    "name": "occamsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "carrion",
+    "weight": "heavy"
+  },
+  {
+    "id": 76776,
+    "name": "yassithswarfists",
+    "type": "gloves",
+    "affix": "viper",
+    "weight": "heavy"
+  },
+  {
+    "id": 76786,
+    "name": "yassithsflangedmace",
+    "type": "mace",
+    "affix": "viper"
+  },
+  {
+    "id": 76809,
+    "name": "attunedlunariacircleofthemooninfused",
+    "type": "ring",
+    "affix": "celestial"
+  },
+  {
+    "id": 76813,
+    "name": "surging",
+    "type": "rune"
+  },
+  {
+    "id": 76814,
+    "name": "rukasbreastplate",
+    "type": "coat",
+    "affix": "wanderer",
+    "weight": "heavy"
+  },
+  {
+    "id": 76821,
+    "name": "tizlakswand",
+    "type": "scepter",
+    "affix": "commander"
+  },
+  {
+    "id": 76823,
+    "name": "attunedadelbernsroyalsignetringinfused",
+    "type": "ring",
+    "affix": "cavalier"
+  },
+  {
+    "id": 76824,
+    "name": "laranthirsherald",
+    "type": "warhorn",
+    "affix": "vigilant"
+  },
+  {
+    "id": 76833,
+    "name": "writofmasterfulaccuracy",
+    "type": "utility"
+  },
+  {
+    "id": 76834,
+    "name": "pahuasmasque",
+    "type": "helm",
+    "affix": "trailblazer",
+    "weight": "light"
+  },
+  {
+    "id": 76837,
+    "name": "wupwupclothbreather",
+    "type": "helmaquatic",
+    "affix": "celestial",
+    "weight": "light"
+  },
+  {
+    "id": 76854,
+    "name": "ossasdoublet",
+    "type": "coat",
+    "affix": "crusader",
+    "weight": "light"
+  },
+  {
+    "id": 76861,
+    "name": "forgemastersclothbreather",
+    "type": "helmaquatic",
+    "affix": "rampager",
+    "weight": "light"
+  },
+  {
+    "id": 76878,
+    "name": "laranthirsshortbow",
+    "type": "shortbow",
+    "affix": "vigilant"
+  },
+  {
+    "id": 76885,
+    "name": "nightfury",
+    "type": "shoulders",
+    "affix": "sinister",
+    "weight": "heavy"
+  },
+  {
+    "id": 76889,
+    "name": "svaardsspire",
+    "type": "staff",
+    "affix": "marauder"
+  },
+  {
+    "id": 76908,
+    "name": "pahuasbreastplate",
+    "type": "coat",
+    "affix": "trailblazer",
+    "weight": "heavy"
+  },
+  {
+    "id": 76936,
+    "name": "attunedluccesealinfused",
+    "type": "ring",
+    "affix": "apothecary"
+  },
+  {
+    "id": 76942,
+    "name": "rukasgreaves",
+    "type": "boots",
+    "affix": "wanderer",
+    "weight": "heavy"
+  },
+  {
+    "id": 76970,
+    "name": "tizlakstrident",
+    "type": "trident",
+    "affix": "commander"
+  },
+  {
+    "id": 76977,
+    "name": "tizlakswarhammer",
+    "type": "hammer",
+    "affix": "commander"
+  },
+  {
+    "id": 76984,
+    "name": "pahuasmusket",
+    "type": "rifle",
+    "affix": "trailblazer"
+  },
+  {
+    "id": 76985,
+    "name": "svaardsblade",
+    "type": "sword",
+    "affix": "marauder"
+  },
+  {
+    "id": 76988,
+    "name": "tizlaksflangedmace",
+    "type": "mace",
+    "affix": "commander"
+  },
+  {
+    "id": 76993,
+    "name": "veldrunnermetalbreather",
+    "type": "helmaquatic",
+    "affix": "apothecary",
+    "weight": "heavy"
+  },
+  {
+    "id": 77022,
+    "name": "maklainstassets",
+    "type": "leggings",
+    "affix": "minstrel",
+    "weight": "heavy"
+  },
+  {
+    "id": 77055,
+    "name": "rukasmusket",
+    "type": "rifle",
+    "affix": "wanderer"
+  },
+  {
+    "id": 77057,
+    "name": "svaardsvisage",
+    "type": "helm",
+    "affix": "marauder",
+    "weight": "medium"
+  },
+  {
+    "id": 77058,
+    "name": "veratasmetalbreather",
+    "type": "helmaquatic",
+    "affix": "sinister",
+    "weight": "heavy"
+  },
+  {
+    "id": 77096,
+    "name": "ventarismetalbreather",
+    "type": "helmaquatic",
+    "affix": "nomad",
+    "weight": "heavy"
+  },
+  {
+    "id": 77100,
+    "name": "ventarisleatherbreather",
+    "type": "helmaquatic",
+    "affix": "nomad",
+    "weight": "medium"
+  },
+  {
+    "id": 77102,
+    "name": "weiqisclothbreather",
+    "type": "helmaquatic",
+    "affix": "sentinel",
+    "weight": "light"
+  },
+  {
+    "id": 77108,
+    "name": "ossasmasque",
+    "type": "helm",
+    "affix": "crusader",
+    "weight": "light"
+  },
+  {
+    "id": 77122,
+    "name": "yassithsreaver",
+    "type": "axe",
+    "affix": "viper"
+  },
+  {
+    "id": 77127,
+    "name": "tizlakspauldrons",
+    "type": "shoulders",
+    "affix": "commander",
+    "weight": "heavy"
+  },
+  {
+    "id": 77143,
+    "name": "yassithstassets",
+    "type": "leggings",
+    "affix": "viper",
+    "weight": "heavy"
+  },
+  {
+    "id": 77146,
+    "name": "thesisonmasterfulstrength",
+    "type": "utility"
+  },
+  {
+    "id": 77150,
+    "name": "laranthirsleggings",
+    "type": "leggings",
+    "affix": "vigilant",
+    "weight": "medium"
+  },
+  {
+    "id": 77169,
+    "name": "tizlaksvisor",
+    "type": "helm",
+    "affix": "commander",
+    "weight": "heavy"
+  },
+  {
+    "id": 77177,
+    "name": "saphirsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "assassin",
+    "weight": "medium"
+  },
+  {
+    "id": 77204,
+    "name": "maklainsstriders",
+    "type": "boots",
+    "affix": "minstrel",
+    "weight": "medium"
+  },
+  {
+    "id": 77208,
+    "name": "tizlakswristguards",
+    "type": "gloves",
+    "affix": "commander",
+    "weight": "light"
+  },
+  {
+    "id": 77229,
+    "name": "laranthirsbreastplate",
+    "type": "coat",
+    "affix": "vigilant",
+    "weight": "heavy"
+  },
+  {
+    "id": 77249,
+    "name": "tizlakswarfists",
+    "type": "gloves",
+    "affix": "commander",
+    "weight": "heavy"
+  },
+  {
+    "id": 77567,
+    "name": "tuningicicle",
+    "type": "utility"
+  },
+  {
+    "id": 77569,
+    "name": "tinoffruitcake",
+    "type": "utility"
+  },
+  {
+    "id": 77632,
+    "name": "peppermintoil",
+    "type": "utility"
+  },
+  {
+    "id": 78305,
+    "name": "superiorsharpeningstone",
+    "type": "utility"
+  },
+  {
+    "id": 78658,
+    "name": "mangopie",
+    "type": "food"
+  },
+  {
+    "id": 78786,
+    "name": "shiningbladebountynoticeruyethecrimson",
+    "type": "gizmo"
+  },
+  {
+    "id": 78978,
+    "name": "whitemantleportaldevice",
+    "type": "gizmo"
+  },
+  {
+    "id": 80116,
+    "name": "thackeraysrifle",
+    "type": "rifle",
+    "affix": "seraph"
+  },
+  {
+    "id": 80132,
+    "name": "thackeraysgreaves",
+    "type": "boots",
+    "affix": "seraph",
+    "weight": "heavy"
+  },
+  {
+    "id": 80133,
+    "name": "thackeraysbulwark",
+    "type": "shield",
+    "affix": "seraph"
+  },
+  {
+    "id": 80137,
+    "name": "thackeraysshoulderguard",
+    "type": "shoulders",
+    "affix": "seraph",
+    "weight": "medium"
+  },
+  {
+    "id": 80158,
+    "name": "thackerayspillar",
+    "type": "staff",
+    "affix": "seraph"
+  },
+  {
+    "id": 80163,
+    "name": "thackeraysslicer",
+    "type": "dagger",
+    "affix": "seraph"
+  },
+  {
+    "id": 80226,
+    "name": "thackerayscrusader",
+    "type": "greatsword",
+    "affix": "seraph"
+  },
+  {
+    "id": 80227,
+    "name": "thackeraysgauntlets",
+    "type": "gloves",
+    "affix": "seraph",
+    "weight": "heavy"
+  },
+  {
+    "id": 80244,
+    "name": "thackeraysdoublet",
+    "type": "coat",
+    "affix": "seraph",
+    "weight": "light"
+  },
+  {
+    "id": 80268,
+    "name": "thackeraysgloves",
+    "type": "gloves",
+    "affix": "seraph",
+    "weight": "light"
+  },
+  {
+    "id": 80274,
+    "name": "thackeraystassets",
+    "type": "leggings",
+    "affix": "seraph",
+    "weight": "heavy"
+  },
+  {
+    "id": 80280,
+    "name": "thackerayscuirass",
+    "type": "coat",
+    "affix": "seraph",
+    "weight": "medium"
+  },
+  {
+    "id": 80300,
+    "name": "thackeraysboots",
+    "type": "boots",
+    "affix": "seraph",
+    "weight": "medium"
+  },
+  {
+    "id": 80318,
+    "name": "thackerayscleaver",
+    "type": "axe",
+    "affix": "seraph"
+  },
+  {
+    "id": 80361,
+    "name": "thackeraysbreastplate",
+    "type": "coat",
+    "affix": "seraph",
+    "weight": "heavy"
+  },
+  {
+    "id": 80370,
+    "name": "thackeraysvisage",
+    "type": "helm",
+    "affix": "seraph",
+    "weight": "medium"
+  },
+  {
+    "id": 80375,
+    "name": "thackeraysrod",
+    "type": "scepter",
+    "affix": "seraph"
+  },
+  {
+    "id": 80391,
+    "name": "thackerayscrescent",
+    "type": "shortbow",
+    "affix": "seraph"
+  },
+  {
+    "id": 80402,
+    "name": "thackeraysgreatbow",
+    "type": "longbow",
+    "affix": "seraph"
+  },
+  {
+    "id": 80407,
+    "name": "thackeraysbugle",
+    "type": "warhorn",
+    "affix": "seraph"
+  },
+  {
+    "id": 80447,
+    "name": "thackeraysharpoongun",
+    "type": "speargun",
+    "affix": "vigilant"
+  },
+  {
+    "id": 80448,
+    "name": "thackeraysepaulets",
+    "type": "shoulders",
+    "affix": "seraph",
+    "weight": "light"
+  },
+  {
+    "id": 80451,
+    "name": "thackeraysbarbute",
+    "type": "helm",
+    "affix": "seraph",
+    "weight": "heavy"
+  },
+  {
+    "id": 80486,
+    "name": "thackeraysfocus",
+    "type": "focus",
+    "affix": "seraph"
+  },
+  {
+    "id": 80491,
+    "name": "thackeraysfootwear",
+    "type": "boots",
+    "affix": "seraph",
+    "weight": "light"
+  },
+  {
+    "id": 80512,
+    "name": "thackeraysgladius",
+    "type": "sword",
+    "affix": "seraph"
+  },
+  {
+    "id": 80520,
+    "name": "thackerayshandcannon",
+    "type": "pistol",
+    "affix": "seraph"
+  },
+  {
+    "id": 80522,
+    "name": "thackerayscrusher",
+    "type": "hammer",
+    "affix": "seraph"
+  },
+  {
+    "id": 80588,
+    "name": "thackeraysvambraces",
+    "type": "gloves",
+    "affix": "seraph",
+    "weight": "medium"
+  },
+  {
+    "id": 80616,
+    "name": "thackerayspauldrons",
+    "type": "shoulders",
+    "affix": "seraph",
+    "weight": "heavy"
+  },
+  {
+    "id": 80618,
+    "name": "thackeraysspire",
+    "type": "trident",
+    "affix": "seraph"
+  },
+  {
+    "id": 80624,
+    "name": "thackeraysgavel",
+    "type": "mace",
+    "affix": "seraph"
+  },
+  {
+    "id": 80637,
+    "name": "thackeraysleggings",
+    "type": "leggings",
+    "affix": "seraph",
+    "weight": "medium"
+  },
+  {
+    "id": 80661,
+    "name": "thackeraysmasque",
+    "type": "helm",
+    "affix": "seraph",
+    "weight": "light"
+  },
+  {
+    "id": 80664,
+    "name": "thackerayspants",
+    "type": "leggings",
+    "affix": "seraph",
+    "weight": "light"
+  },
+  {
+    "id": 80670,
+    "name": "thackeraysskewer",
+    "type": "harpoon",
+    "affix": "seraph"
+  },
+  {
+    "id": 80683,
+    "name": "thackeraysflame",
+    "type": "torch",
+    "affix": "seraph"
+  },
+  {
+    "id": 81045,
+    "name": "bounty",
+    "type": "sigil"
+  },
+  {
+    "id": 81091,
+    "name": "naturesbounty",
+    "type": "rune"
+  },
+  {
+    "id": 82505,
+    "name": "attuneddunkorostreasureinfused",
+    "type": "ring",
+    "affix": "marshal"
+  },
+  {
+    "id": 82599,
+    "name": "firstspearsicon",
+    "type": "amulet",
+    "affix": "marshal"
+  },
+  {
+    "id": 82633,
+    "name": "holosmith",
+    "type": "rune"
+  },
+  {
+    "id": 82705,
+    "name": "attunedsigilofthefoolinfused",
+    "type": "ring",
+    "affix": "harrier"
+  },
+  {
+    "id": 82769,
+    "name": "gorenseeltoothcharm",
+    "type": "amulet",
+    "affix": "harrier"
+  },
+  {
+    "id": 82791,
+    "name": "deadeye",
+    "type": "rune"
+  },
+  {
+    "id": 82876,
+    "name": "frenzy",
+    "type": "sigil"
+  },
+  {
+    "id": 82897,
+    "name": "jahnussstainedpectoral",
+    "type": "amulet",
+    "affix": "grieving"
+  },
+  {
+    "id": 83321,
+    "name": "attunednadijehsdynasticsignetinfused",
+    "type": "ring",
+    "affix": "marshal"
+  },
+  {
+    "id": 83338,
+    "name": "firebrand",
+    "type": "rune"
+  },
+  {
+    "id": 83367,
+    "name": "cavalier",
+    "type": "rune"
+  },
+  {
+    "id": 83404,
+    "name": "mourningbell",
+    "type": "accessory",
+    "affix": "grieving"
+  },
+  {
+    "id": 83423,
+    "name": "weaver",
+    "type": "rune"
+  },
+  {
+    "id": 83429,
+    "name": "eloniantransitpass",
+    "type": "accessory",
+    "affix": "harrier"
+  },
+  {
+    "id": 83502,
+    "name": "renegade",
+    "type": "rune"
+  },
+  {
+    "id": 83663,
+    "name": "scourge",
+    "type": "rune"
+  },
+  {
+    "id": 83675,
+    "name": "attunedcorsairsringinfused",
+    "type": "ring",
+    "affix": "harrier"
+  },
+  {
+    "id": 83964,
+    "name": "soulbeast",
+    "type": "rune"
+  },
+  {
+    "id": 84127,
+    "name": "mirage",
+    "type": "rune"
+  },
+  {
+    "id": 84171,
+    "name": "rebirth",
+    "type": "rune"
+  },
+  {
+    "id": 84212,
+    "name": "attunedkolestormentedeyeinfused",
+    "type": "ring",
+    "affix": "grieving"
+  },
+  {
+    "id": 84296,
+    "name": "anthemofliberty",
+    "type": "accessory",
+    "affix": "marshal"
+  },
+  {
+    "id": 84505,
+    "name": "severance",
+    "type": "sigil"
+  },
+  {
+    "id": 84577,
+    "name": "attunedgiftofthehiddenscioninfused",
+    "type": "ring",
+    "affix": "grieving"
+  },
+  {
+    "id": 84749,
+    "name": "spellbreaker",
+    "type": "rune"
+  },
+  {
+    "id": 84866,
+    "name": "nadijehswristguards",
+    "type": "gloves",
+    "affix": "marshal",
+    "weight": "light"
+  },
+  {
+    "id": 84876,
+    "name": "thetwinsblade",
+    "type": "sword",
+    "affix": "grieving"
+  },
+  {
+    "id": 84878,
+    "name": "zehtukasrevolver",
+    "type": "pistol",
+    "affix": "harrier"
+  },
+  {
+    "id": 84879,
+    "name": "zehtukasvisor",
+    "type": "helm",
+    "affix": "harrier",
+    "weight": "heavy"
+  },
+  {
+    "id": 84883,
+    "name": "nadijehsvisage",
+    "type": "helm",
+    "affix": "marshal",
+    "weight": "medium"
+  },
+  {
+    "id": 84886,
+    "name": "nadijehsmusket",
+    "type": "rifle",
+    "affix": "marshal"
+  },
+  {
+    "id": 84909,
+    "name": "nadijehsrazor",
+    "type": "dagger",
+    "affix": "marshal"
+  },
+  {
+    "id": 84911,
+    "name": "thetwinstassets",
+    "type": "leggings",
+    "affix": "grieving",
+    "weight": "heavy"
+  },
+  {
+    "id": 84912,
+    "name": "zehtukasflangedmace",
+    "type": "mace",
+    "affix": "harrier"
+  },
+  {
+    "id": 84923,
+    "name": "zehtukasguise",
+    "type": "coat",
+    "affix": "harrier",
+    "weight": "medium"
+  },
+  {
+    "id": 84926,
+    "name": "zehtukasbreeches",
+    "type": "leggings",
+    "affix": "harrier",
+    "weight": "light"
+  },
+  {
+    "id": 84931,
+    "name": "thetwinsrevolver",
+    "type": "pistol",
+    "affix": "grieving"
+  },
+  {
+    "id": 84936,
+    "name": "thetwinsrazor",
+    "type": "dagger",
+    "affix": "grieving"
+  },
+  {
+    "id": 84939,
+    "name": "zehtukasblade",
+    "type": "sword",
+    "affix": "harrier"
+  },
+  {
+    "id": 84944,
+    "name": "thetwinsharpoongun",
+    "type": "speargun",
+    "affix": "grieving"
+  },
+  {
+    "id": 84954,
+    "name": "nadijehsstriders",
+    "type": "boots",
+    "affix": "marshal",
+    "weight": "medium"
+  },
+  {
+    "id": 84957,
+    "name": "zehtukasbastion",
+    "type": "shield",
+    "affix": "harrier"
+  },
+  {
+    "id": 84973,
+    "name": "zehtukasherald",
+    "type": "warhorn",
+    "affix": "harrier"
+  },
+  {
+    "id": 84983,
+    "name": "zehtukasgrips",
+    "type": "gloves",
+    "affix": "harrier",
+    "weight": "medium"
+  },
+  {
+    "id": 85001,
+    "name": "thetwinsspire",
+    "type": "staff",
+    "affix": "grieving"
+  },
+  {
+    "id": 85004,
+    "name": "zehtukaswristguards",
+    "type": "gloves",
+    "affix": "harrier",
+    "weight": "light"
+  },
+  {
+    "id": 85006,
+    "name": "thetwinsbrazier",
+    "type": "torch",
+    "affix": "grieving"
+  },
+  {
+    "id": 85007,
+    "name": "thetwinsfootwear",
+    "type": "boots",
+    "affix": "grieving",
+    "weight": "light"
+  },
+  {
+    "id": 85008,
+    "name": "nadijehsblade",
+    "type": "sword",
+    "affix": "marshal"
+  },
+  {
+    "id": 85013,
+    "name": "zehtukasbrazier",
+    "type": "torch",
+    "affix": "harrier"
+  },
+  {
+    "id": 85019,
+    "name": "thetwinsclaymore",
+    "type": "greatsword",
+    "affix": "grieving"
+  },
+  {
+    "id": 85021,
+    "name": "nadijehsleggings",
+    "type": "leggings",
+    "affix": "marshal",
+    "weight": "medium"
+  },
+  {
+    "id": 85024,
+    "name": "zehtukastassets",
+    "type": "leggings",
+    "affix": "harrier",
+    "weight": "heavy"
+  },
+  {
+    "id": 85027,
+    "name": "zehtukaswand",
+    "type": "scepter",
+    "affix": "harrier"
+  },
+  {
+    "id": 85036,
+    "name": "zehtukasharpoongun",
+    "type": "speargun",
+    "affix": "harrier"
+  },
+  {
+    "id": 85041,
+    "name": "nadijehsgreaves",
+    "type": "boots",
+    "affix": "marshal",
+    "weight": "heavy"
+  },
+  {
+    "id": 85042,
+    "name": "thetwinsbreastplate",
+    "type": "coat",
+    "affix": "grieving",
+    "weight": "heavy"
+  },
+  {
+    "id": 85044,
+    "name": "thetwinsartifact",
+    "type": "focus",
+    "affix": "grieving"
+  },
+  {
+    "id": 85047,
+    "name": "zehtukasreaver",
+    "type": "axe",
+    "affix": "harrier"
+  },
+  {
+    "id": 85048,
+    "name": "thetwinswristguards",
+    "type": "gloves",
+    "affix": "grieving",
+    "weight": "light"
+  },
+  {
+    "id": 85051,
+    "name": "zehtukasrazor",
+    "type": "dagger",
+    "affix": "harrier"
+  },
+  {
+    "id": 85054,
+    "name": "thetwinsshoulderguard",
+    "type": "shoulders",
+    "affix": "grieving",
+    "weight": "medium"
+  },
+  {
+    "id": 85061,
+    "name": "nadijehsrevolver",
+    "type": "pistol",
+    "affix": "marshal"
+  },
+  {
+    "id": 85062,
+    "name": "thetwinsguise",
+    "type": "coat",
+    "affix": "grieving",
+    "weight": "medium"
+  },
+  {
+    "id": 85066,
+    "name": "nadijehsepaulets",
+    "type": "shoulders",
+    "affix": "marshal",
+    "weight": "light"
+  },
+  {
+    "id": 85067,
+    "name": "thetwinsvisage",
+    "type": "helm",
+    "affix": "grieving",
+    "weight": "medium"
+  },
+  {
+    "id": 85071,
+    "name": "nadijehstassets",
+    "type": "leggings",
+    "affix": "marshal",
+    "weight": "heavy"
+  },
+  {
+    "id": 85072,
+    "name": "thetwinsmusket",
+    "type": "rifle",
+    "affix": "grieving"
+  },
+  {
+    "id": 85073,
+    "name": "nadijehsgreatbow",
+    "type": "longbow",
+    "affix": "marshal"
+  },
+  {
+    "id": 85074,
+    "name": "thetwinsherald",
+    "type": "warhorn",
+    "affix": "grieving"
+  },
+  {
+    "id": 85076,
+    "name": "thetwinswand",
+    "type": "scepter",
+    "affix": "grieving"
+  },
+  {
+    "id": 85083,
+    "name": "nadijehsguise",
+    "type": "coat",
+    "affix": "marshal",
+    "weight": "medium"
+  },
+  {
+    "id": 85089,
+    "name": "zehtukasepaulets",
+    "type": "shoulders",
+    "affix": "harrier",
+    "weight": "light"
+  },
+  {
+    "id": 85093,
+    "name": "thetwinsgreaves",
+    "type": "boots",
+    "affix": "grieving",
+    "weight": "heavy"
+  },
+  {
+    "id": 85094,
+    "name": "thetwinstrident",
+    "type": "trident",
+    "affix": "grieving"
+  },
+  {
+    "id": 85098,
+    "name": "zehtukasdoublet",
+    "type": "coat",
+    "affix": "harrier",
+    "weight": "light"
+  },
+  {
+    "id": 85109,
+    "name": "nadijehswand",
+    "type": "scepter",
+    "affix": "marshal"
+  },
+  {
+    "id": 85111,
+    "name": "zehtukasgreatbow",
+    "type": "longbow",
+    "affix": "harrier"
+  },
+  {
+    "id": 85112,
+    "name": "zehtukasspire",
+    "type": "staff",
+    "affix": "harrier"
+  },
+  {
+    "id": 85116,
+    "name": "nadijehsherald",
+    "type": "warhorn",
+    "affix": "marshal"
+  },
+  {
+    "id": 85121,
+    "name": "zehtukasclaymore",
+    "type": "greatsword",
+    "affix": "harrier"
+  },
+  {
+    "id": 85126,
+    "name": "zehtukasbreastplate",
+    "type": "coat",
+    "affix": "harrier",
+    "weight": "heavy"
+  },
+  {
+    "id": 85131,
+    "name": "zehtukasimpaler",
+    "type": "harpoon",
+    "affix": "harrier"
+  },
+  {
+    "id": 85149,
+    "name": "zehtukasleggings",
+    "type": "leggings",
+    "affix": "harrier",
+    "weight": "medium"
+  },
+  {
+    "id": 85152,
+    "name": "nadijehsbrazier",
+    "type": "torch",
+    "affix": "marshal"
+  },
+  {
+    "id": 85154,
+    "name": "nadijehsgrips",
+    "type": "gloves",
+    "affix": "marshal",
+    "weight": "medium"
+  },
+  {
+    "id": 85156,
+    "name": "nadijehsshortbow",
+    "type": "shortbow",
+    "affix": "marshal"
+  },
+  {
+    "id": 85161,
+    "name": "zehtukasmasque",
+    "type": "helm",
+    "affix": "harrier",
+    "weight": "light"
+  },
+  {
+    "id": 85166,
+    "name": "nadijehsflangedmace",
+    "type": "mace",
+    "affix": "marshal"
+  },
+  {
+    "id": 85172,
+    "name": "zehtukasvisage",
+    "type": "helm",
+    "affix": "harrier",
+    "weight": "medium"
+  },
+  {
+    "id": 85180,
+    "name": "nadijehsbreeches",
+    "type": "leggings",
+    "affix": "marshal",
+    "weight": "light"
+  },
+  {
+    "id": 85183,
+    "name": "zehtukasshoulderguard",
+    "type": "shoulders",
+    "affix": "harrier",
+    "weight": "medium"
+  },
+  {
+    "id": 85187,
+    "name": "nadijehstrident",
+    "type": "trident",
+    "affix": "marshal"
+  },
+  {
+    "id": 85196,
+    "name": "zehtukasgreaves",
+    "type": "boots",
+    "affix": "harrier",
+    "weight": "heavy"
+  },
+  {
+    "id": 85200,
+    "name": "zehtukasshortbow",
+    "type": "shortbow",
+    "affix": "harrier"
+  },
+  {
+    "id": 85208,
+    "name": "thetwinsgrips",
+    "type": "gloves",
+    "affix": "grieving",
+    "weight": "medium"
+  },
+  {
+    "id": 85212,
+    "name": "thetwinsgreatbow",
+    "type": "longbow",
+    "affix": "grieving"
+  },
+  {
+    "id": 85222,
+    "name": "nadijehsclaymore",
+    "type": "greatsword",
+    "affix": "marshal"
+  },
+  {
+    "id": 85223,
+    "name": "nadijehsbreastplate",
+    "type": "coat",
+    "affix": "marshal",
+    "weight": "heavy"
+  },
+  {
+    "id": 85224,
+    "name": "nadijehsartifact",
+    "type": "focus",
+    "affix": "marshal"
+  },
+  {
+    "id": 85225,
+    "name": "nadijehswarfists",
+    "type": "gloves",
+    "affix": "marshal",
+    "weight": "heavy"
+  },
+  {
+    "id": 85226,
+    "name": "nadijehsshoulderguard",
+    "type": "shoulders",
+    "affix": "marshal",
+    "weight": "medium"
+  },
+  {
+    "id": 85228,
+    "name": "zehtukaswarhammer",
+    "type": "hammer",
+    "affix": "harrier"
+  },
+  {
+    "id": 85233,
+    "name": "nadijehsreaver",
+    "type": "axe",
+    "affix": "marshal"
+  },
+  {
+    "id": 85241,
+    "name": "thetwinsepaulets",
+    "type": "shoulders",
+    "affix": "grieving",
+    "weight": "light"
+  },
+  {
+    "id": 85242,
+    "name": "thetwinsshortbow",
+    "type": "shortbow",
+    "affix": "grieving"
+  },
+  {
+    "id": 85244,
+    "name": "endlesschoyapiatatonic",
+    "type": "gizmo"
+  },
+  {
+    "id": 85249,
+    "name": "thetwinswarhammer",
+    "type": "hammer",
+    "affix": "grieving"
+  },
+  {
+    "id": 85253,
+    "name": "thetwinsreaver",
+    "type": "axe",
+    "affix": "grieving"
+  },
+  {
+    "id": 85254,
+    "name": "thetwinsimpaler",
+    "type": "harpoon",
+    "affix": "grieving"
+  },
+  {
+    "id": 85266,
+    "name": "thetwinsbastion",
+    "type": "shield",
+    "affix": "grieving"
+  },
+  {
+    "id": 85274,
+    "name": "nadijehsvisor",
+    "type": "helm",
+    "affix": "marshal",
+    "weight": "heavy"
+  },
+  {
+    "id": 85285,
+    "name": "nadijehsmasque",
+    "type": "helm",
+    "affix": "marshal",
+    "weight": "light"
+  },
+  {
+    "id": 85286,
+    "name": "zehtukaspauldrons",
+    "type": "shoulders",
+    "affix": "harrier",
+    "weight": "heavy"
+  },
+  {
+    "id": 85288,
+    "name": "nadijehsdoublet",
+    "type": "coat",
+    "affix": "marshal",
+    "weight": "light"
+  },
+  {
+    "id": 85293,
+    "name": "nadijehsharpoongun",
+    "type": "speargun",
+    "affix": "marshal"
+  },
+  {
+    "id": 85295,
+    "name": "thetwinsflangedmace",
+    "type": "mace",
+    "affix": "grieving"
+  },
+  {
+    "id": 85296,
+    "name": "thetwinsmasque",
+    "type": "helm",
+    "affix": "grieving",
+    "weight": "light"
+  },
+  {
+    "id": 85300,
+    "name": "thetwinswarfists",
+    "type": "gloves",
+    "affix": "grieving",
+    "weight": "heavy"
+  },
+  {
+    "id": 85308,
+    "name": "thetwinsstriders",
+    "type": "boots",
+    "affix": "grieving",
+    "weight": "medium"
+  },
+  {
+    "id": 85317,
+    "name": "zehtukasfootwear",
+    "type": "boots",
+    "affix": "harrier",
+    "weight": "light"
+  },
+  {
+    "id": 85319,
+    "name": "thetwinsdoublet",
+    "type": "coat",
+    "affix": "grieving",
+    "weight": "light"
+  },
+  {
+    "id": 85324,
+    "name": "thetwinsleggings",
+    "type": "leggings",
+    "affix": "grieving",
+    "weight": "medium"
+  },
+  {
+    "id": 85330,
+    "name": "zehtukaswarfists",
+    "type": "gloves",
+    "affix": "harrier",
+    "weight": "heavy"
+  },
+  {
+    "id": 85335,
+    "name": "nadijehspauldrons",
+    "type": "shoulders",
+    "affix": "marshal",
+    "weight": "heavy"
+  },
+  {
+    "id": 85342,
+    "name": "nadijehsfootwear",
+    "type": "boots",
+    "affix": "marshal",
+    "weight": "light"
+  },
+  {
+    "id": 85343,
+    "name": "zehtukasstriders",
+    "type": "boots",
+    "affix": "harrier",
+    "weight": "medium"
+  },
+  {
+    "id": 85345,
+    "name": "zehtukastrident",
+    "type": "trident",
+    "affix": "harrier"
+  },
+  {
+    "id": 85346,
+    "name": "zehtukasartifact",
+    "type": "focus",
+    "affix": "harrier"
+  },
+  {
+    "id": 85347,
+    "name": "nadijehswarhammer",
+    "type": "hammer",
+    "affix": "marshal"
+  },
+  {
+    "id": 85348,
+    "name": "zehtukasmusket",
+    "type": "rifle",
+    "affix": "harrier"
+  },
+  {
+    "id": 85350,
+    "name": "thetwinsvisor",
+    "type": "helm",
+    "affix": "grieving",
+    "weight": "heavy"
+  },
+  {
+    "id": 85352,
+    "name": "thetwinsbreeches",
+    "type": "leggings",
+    "affix": "grieving",
+    "weight": "light"
+  },
+  {
+    "id": 85355,
+    "name": "thetwinspauldrons",
+    "type": "shoulders",
+    "affix": "grieving",
+    "weight": "heavy"
+  },
+  {
+    "id": 85356,
+    "name": "nadijehsspire",
+    "type": "staff",
+    "affix": "marshal"
+  },
+  {
+    "id": 85357,
+    "name": "nadijehsbastion",
+    "type": "shield",
+    "affix": "marshal"
+  },
+  {
+    "id": 85364,
+    "name": "nadijehsimpaler",
+    "type": "harpoon",
+    "affix": "marshal"
+  },
+  {
+    "id": 85380,
+    "name": "antonina",
+    "type": "scepter",
+    "affix": "sinister"
+  },
+  {
+    "id": 85406,
+    "name": "sikandar",
+    "type": "mace",
+    "affix": "sinister"
+  },
+  {
+    "id": 85527,
+    "name": "spellbreaker",
+    "type": "rune"
+  },
+  {
+    "id": 85559,
+    "name": "renegade",
+    "type": "rune"
+  },
+  {
+    "id": 85573,
+    "name": "deadeye",
+    "type": "rune"
+  },
+  {
+    "id": 85578,
+    "name": "firebrand",
+    "type": "rune"
+  },
+  {
+    "id": 85588,
+    "name": "weaver",
+    "type": "rune"
+  },
+  {
+    "id": 85602,
+    "name": "mirage",
+    "type": "rune"
+  },
+  {
+    "id": 85606,
+    "name": "soulbeast",
+    "type": "rune"
+  },
+  {
+    "id": 85617,
+    "name": "holosmith",
+    "type": "rune"
+  },
+  {
+    "id": 85695,
+    "name": "marshalsstellarharbinger",
+    "type": "warhorn",
+    "affix": "marshal"
+  },
+  {
+    "id": 85713,
+    "name": "stars",
+    "type": "rune"
+  },
+  {
+    "id": 85755,
+    "name": "marshalsstellaravenger",
+    "type": "greatsword",
+    "affix": "marshal"
+  },
+  {
+    "id": 85794,
+    "name": "marshalsstellarscepter",
+    "type": "scepter",
+    "affix": "marshal"
+  },
+  {
+    "id": 85862,
+    "name": "marshalsstellarknobkerrie",
+    "type": "mace",
+    "affix": "marshal"
+  },
+  {
+    "id": 85926,
+    "name": "marshalsstellarspire",
+    "type": "staff",
+    "affix": "marshal"
+  },
+  {
+    "id": 85946,
+    "name": "marshalsstellarcannon",
+    "type": "rifle",
+    "affix": "marshal"
+  },
+  {
+    "id": 86007,
+    "name": "marshalsstellarbeacon",
+    "type": "torch",
+    "affix": "marshal"
+  },
+  {
+    "id": 86026,
+    "name": "marshalsstellardisk",
+    "type": "shield",
+    "affix": "marshal"
+  },
+  {
+    "id": 86074,
+    "name": "marshalsstellarshortbow",
+    "type": "shortbow",
+    "affix": "marshal"
+  },
+  {
+    "id": 86085,
+    "name": "marshalsstellarrazor",
+    "type": "dagger",
+    "affix": "marshal"
+  },
+  {
+    "id": 86113,
+    "name": "spitefulagonyinfusion",
+    "type": "infusion"
+  },
+  {
+    "id": 86170,
+    "name": "stars",
+    "type": "sigil"
+  },
+  {
+    "id": 86178,
+    "name": "marshalsstellarcleaver",
+    "type": "axe",
+    "affix": "marshal"
+  },
+  {
+    "id": 86180,
+    "name": "mysticalagonyinfusion",
+    "type": "infusion"
+  },
+  {
+    "id": 86233,
+    "name": "marshalsstellarlongbow",
+    "type": "longbow",
+    "affix": "marshal"
+  },
+  {
+    "id": 86279,
+    "name": "marshalsstellarapparatus",
+    "type": "focus",
+    "affix": "marshal"
+  },
+  {
+    "id": 86300,
+    "name": "marshalsstellarrevolver",
+    "type": "pistol",
+    "affix": "marshal"
+  },
+  {
+    "id": 86348,
+    "name": "marshalsstellarkhopesh",
+    "type": "sword",
+    "affix": "marshal"
+  },
+  {
+    "id": 86354,
+    "name": "marshalsstellarorrery",
+    "type": "hammer",
+    "affix": "marshal"
+  },
+  {
+    "id": 86389,
+    "name": "giftbringersvisor",
+    "type": "helm",
+    "affix": "bringer",
+    "weight": "heavy"
+  },
+  {
+    "id": 86402,
+    "name": "giftbringersgreatbow",
+    "type": "longbow",
+    "affix": "bringer"
+  },
+  {
+    "id": 86411,
+    "name": "giftbringersgreaves",
+    "type": "boots",
+    "affix": "bringer",
+    "weight": "heavy"
+  },
+  {
+    "id": 86412,
+    "name": "tixxsleggings",
+    "type": "leggings",
+    "affix": "giver",
+    "weight": "medium"
+  },
+  {
+    "id": 86420,
+    "name": "tixxstrident",
+    "type": "trident",
+    "affix": "giver"
+  },
+  {
+    "id": 86422,
+    "name": "tixxsfootwear",
+    "type": "boots",
+    "affix": "giver",
+    "weight": "light"
+  },
+  {
+    "id": 86434,
+    "name": "giftbringerswarhammer",
+    "type": "hammer",
+    "affix": "bringer"
+  },
+  {
+    "id": 86435,
+    "name": "giftbringersvisage",
+    "type": "helm",
+    "affix": "bringer",
+    "weight": "medium"
+  },
+  {
+    "id": 86439,
+    "name": "tixxsbrazier",
+    "type": "torch",
+    "affix": "giver"
+  },
+  {
+    "id": 86440,
+    "name": "tixxsherald",
+    "type": "warhorn",
+    "affix": "giver"
+  },
+  {
+    "id": 86443,
+    "name": "tixxswand",
+    "type": "scepter",
+    "affix": "giver"
+  },
+  {
+    "id": 86444,
+    "name": "tixxsreaver",
+    "type": "axe",
+    "affix": "giver"
+  },
+  {
+    "id": 86450,
+    "name": "giftbringersblade",
+    "type": "sword",
+    "affix": "bringer"
+  },
+  {
+    "id": 86451,
+    "name": "giftbringersflangedmace",
+    "type": "mace",
+    "affix": "bringer"
+  },
+  {
+    "id": 86460,
+    "name": "giftbringersreaver",
+    "type": "axe",
+    "affix": "bringer"
+  },
+  {
+    "id": 86463,
+    "name": "tixxsartifact",
+    "type": "focus",
+    "affix": "giver"
+  },
+  {
+    "id": 86471,
+    "name": "tixxsbreeches",
+    "type": "leggings",
+    "affix": "giver",
+    "weight": "light"
+  },
+  {
+    "id": 86483,
+    "name": "tixxsgreatbow",
+    "type": "longbow",
+    "affix": "giver"
+  },
+  {
+    "id": 86486,
+    "name": "tixxsdoublet",
+    "type": "coat",
+    "affix": "giver",
+    "weight": "light"
+  },
+  {
+    "id": 86489,
+    "name": "giftbringersharpoongun",
+    "type": "speargun",
+    "affix": "bringer"
+  },
+  {
+    "id": 86504,
+    "name": "tixxsflangedmace",
+    "type": "mace",
+    "affix": "giver"
+  },
+  {
+    "id": 86505,
+    "name": "tixxsbastion",
+    "type": "shield",
+    "affix": "giver"
+  },
+  {
+    "id": 86506,
+    "name": "tixxsgrips",
+    "type": "gloves",
+    "affix": "giver",
+    "weight": "medium"
+  },
+  {
+    "id": 86510,
+    "name": "giftbringersbreastplate",
+    "type": "coat",
+    "affix": "bringer",
+    "weight": "heavy"
+  },
+  {
+    "id": 86518,
+    "name": "tixxswristguards",
+    "type": "gloves",
+    "affix": "giver",
+    "weight": "light"
+  },
+  {
+    "id": 86520,
+    "name": "giftbringersfootwear",
+    "type": "boots",
+    "affix": "bringer",
+    "weight": "light"
+  },
+  {
+    "id": 86526,
+    "name": "tixxsrevolver",
+    "type": "pistol",
+    "affix": "giver"
+  },
+  {
+    "id": 86530,
+    "name": "giftbringerswand",
+    "type": "scepter",
+    "affix": "bringer"
+  },
+  {
+    "id": 86536,
+    "name": "tixxsbreastplate",
+    "type": "coat",
+    "affix": "giver",
+    "weight": "heavy"
+  },
+  {
+    "id": 86541,
+    "name": "tixxspauldrons",
+    "type": "shoulders",
+    "affix": "giver",
+    "weight": "heavy"
+  },
+  {
+    "id": 86542,
+    "name": "giftbringersartifact",
+    "type": "focus",
+    "affix": "bringer"
+  },
+  {
+    "id": 86544,
+    "name": "giftbringersguise",
+    "type": "coat",
+    "affix": "bringer",
+    "weight": "medium"
+  },
+  {
+    "id": 86548,
+    "name": "tixxstassets",
+    "type": "leggings",
+    "affix": "giver",
+    "weight": "heavy"
+  },
+  {
+    "id": 86558,
+    "name": "giftbringersbastion",
+    "type": "shield",
+    "affix": "bringer"
+  },
+  {
+    "id": 86561,
+    "name": "tixxsspire",
+    "type": "staff",
+    "affix": "giver"
+  },
+  {
+    "id": 86564,
+    "name": "tixxswarhammer",
+    "type": "hammer",
+    "affix": "giver"
+  },
+  {
+    "id": 86574,
+    "name": "tixxsharpoongun",
+    "type": "speargun",
+    "affix": "giver"
+  },
+  {
+    "id": 86583,
+    "name": "giftbringersrazor",
+    "type": "dagger",
+    "affix": "bringer"
+  },
+  {
+    "id": 86594,
+    "name": "tixxsclaymore",
+    "type": "greatsword",
+    "affix": "giver"
+  },
+  {
+    "id": 86604,
+    "name": "giftbringerspauldrons",
+    "type": "shoulders",
+    "affix": "bringer",
+    "weight": "heavy"
+  },
+  {
+    "id": 86610,
+    "name": "giftbringersspire",
+    "type": "staff",
+    "affix": "bringer"
+  },
+  {
+    "id": 86620,
+    "name": "giftbringersshoulderguard",
+    "type": "shoulders",
+    "affix": "bringer",
+    "weight": "medium"
+  },
+  {
+    "id": 86623,
+    "name": "tixxsshoulderguard",
+    "type": "shoulders",
+    "affix": "giver",
+    "weight": "medium"
+  },
+  {
+    "id": 86628,
+    "name": "giftbringersepaulets",
+    "type": "shoulders",
+    "affix": "bringer",
+    "weight": "light"
+  },
+  {
+    "id": 86629,
+    "name": "giftbringerstassets",
+    "type": "leggings",
+    "affix": "bringer",
+    "weight": "heavy"
+  },
+  {
+    "id": 86632,
+    "name": "giftbringersclaymore",
+    "type": "greatsword",
+    "affix": "bringer"
+  },
+  {
+    "id": 86633,
+    "name": "giftbringersbreeches",
+    "type": "leggings",
+    "affix": "bringer",
+    "weight": "light"
+  },
+  {
+    "id": 86640,
+    "name": "giftbringersbrazier",
+    "type": "torch",
+    "affix": "bringer"
+  },
+  {
+    "id": 86642,
+    "name": "tixxsmasque",
+    "type": "helm",
+    "affix": "giver",
+    "weight": "light"
+  },
+  {
+    "id": 86648,
+    "name": "tixxsvisage",
+    "type": "helm",
+    "affix": "giver",
+    "weight": "medium"
+  },
+  {
+    "id": 86650,
+    "name": "tixxsepaulets",
+    "type": "shoulders",
+    "affix": "giver",
+    "weight": "light"
+  },
+  {
+    "id": 86653,
+    "name": "giftbringersherald",
+    "type": "warhorn",
+    "affix": "bringer"
+  },
+  {
+    "id": 86662,
+    "name": "tixxsblade",
+    "type": "sword",
+    "affix": "giver"
+  },
+  {
+    "id": 86668,
+    "name": "tixxsmusket",
+    "type": "rifle",
+    "affix": "giver"
+  },
+  {
+    "id": 86670,
+    "name": "giftbringersdoublet",
+    "type": "coat",
+    "affix": "bringer",
+    "weight": "light"
+  },
+  {
+    "id": 86671,
+    "name": "giftbringersmasque",
+    "type": "helm",
+    "affix": "bringer",
+    "weight": "light"
+  },
+  {
+    "id": 86672,
+    "name": "tixxsvisor",
+    "type": "helm",
+    "affix": "giver",
+    "weight": "heavy"
+  },
+  {
+    "id": 86673,
+    "name": "giftbringersmusket",
+    "type": "rifle",
+    "affix": "bringer"
+  },
+  {
+    "id": 86681,
+    "name": "giftbringersleggings",
+    "type": "leggings",
+    "affix": "bringer",
+    "weight": "medium"
+  },
+  {
+    "id": 86682,
+    "name": "giftbringerstrident",
+    "type": "trident",
+    "affix": "bringer"
+  },
+  {
+    "id": 86684,
+    "name": "tixxsguise",
+    "type": "coat",
+    "affix": "giver",
+    "weight": "medium"
+  },
+  {
+    "id": 86686,
+    "name": "tixxsstriders",
+    "type": "boots",
+    "affix": "giver",
+    "weight": "medium"
+  },
+  {
+    "id": 86687,
+    "name": "giftbringersrevolver",
+    "type": "pistol",
+    "affix": "bringer"
+  },
+  {
+    "id": 86688,
+    "name": "tixxsimpaler",
+    "type": "harpoon",
+    "affix": "giver"
+  },
+  {
+    "id": 86689,
+    "name": "tixxsrazor",
+    "type": "dagger",
+    "affix": "giver"
+  },
+  {
+    "id": 86691,
+    "name": "giftbringerswristguards",
+    "type": "gloves",
+    "affix": "bringer",
+    "weight": "light"
+  },
+  {
+    "id": 86698,
+    "name": "giftbringersimpaler",
+    "type": "harpoon",
+    "affix": "bringer"
+  },
+  {
+    "id": 86703,
+    "name": "giftbringerswarfists",
+    "type": "gloves",
+    "affix": "bringer",
+    "weight": "heavy"
+  },
+  {
+    "id": 86706,
+    "name": "tixxsshortbow",
+    "type": "shortbow",
+    "affix": "giver"
+  },
+  {
+    "id": 86707,
+    "name": "giftbringersstriders",
+    "type": "boots",
+    "affix": "bringer",
+    "weight": "medium"
+  },
+  {
+    "id": 86709,
+    "name": "giftbringersgrips",
+    "type": "gloves",
+    "affix": "bringer",
+    "weight": "medium"
+  },
+  {
+    "id": 86717,
+    "name": "tixxswarfists",
+    "type": "gloves",
+    "affix": "giver",
+    "weight": "heavy"
+  },
+  {
+    "id": 86730,
+    "name": "tixxsgreaves",
+    "type": "boots",
+    "affix": "giver",
+    "weight": "heavy"
+  },
+  {
+    "id": 86731,
+    "name": "giftbringersshortbow",
+    "type": "shortbow",
+    "affix": "bringer"
+  },
+  {
+    "id": 87592,
+    "name": "nerashisartifact",
+    "type": "focus",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87604,
+    "name": "nerashisclaymore",
+    "type": "greatsword",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87605,
+    "name": "nerashisreaver",
+    "type": "axe",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87608,
+    "name": "nerashisbastion",
+    "type": "shield",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87629,
+    "name": "nerashisstriders",
+    "type": "boots",
+    "affix": "plaguedoctor",
+    "weight": "medium"
+  },
+  {
+    "id": 87650,
+    "name": "nerashisbreastplate",
+    "type": "coat",
+    "affix": "plaguedoctor",
+    "weight": "heavy"
+  },
+  {
+    "id": 87671,
+    "name": "nerashiswarhammer",
+    "type": "hammer",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87696,
+    "name": "nerashisfootwear",
+    "type": "boots",
+    "affix": "plaguedoctor",
+    "weight": "light"
+  },
+  {
+    "id": 87739,
+    "name": "nerashisflangedmace",
+    "type": "mace",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87742,
+    "name": "nerashisgreaves",
+    "type": "boots",
+    "affix": "plaguedoctor",
+    "weight": "heavy"
+  },
+  {
+    "id": 87751,
+    "name": "nerashisgrips",
+    "type": "gloves",
+    "affix": "plaguedoctor",
+    "weight": "medium"
+  },
+  {
+    "id": 87784,
+    "name": "nerashisimpaler",
+    "type": "harpoon",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87785,
+    "name": "nerashisspire",
+    "type": "staff",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87805,
+    "name": "nerashisvisage",
+    "type": "helm",
+    "affix": "plaguedoctor",
+    "weight": "medium"
+  },
+  {
+    "id": 87806,
+    "name": "nerashisbreeches",
+    "type": "leggings",
+    "affix": "plaguedoctor",
+    "weight": "light"
+  },
+  {
+    "id": 87811,
+    "name": "nerashisshortbow",
+    "type": "shortbow",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87823,
+    "name": "nerashisrazor",
+    "type": "dagger",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87857,
+    "name": "nerashiswand",
+    "type": "scepter",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87858,
+    "name": "nerashisbrazier",
+    "type": "torch",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87859,
+    "name": "nerashisshoulderguard",
+    "type": "shoulders",
+    "affix": "plaguedoctor",
+    "weight": "medium"
+  },
+  {
+    "id": 87860,
+    "name": "scarabchoker",
+    "type": "amulet",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87866,
+    "name": "nerashisgreatbow",
+    "type": "longbow",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87873,
+    "name": "tarnishedkournancoin",
+    "type": "accessory",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87884,
+    "name": "attunedlonaissignetringinfused",
+    "type": "ring",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87885,
+    "name": "nerashisblade",
+    "type": "sword",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87887,
+    "name": "nerashiswarfists",
+    "type": "gloves",
+    "affix": "plaguedoctor",
+    "weight": "heavy"
+  },
+  {
+    "id": 87898,
+    "name": "nerashisherald",
+    "type": "warhorn",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87948,
+    "name": "nerashistrident",
+    "type": "trident",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87956,
+    "name": "nerashismusket",
+    "type": "rifle",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 87960,
+    "name": "nerashiswristguards",
+    "type": "gloves",
+    "affix": "plaguedoctor",
+    "weight": "light"
+  },
+  {
+    "id": 87977,
+    "name": "nerashisdoublet",
+    "type": "coat",
+    "affix": "plaguedoctor",
+    "weight": "light"
+  },
+  {
+    "id": 87985,
+    "name": "nerashisguise",
+    "type": "coat",
+    "affix": "plaguedoctor",
+    "weight": "medium"
+  },
+  {
+    "id": 87994,
+    "name": "nerashisharpoongun",
+    "type": "speargun",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 88003,
+    "name": "nerashistassets",
+    "type": "leggings",
+    "affix": "plaguedoctor",
+    "weight": "heavy"
+  },
+  {
+    "id": 88022,
+    "name": "nerashismasque",
+    "type": "helm",
+    "affix": "plaguedoctor",
+    "weight": "light"
+  },
+  {
+    "id": 88025,
+    "name": "nerashisleggings",
+    "type": "leggings",
+    "affix": "plaguedoctor",
+    "weight": "medium"
+  },
+  {
+    "id": 88047,
+    "name": "nerashisrevolver",
+    "type": "pistol",
+    "affix": "plaguedoctor"
+  },
+  {
+    "id": 88073,
+    "name": "nerashispauldrons",
+    "type": "shoulders",
+    "affix": "plaguedoctor",
+    "weight": "heavy"
+  },
+  {
+    "id": 88085,
+    "name": "nerashisepaulets",
+    "type": "shoulders",
+    "affix": "plaguedoctor",
+    "weight": "light"
+  },
+  {
+    "id": 88105,
+    "name": "nerashisvisor",
+    "type": "helm",
+    "affix": "plaguedoctor",
+    "weight": "heavy"
+  },
+  {
+    "id": 88118,
+    "name": "zephyrite",
+    "type": "rune"
+  },
+  {
+    "id": 88370,
+    "name": "svaardsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "marauder",
+    "weight": "medium"
+  },
+  {
+    "id": 88371,
+    "name": "tizlaksclothbreather",
+    "type": "helmaquatic",
+    "affix": "commander",
+    "weight": "light"
+  },
+  {
+    "id": 88373,
+    "name": "ossasclothbreather",
+    "type": "helmaquatic",
+    "affix": "crusader",
+    "weight": "light"
+  },
+  {
+    "id": 88376,
+    "name": "yassithsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "viper",
+    "weight": "heavy"
+  },
+  {
+    "id": 88380,
+    "name": "pahuasmetalbreather",
+    "type": "helmaquatic",
+    "affix": "trailblazer",
+    "weight": "heavy"
+  },
+  {
+    "id": 88392,
+    "name": "svaardsclothbreather",
+    "type": "helmaquatic",
+    "affix": "marauder",
+    "weight": "light"
+  },
+  {
+    "id": 88400,
+    "name": "yassithsclothbreather",
+    "type": "helmaquatic",
+    "affix": "viper",
+    "weight": "light"
+  },
+  {
+    "id": 88405,
+    "name": "pahuasclothbreather",
+    "type": "helmaquatic",
+    "affix": "trailblazer",
+    "weight": "light"
+  },
+  {
+    "id": 88410,
+    "name": "svaardsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "marauder",
+    "weight": "heavy"
+  },
+  {
+    "id": 88413,
+    "name": "rukasclothbreather",
+    "type": "helmaquatic",
+    "affix": "wanderer",
+    "weight": "light"
+  },
+  {
+    "id": 88418,
+    "name": "ossasmetalbreather",
+    "type": "helmaquatic",
+    "affix": "crusader",
+    "weight": "heavy"
+  },
+  {
+    "id": 88419,
+    "name": "ossasleatherbreather",
+    "type": "helmaquatic",
+    "affix": "crusader",
+    "weight": "medium"
+  },
+  {
+    "id": 88420,
+    "name": "yassithsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "viper",
+    "weight": "medium"
+  },
+  {
+    "id": 88422,
+    "name": "tizlaksleatherbreather",
+    "type": "helmaquatic",
+    "affix": "commander",
+    "weight": "medium"
+  },
+  {
+    "id": 88424,
+    "name": "pahuasleatherbreather",
+    "type": "helmaquatic",
+    "affix": "trailblazer",
+    "weight": "medium"
+  },
+  {
+    "id": 88427,
+    "name": "maklainsclothbreather",
+    "type": "helmaquatic",
+    "affix": "minstrel",
+    "weight": "light"
+  },
+  {
+    "id": 88429,
+    "name": "laranthirsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "vigilant",
+    "weight": "heavy"
+  },
+  {
+    "id": 88432,
+    "name": "thackeraysleatherbreather",
+    "type": "helmaquatic",
+    "affix": "seraph",
+    "weight": "medium"
+  },
+  {
+    "id": 88440,
+    "name": "thackeraysmetalbreather",
+    "type": "helmaquatic",
+    "affix": "seraph",
+    "weight": "heavy"
+  },
+  {
+    "id": 88443,
+    "name": "maklainsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "minstrel",
+    "weight": "medium"
+  },
+  {
+    "id": 88445,
+    "name": "maklainsmetalbreather",
+    "type": "helmaquatic",
+    "affix": "minstrel",
+    "weight": "heavy"
+  },
+  {
+    "id": 88452,
+    "name": "rukasleatherbreather",
+    "type": "helmaquatic",
+    "affix": "wanderer",
+    "weight": "medium"
+  },
+  {
+    "id": 88455,
+    "name": "laranthirsleatherbreather",
+    "type": "helmaquatic",
+    "affix": "vigilant",
+    "weight": "medium"
+  },
+  {
+    "id": 88458,
+    "name": "laranthirsclothbreather",
+    "type": "helmaquatic",
+    "affix": "vigilant",
+    "weight": "light"
+  },
+  {
+    "id": 88463,
+    "name": "rukasmetalbreather",
+    "type": "helmaquatic",
+    "affix": "wanderer",
+    "weight": "heavy"
+  },
+  {
+    "id": 88466,
+    "name": "thackeraysclothbreather",
+    "type": "helmaquatic",
+    "affix": "seraph",
+    "weight": "light"
+  },
+  {
+    "id": 88467,
+    "name": "tizlaksmetalbreather",
+    "type": "helmaquatic",
+    "affix": "commander",
+    "weight": "heavy"
+  },
+  {
+    "id": 89441,
+    "name": "heroicdragonsbloodshield",
+    "type": "shield",
+    "affix": "diviner"
+  },
+  {
+    "id": 89446,
+    "name": "heroicdragonsbloodstaff",
+    "type": "staff",
+    "affix": "diviner"
+  },
+  {
+    "id": 89452,
+    "name": "steelstarsfootwear",
+    "type": "boots",
+    "affix": "diviner",
+    "weight": "light"
+  },
+  {
+    "id": 89460,
+    "name": "steelstarstassets",
+    "type": "leggings",
+    "affix": "diviner",
+    "weight": "heavy"
+  },
+  {
+    "id": 89461,
+    "name": "dragoncrystalpotion",
+    "type": "utility"
+  },
+  {
+    "id": 89484,
+    "name": "steelstarswand",
+    "type": "scepter",
+    "affix": "diviner"
+  },
+  {
+    "id": 89495,
+    "name": "heroicdragonsbloodscepter",
+    "type": "scepter",
+    "affix": "diviner"
+  },
+  {
+    "id": 89503,
+    "name": "heroicdragonsbloodlongbow",
+    "type": "longbow",
+    "affix": "diviner"
+  },
+  {
+    "id": 89528,
+    "name": "steelstarsguise",
+    "type": "coat",
+    "affix": "diviner",
+    "weight": "medium"
+  },
+  {
+    "id": 89544,
+    "name": "dagnarsbadge",
+    "type": "accessory",
+    "affix": "diviner"
+  },
+  {
+    "id": 89566,
+    "name": "heroicdragonsbloodsword",
+    "type": "sword",
+    "affix": "diviner"
+  },
+  {
+    "id": 89592,
+    "name": "heroicdragonsbloodwarhorn",
+    "type": "warhorn",
+    "affix": "diviner"
+  },
+  {
+    "id": 89610,
+    "name": "steelstarsimpaler",
+    "type": "harpoon",
+    "affix": "diviner"
+  },
+  {
+    "id": 89612,
+    "name": "steelstarsbrazier",
+    "type": "torch",
+    "affix": "diviner"
+  },
+  {
+    "id": 89624,
+    "name": "steelstarsherald",
+    "type": "warhorn",
+    "affix": "diviner"
+  },
+  {
+    "id": 89628,
+    "name": "steelstarsepaulets",
+    "type": "shoulders",
+    "affix": "diviner",
+    "weight": "light"
+  },
+  {
+    "id": 89632,
+    "name": "heroicdragonsbloodaxe",
+    "type": "axe",
+    "affix": "diviner"
+  },
+  {
+    "id": 89645,
+    "name": "steelstarsblade",
+    "type": "sword",
+    "affix": "diviner"
+  },
+  {
+    "id": 89647,
+    "name": "heroicdragonsbloodpistol",
+    "type": "pistol",
+    "affix": "diviner"
+  },
+  {
+    "id": 89656,
+    "name": "steelstarsgreaves",
+    "type": "boots",
+    "affix": "diviner",
+    "weight": "heavy"
+  },
+  {
+    "id": 89681,
+    "name": "steelstarsgreatbow",
+    "type": "longbow",
+    "affix": "diviner"
+  },
+  {
+    "id": 89706,
+    "name": "steelstarsclaymore",
+    "type": "greatsword",
+    "affix": "diviner"
+  },
+  {
+    "id": 89707,
+    "name": "steelstarsflangedmace",
+    "type": "mace",
+    "affix": "diviner"
+  },
+  {
+    "id": 89716,
+    "name": "steelstarsrevolver",
+    "type": "pistol",
+    "affix": "diviner"
+  },
+  {
+    "id": 89733,
+    "name": "steelstarsbreastplate",
+    "type": "coat",
+    "affix": "diviner",
+    "weight": "heavy"
+  },
+  {
+    "id": 89736,
+    "name": "steelstarsmusket",
+    "type": "rifle",
+    "affix": "diviner"
+  },
+  {
+    "id": 89741,
+    "name": "heroicdragonsbloodtorch",
+    "type": "torch",
+    "affix": "diviner"
+  },
+  {
+    "id": 89759,
+    "name": "frodakssteelstar",
+    "type": "amulet",
+    "affix": "diviner"
+  },
+  {
+    "id": 89768,
+    "name": "steelstarsdoublet",
+    "type": "coat",
+    "affix": "diviner",
+    "weight": "light"
+  },
+  {
+    "id": 89773,
+    "name": "steelstarswarhammer",
+    "type": "hammer",
+    "affix": "diviner"
+  },
+  {
+    "id": 89785,
+    "name": "steelstarspauldrons",
+    "type": "shoulders",
+    "affix": "diviner",
+    "weight": "heavy"
+  },
+  {
+    "id": 89787,
+    "name": "heroicdragonsblooddagger",
+    "type": "dagger",
+    "affix": "diviner"
+  },
+  {
+    "id": 89789,
+    "name": "steelstarsshoulderguard",
+    "type": "shoulders",
+    "affix": "diviner",
+    "weight": "medium"
+  },
+  {
+    "id": 89791,
+    "name": "heroicdragonsbloodrifle",
+    "type": "rifle",
+    "affix": "diviner"
+  },
+  {
+    "id": 89799,
+    "name": "steelstarsreaver",
+    "type": "axe",
+    "affix": "diviner"
+  },
+  {
+    "id": 89810,
+    "name": "steelstarsharpoongun",
+    "type": "speargun",
+    "affix": "diviner"
+  },
+  {
+    "id": 89821,
+    "name": "heroicdragonsbloodfocus",
+    "type": "focus",
+    "affix": "diviner"
+  },
+  {
+    "id": 89822,
+    "name": "steelstarswarfists",
+    "type": "gloves",
+    "affix": "diviner",
+    "weight": "heavy"
+  },
+  {
+    "id": 89826,
+    "name": "heroicdragonsbloodshortbow",
+    "type": "shortbow",
+    "affix": "diviner"
+  },
+  {
+    "id": 89842,
+    "name": "heroicdragonsbloodhammer",
+    "type": "hammer",
+    "affix": "diviner"
+  },
+  {
+    "id": 89846,
+    "name": "steelstarsartifact",
+    "type": "focus",
+    "affix": "diviner"
+  },
+  {
+    "id": 89848,
+    "name": "heroicdragonsbloodmace",
+    "type": "mace",
+    "affix": "diviner"
+  },
+  {
+    "id": 89879,
+    "name": "heroicdragonsbloodgreatsword",
+    "type": "greatsword",
+    "affix": "diviner"
+  },
+  {
+    "id": 89893,
+    "name": "steelstarsstriders",
+    "type": "boots",
+    "affix": "diviner",
+    "weight": "medium"
+  },
+  {
+    "id": 89904,
+    "name": "steelstarstrident",
+    "type": "trident",
+    "affix": "diviner"
+  },
+  {
+    "id": 89906,
+    "name": "steelstarsrazor",
+    "type": "dagger",
+    "affix": "diviner"
+  },
+  {
+    "id": 89912,
+    "name": "steelstarsmasque",
+    "type": "helm",
+    "affix": "diviner",
+    "weight": "light"
+  },
+  {
+    "id": 89922,
+    "name": "steelstarsbastion",
+    "type": "shield",
+    "affix": "diviner"
+  },
+  {
+    "id": 89924,
+    "name": "steelstarsvisor",
+    "type": "helm",
+    "affix": "diviner",
+    "weight": "heavy"
+  },
+  {
+    "id": 89925,
+    "name": "steelstarswristguards",
+    "type": "gloves",
+    "affix": "diviner",
+    "weight": "light"
+  },
+  {
+    "id": 89934,
+    "name": "steelstarsleggings",
+    "type": "leggings",
+    "affix": "diviner",
+    "weight": "medium"
+  },
+  {
+    "id": 89940,
+    "name": "steelstarsbreeches",
+    "type": "leggings",
+    "affix": "diviner",
+    "weight": "light"
+  },
+  {
+    "id": 89945,
+    "name": "steelstarsspire",
+    "type": "staff",
+    "affix": "diviner"
+  },
+  {
+    "id": 89949,
+    "name": "steelstarsshortbow",
+    "type": "shortbow",
+    "affix": "diviner"
+  },
+  {
+    "id": 89969,
+    "name": "steelstarsvisage",
+    "type": "helm",
+    "affix": "diviner",
+    "weight": "medium"
+  },
+  {
+    "id": 89985,
+    "name": "steelstarsgrips",
+    "type": "gloves",
+    "affix": "diviner",
+    "weight": "medium"
+  },
+  {
+    "id": 89999,
+    "name": "fireworks",
+    "type": "rune"
+  },
+  {
+    "id": 91289,
+    "name": "powerfulpotionofbrandedslaying",
+    "type": "utility"
+  },
+  {
+    "id": 91339,
+    "name": "hologramslaying",
+    "type": "sigil"
+  },
+  {
+    "id": 91350,
+    "name": "powerfulpotionofmordremslaying",
+    "type": "utility"
+  },
+  {
+    "id": 94709,
+    "name": "vipersfierydragonslayerfocusoficebroodslaying",
+    "type": "focus",
+    "affix": "viper"
+  },
+  {
+    "id": 94711,
+    "name": "vipersfierydragonslayertorchoficebroodslaying",
+    "type": "torch",
+    "affix": "viper"
+  },
+  {
+    "id": 94716,
+    "name": "vipersfierydragonslayeraxeoficebroodslaying",
+    "type": "axe",
+    "affix": "viper"
+  },
+  {
+    "id": 94721,
+    "name": "vipersfierydragonslayerpistoloficebroodslaying",
+    "type": "pistol",
+    "affix": "viper"
+  },
+  {
+    "id": 94724,
+    "name": "maraudericydragonslayerwarhornofdestroyerslaying",
+    "type": "warhorn",
+    "affix": "marauder"
+  },
+  {
+    "id": 94733,
+    "name": "vipersfierydragonslayerlongbowoficebroodslaying",
+    "type": "longbow",
+    "affix": "viper"
+  },
+  {
+    "id": 94736,
+    "name": "maraudericydragonslayerpistolofdestroyerslaying",
+    "type": "pistol",
+    "affix": "marauder"
+  },
+  {
+    "id": 94738,
+    "name": "maraudericydragonslayeraxeofdestroyerslaying",
+    "type": "axe",
+    "affix": "marauder"
+  },
+  {
+    "id": 94745,
+    "name": "maraudericydragonslayerscepterofdestroyerslaying",
+    "type": "scepter",
+    "affix": "marauder"
+  },
+  {
+    "id": 94747,
+    "name": "maraudericydragonslayerfocusofdestroyerslaying",
+    "type": "focus",
+    "affix": "marauder"
+  },
+  {
+    "id": 94754,
+    "name": "vipersfierydragonslayershortbowoficebroodslaying",
+    "type": "shortbow",
+    "affix": "viper"
+  },
+  {
+    "id": 94763,
+    "name": "vipersfierydragonslayershieldoficebroodslaying",
+    "type": "shield",
+    "affix": "viper"
+  },
+  {
+    "id": 94764,
+    "name": "maraudericydragonslayerdaggerofdestroyerslaying",
+    "type": "dagger",
+    "affix": "marauder"
+  },
+  {
+    "id": 94775,
+    "name": "vipersfierydragonslayerdaggeroficebroodslaying",
+    "type": "dagger",
+    "affix": "viper"
+  },
+  {
+    "id": 94781,
+    "name": "maraudericydragonslayershieldofdestroyerslaying",
+    "type": "shield",
+    "affix": "marauder"
+  },
+  {
+    "id": 94785,
+    "name": "vipersfierydragonslayerwarhornoficebroodslaying",
+    "type": "warhorn",
+    "affix": "viper"
+  },
+  {
+    "id": 94787,
+    "name": "maraudericydragonslayerstaffofdestroyerslaying",
+    "type": "staff",
+    "affix": "marauder"
+  },
+  {
+    "id": 94788,
+    "name": "vipersfierydragonslayerhammeroficebroodslaying",
+    "type": "hammer",
+    "affix": "viper"
+  },
+  {
+    "id": 94789,
+    "name": "maraudericydragonslayermaceofdestroyerslaying",
+    "type": "mace",
+    "affix": "marauder"
+  },
+  {
+    "id": 94793,
+    "name": "maraudericydragonslayerrifleofdestroyerslaying",
+    "type": "rifle",
+    "affix": "marauder"
+  },
+  {
+    "id": 94796,
+    "name": "vipersfierydragonslayerrifleoficebroodslaying",
+    "type": "rifle",
+    "affix": "viper"
+  },
+  {
+    "id": 94812,
+    "name": "maraudericydragonslayerswordofdestroyerslaying",
+    "type": "sword",
+    "affix": "marauder"
+  },
+  {
+    "id": 94815,
+    "name": "maraudericydragonslayergreatswordofdestroyerslaying",
+    "type": "greatsword",
+    "affix": "marauder"
+  },
+  {
+    "id": 94818,
+    "name": "vipersfierydragonslayerscepteroficebroodslaying",
+    "type": "scepter",
+    "affix": "viper"
+  },
+  {
+    "id": 94821,
+    "name": "maraudericydragonslayershortbowofdestroyerslaying",
+    "type": "shortbow",
+    "affix": "marauder"
+  },
+  {
+    "id": 94822,
+    "name": "maraudericydragonslayerhammerofdestroyerslaying",
+    "type": "hammer",
+    "affix": "marauder"
+  },
+  {
+    "id": 94826,
+    "name": "maraudericydragonslayertorchofdestroyerslaying",
+    "type": "torch",
+    "affix": "marauder"
+  },
+  {
+    "id": 94841,
+    "name": "vipersfierydragonslayermaceoficebroodslaying",
+    "type": "mace",
+    "affix": "viper"
+  },
+  {
+    "id": 94843,
+    "name": "vipersfierydragonslayerswordoficebroodslaying",
+    "type": "sword",
+    "affix": "viper"
+  },
+  {
+    "id": 94857,
+    "name": "vipersfierydragonslayergreatswordoficebroodslaying",
+    "type": "greatsword",
+    "affix": "viper"
+  },
+  {
+    "id": 94861,
+    "name": "maraudericydragonslayerlongbowofdestroyerslaying",
+    "type": "longbow",
+    "affix": "marauder"
+  },
+  {
+    "id": 94865,
+    "name": "vipersfierydragonslayerstaffoficebroodslaying",
+    "type": "staff",
+    "affix": "viper"
+  },
+  {
+    "id": 95013,
+    "name": "fractaltroubleshootersstar",
+    "type": "accessory",
+    "affix": "berserkerandvalkyrie"
+  },
+  {
+    "id": 95071,
+    "name": "plushprimo",
+    "type": "accessory",
+    "affix": "marauder"
+  },
+  {
+    "id": 95276,
+    "name": "plushkralky",
+    "type": "accessory",
+    "affix": "diviner"
+  },
+  {
+    "id": 95318,
+    "name": "plushzhaia",
+    "type": "accessory",
+    "affix": "grieving"
+  }
+]

--- a/src/utils/mapping/itemstats.json
+++ b/src/utils/mapping/itemstats.json
@@ -1,1 +1,485 @@
-[{"name":"mighty","ids":[137]},{"name":"precise","ids":[138]},{"name":"vital","ids":[139]},{"name":"resilient","ids":[140]},{"name":"lingering","ids":[141]},{"name":"strong","ids":[142]},{"name":"ravaging","ids":[144]},{"name":"rejuvenating","ids":[145]},{"name":"vigorous","ids":[146]},{"name":"mending","ids":[147]},{"name":"stout","ids":[148]},{"name":"hearty","ids":[149]},{"name":"potent","ids":[150]},{"name":"penetrating","ids":[151]},{"name":"honed","ids":[152]},{"name":"shaman","ids":[153,1071,1097]},{"name":"rabid","ids":[154,585,594,1042]},{"name":"cleric","ids":[155,656,661,1044,1076]},{"name":"magi","ids":[156,1037]},{"name":"valkyrie","ids":[157,1119]},{"name":"knight","ids":[158,657,662,1051]},{"name":"rampager","ids":[159,658,663,1047,1078]},{"name":"carrion","ids":[160,1038,1075]},{"name":"berserker","ids":[161,584,599,1046,1077]},{"name":"soldier","ids":[162,586,601,1048]},{"name":"healing","ids":[175]},{"name":"malign","ids":[176]},{"name":"celestial","ids":[559,588,593,1052]},{"name":"direandrabid","ids":[581,596]},{"name":"cavalier","ids":[583,602,616,1050]},{"name":"berserkerandvalkyrie","ids":[591,600]},{"name":"rabidandapothecary","ids":[592,595]},{"name":"apothecary","ids":[605,659,664,1043]},{"name":"giver","ids":[627,628,629,630,631,1030,1031,1070,1430]},{"name":"captain","ids":[660,665,1041]},{"name":"sentinel","ids":[686,1035]},{"name":"settler","ids":[690,693,700]},{"name":"assassin","ids":[753,1040,1128]},{"name":"dire","ids":[754,756,1073,1114]},{"name":"hunter","ids":[755]},{"name":"zealot","ids":[799,1163]},{"name":"forsaken","ids":[1011]},{"name":"apostate","ids":[1012]},{"name":"survivor","ids":[1013]},{"name":"deserter","ids":[1014]},{"name":"vagabond","ids":[1015]},{"name":"nomad","ids":[1026,1063,1066]},{"name":"bringer","ids":[1032,1436]},{"name":"sinister","ids":[1064,1065,1067]},{"name":"trailblazer","ids":[1085,1115,1229,1262]},{"name":"crusader","ids":[1098,1109,1232,1271]},{"name":"marauder","ids":[1111,1145,1231,1263]},{"name":"vigilant","ids":[1118,1139,1228,1264]},{"name":"minstrel","ids":[1123,1134,1226,1265]},{"name":"commander","ids":[1125,1131,1227,1267]},{"name":"viper","ids":[1130,1153,1224,1268]},{"name":"wanderer","ids":[1140,1162,1225,1270]},{"name":"seraph","ids":[1220,1222,1230,1269]},{"name":"grieving","ids":[1329,1344,1366,1379]},{"name":"marshal","ids":[1337,1364,1374,1378]},{"name":"harrier","ids":[1345,1363,1367,1377]},{"name":"plaguedoctor","ids":[1484,1486,1549,1559]},{"name":"diviner","ids":[1538,1539,1556,1566]}]
+[
+  {
+    "name": "mighty",
+    "ids": [
+      137
+    ]
+  },
+  {
+    "name": "precise",
+    "ids": [
+      138
+    ]
+  },
+  {
+    "name": "vital",
+    "ids": [
+      139
+    ]
+  },
+  {
+    "name": "resilient",
+    "ids": [
+      140
+    ]
+  },
+  {
+    "name": "lingering",
+    "ids": [
+      141
+    ]
+  },
+  {
+    "name": "strong",
+    "ids": [
+      142
+    ]
+  },
+  {
+    "name": "ravaging",
+    "ids": [
+      144
+    ]
+  },
+  {
+    "name": "rejuvenating",
+    "ids": [
+      145
+    ]
+  },
+  {
+    "name": "vigorous",
+    "ids": [
+      146
+    ]
+  },
+  {
+    "name": "mending",
+    "ids": [
+      147
+    ]
+  },
+  {
+    "name": "stout",
+    "ids": [
+      148
+    ]
+  },
+  {
+    "name": "hearty",
+    "ids": [
+      149
+    ]
+  },
+  {
+    "name": "potent",
+    "ids": [
+      150
+    ]
+  },
+  {
+    "name": "penetrating",
+    "ids": [
+      151
+    ]
+  },
+  {
+    "name": "honed",
+    "ids": [
+      152
+    ]
+  },
+  {
+    "name": "shaman",
+    "ids": [
+      153,
+      1071,
+      1097
+    ]
+  },
+  {
+    "name": "rabid",
+    "ids": [
+      154,
+      585,
+      594,
+      1042
+    ]
+  },
+  {
+    "name": "cleric",
+    "ids": [
+      155,
+      656,
+      661,
+      1044,
+      1076
+    ]
+  },
+  {
+    "name": "magi",
+    "ids": [
+      156,
+      1037
+    ]
+  },
+  {
+    "name": "valkyrie",
+    "ids": [
+      157,
+      1119
+    ]
+  },
+  {
+    "name": "knight",
+    "ids": [
+      158,
+      657,
+      662,
+      1051
+    ]
+  },
+  {
+    "name": "rampager",
+    "ids": [
+      159,
+      658,
+      663,
+      1047,
+      1078
+    ]
+  },
+  {
+    "name": "carrion",
+    "ids": [
+      160,
+      1038,
+      1075
+    ]
+  },
+  {
+    "name": "berserker",
+    "ids": [
+      161,
+      584,
+      599,
+      1046,
+      1077
+    ]
+  },
+  {
+    "name": "soldier",
+    "ids": [
+      162,
+      586,
+      601,
+      1048
+    ]
+  },
+  {
+    "name": "healing",
+    "ids": [
+      175
+    ]
+  },
+  {
+    "name": "malign",
+    "ids": [
+      176
+    ]
+  },
+  {
+    "name": "celestial",
+    "ids": [
+      559,
+      588,
+      593,
+      1052
+    ]
+  },
+  {
+    "name": "direandrabid",
+    "ids": [
+      581,
+      596
+    ]
+  },
+  {
+    "name": "cavalier",
+    "ids": [
+      583,
+      602,
+      616,
+      1050
+    ]
+  },
+  {
+    "name": "berserkerandvalkyrie",
+    "ids": [
+      591,
+      600
+    ]
+  },
+  {
+    "name": "rabidandapothecary",
+    "ids": [
+      592,
+      595
+    ]
+  },
+  {
+    "name": "apothecary",
+    "ids": [
+      605,
+      659,
+      664,
+      1043
+    ]
+  },
+  {
+    "name": "giver",
+    "ids": [
+      627,
+      628,
+      629,
+      630,
+      631,
+      1030,
+      1031,
+      1070,
+      1430
+    ]
+  },
+  {
+    "name": "captain",
+    "ids": [
+      660,
+      665,
+      1041
+    ]
+  },
+  {
+    "name": "sentinel",
+    "ids": [
+      686,
+      1035
+    ]
+  },
+  {
+    "name": "settler",
+    "ids": [
+      690,
+      693,
+      700
+    ]
+  },
+  {
+    "name": "assassin",
+    "ids": [
+      753,
+      1040,
+      1128
+    ]
+  },
+  {
+    "name": "dire",
+    "ids": [
+      754,
+      756,
+      1073,
+      1114
+    ]
+  },
+  {
+    "name": "hunter",
+    "ids": [
+      755
+    ]
+  },
+  {
+    "name": "zealot",
+    "ids": [
+      799,
+      1163
+    ]
+  },
+  {
+    "name": "forsaken",
+    "ids": [
+      1011
+    ]
+  },
+  {
+    "name": "apostate",
+    "ids": [
+      1012
+    ]
+  },
+  {
+    "name": "survivor",
+    "ids": [
+      1013
+    ]
+  },
+  {
+    "name": "deserter",
+    "ids": [
+      1014
+    ]
+  },
+  {
+    "name": "vagabond",
+    "ids": [
+      1015
+    ]
+  },
+  {
+    "name": "nomad",
+    "ids": [
+      1026,
+      1063,
+      1066
+    ]
+  },
+  {
+    "name": "bringer",
+    "ids": [
+      1032,
+      1436
+    ]
+  },
+  {
+    "name": "sinister",
+    "ids": [
+      1064,
+      1065,
+      1067
+    ]
+  },
+  {
+    "name": "trailblazer",
+    "ids": [
+      1085,
+      1115,
+      1229,
+      1262
+    ]
+  },
+  {
+    "name": "crusader",
+    "ids": [
+      1098,
+      1109,
+      1232,
+      1271
+    ]
+  },
+  {
+    "name": "marauder",
+    "ids": [
+      1111,
+      1145,
+      1231,
+      1263
+    ]
+  },
+  {
+    "name": "vigilant",
+    "ids": [
+      1118,
+      1139,
+      1228,
+      1264
+    ]
+  },
+  {
+    "name": "minstrel",
+    "ids": [
+      1123,
+      1134,
+      1226,
+      1265
+    ]
+  },
+  {
+    "name": "commander",
+    "ids": [
+      1125,
+      1131,
+      1227,
+      1267
+    ]
+  },
+  {
+    "name": "viper",
+    "ids": [
+      1130,
+      1153,
+      1224,
+      1268
+    ]
+  },
+  {
+    "name": "wanderer",
+    "ids": [
+      1140,
+      1162,
+      1225,
+      1270
+    ]
+  },
+  {
+    "name": "seraph",
+    "ids": [
+      1220,
+      1222,
+      1230,
+      1269
+    ]
+  },
+  {
+    "name": "grieving",
+    "ids": [
+      1329,
+      1344,
+      1366,
+      1379
+    ]
+  },
+  {
+    "name": "marshal",
+    "ids": [
+      1337,
+      1364,
+      1374,
+      1378
+    ]
+  },
+  {
+    "name": "harrier",
+    "ids": [
+      1345,
+      1363,
+      1367,
+      1377
+    ]
+  },
+  {
+    "name": "plaguedoctor",
+    "ids": [
+      1484,
+      1486,
+      1549,
+      1559
+    ]
+  },
+  {
+    "name": "diviner",
+    "ids": [
+      1538,
+      1539,
+      1556,
+      1566
+    ]
+  }
+]

--- a/src/utils/mapping/skills.json
+++ b/src/utils/mapping/skills.json
@@ -1,1 +1,17429 @@
-[{"id":1110,"name":"throwgunk","profession":"bundle"},{"id":1115,"name":"branchleap","profession":"bundle"},{"id":1118,"name":"throwchain","profession":"bundle"},{"id":1123,"name":"consumeplasma","profession":"bundle"},{"id":1125,"name":"eategg","profession":"bundle"},{"id":1129,"name":"iceshardstab","profession":"bundle"},{"id":1131,"name":"maceheadcrack","profession":"bundle"},{"id":1139,"name":"healingseed","profession":"bundle"},{"id":1141,"name":"skullfear","profession":"bundle"},{"id":1148,"name":"blindingtuft","profession":"bundle"},{"id":1162,"name":"whirlingaxe","profession":"bundle"},{"id":1167,"name":"whirlingstrike","profession":"bundle"},{"id":1175,"name":"bandage","profession":"bundle"},{"id":1279,"name":"bindingroots","profession":"bundle"},{"id":1355,"name":"slash","profession":"bundle"},{"id":1359,"name":"flurry","profession":"bundle"},{"id":1364,"name":"whirlwind","profession":"bundle"},{"id":1408,"name":"gallopingslash","profession":"bundle"},{"id":1510,"name":"dualattack","profession":"bundle"},{"id":1512,"name":"shoot","profession":"bundle"},{"id":1531,"name":"slash","profession":"bundle"},{"id":1539,"name":"stab","profession":"bundle"},{"id":1541,"name":"leap","profession":"bundle"},{"id":1626,"name":"throw","profession":"bundle"},{"id":1628,"name":"skullbolas","profession":"bundle"},{"id":1629,"name":"stab","profession":"bundle"},{"id":1631,"name":"throwjavelin","profession":"bundle"},{"id":1641,"name":"stab","profession":"bundle"},{"id":1642,"name":"lunge","profession":"bundle"},{"id":1644,"name":"smash","profession":"bundle"},{"id":1691,"name":"slash","profession":"bundle"},{"id":1932,"name":"trample","profession":"bundle"},{"id":1940,"name":"slash","profession":"bundle"},{"id":1991,"name":"counterattack","profession":"bundle"},{"id":1996,"name":"frosttrap","profession":"bundle"},{"id":2013,"name":"axe","profession":"bundle"},{"id":2014,"name":"cyclonespin","profession":"bundle"},{"id":2131,"name":"severartery","profession":"bundle"},{"id":2132,"name":"gash","profession":"bundle"},{"id":2133,"name":"finalthrust","profession":"bundle"},{"id":2134,"name":"slash","profession":"bundle"},{"id":2135,"name":"savageleap","profession":"bundle"},{"id":2136,"name":"whirlwindattack","profession":"bundle"},{"id":2302,"name":"flurry","profession":"bundle"},{"id":2365,"name":"punch","profession":"bundle"},{"id":2367,"name":"brandedcrystals","profession":"bundle"},{"id":2397,"name":"slash","profession":"bundle"},{"id":2399,"name":"slice","profession":"bundle"},{"id":2400,"name":"ambush","profession":"bundle"},{"id":2401,"name":"ambush","profession":"bundle"},{"id":2403,"name":"ambush","profession":"bundle"},{"id":2433,"name":"spit","profession":"bundle"},{"id":2434,"name":"tarpool","profession":"bundle"},{"id":2446,"name":"shred","profession":"bundle"},{"id":2498,"name":"firebolt","profession":"bundle"},{"id":2503,"name":"slash","profession":"bundle"},{"id":2504,"name":"lunge","profession":"bundle"},{"id":2505,"name":"slash","profession":"bundle"},{"id":2760,"name":"fireblast","profession":"bundle"},{"id":2783,"name":"hit","profession":"bundle"},{"id":2784,"name":"glueshot","profession":"bundle"},{"id":2800,"name":"eyebeam","profession":"bundle"},{"id":2804,"name":"tentacleslash","profession":"bundle"},{"id":2806,"name":"shoot","profession":"bundle"},{"id":2823,"name":"slash","profession":"bundle"},{"id":2824,"name":"throwaxe","profession":"bundle"},{"id":2839,"name":"slash","profession":"bundle"},{"id":2843,"name":"pawswipe","profession":"bundle"},{"id":2845,"name":"brutalmauling","profession":"bundle"},{"id":2871,"name":"jab","profession":"bundle"},{"id":2879,"name":"bite","profession":"bundle"},{"id":2880,"name":"eyeblast","profession":"bundle"},{"id":2881,"name":"petrifyinggaze","profession":"bundle"},{"id":2904,"name":"slash","profession":"bundle"},{"id":2905,"name":"swoop","profession":"bundle"},{"id":2907,"name":"shred","profession":"bundle"},{"id":2919,"name":"thump","profession":"bundle"},{"id":2920,"name":"lunge","profession":"bundle"},{"id":2922,"name":"charge","profession":"bundle"},{"id":2924,"name":"oakheartswipe","profession":"bundle"},{"id":2937,"name":"vomit","profession":"bundle"},{"id":2939,"name":"slash","profession":"bundle"},{"id":2961,"name":"rockshards","profession":"bundle"},{"id":2962,"name":"bite","profession":"bundle"},{"id":3032,"name":"jab","profession":"bundle"},{"id":3080,"name":"slash","profession":"bundle"},{"id":3096,"name":"slash","profession":"bundle"},{"id":3101,"name":"diseasedbite","profession":"bundle"},{"id":3102,"name":"slash","profession":"bundle"},{"id":3103,"name":"screech","profession":"bundle"},{"id":3717,"name":"frostspit","profession":"bundle"},{"id":3777,"name":"buffpassiveoakheart","profession":"bundle"},{"id":3786,"name":"maul","profession":"bundle"},{"id":3787,"name":"lunge","profession":"bundle"},{"id":3788,"name":"jab","profession":"bundle"},{"id":3789,"name":"frozenburst","profession":"bundle"},{"id":5487,"name":"frozenburst","profession":"bundle"},{"id":5489,"name":"lightningwhip","profession":"bundle"},{"id":5490,"name":"comet","profession":"bundle"},{"id":5491,"name":"fireball","profession":"bundle"},{"id":5492,"name":"fireattunement","profession":"bundle"},{"id":5493,"name":"waterattunement","profession":"bundle"},{"id":5494,"name":"airattunement","profession":"bundle"},{"id":5495,"name":"earthattunement","profession":"bundle"},{"id":5496,"name":"drakesbreath","profession":"bundle"},{"id":5497,"name":"flamewall","profession":"bundle"},{"id":5500,"name":"stoneshards","profession":"bundle"},{"id":5501,"name":"meteorshower","profession":"bundle"},{"id":5502,"name":"glyphoflesserelementals","profession":"bundle"},{"id":5503,"name":"signetofrestoration","profession":"bundle"},{"id":5504,"name":"dischargelightning","profession":"bundle"},{"id":5505,"name":"graspingearth","profession":"bundle"},{"id":5506,"name":"glyphofelementalpower","profession":"bundle"},{"id":5507,"name":"etherrenewal","profession":"bundle"},{"id":5508,"name":"flamestrike","profession":"bundle"},{"id":5510,"name":"watertrident","profession":"bundle"},{"id":5515,"name":"frozenground","profession":"bundle"},{"id":5516,"name":"conjurefierygreatsword","profession":"bundle"},{"id":5517,"name":"fieryrush","profession":"bundle"},{"id":5518,"name":"chainlightning","profession":"bundle"},{"id":5519,"name":"stoning","profession":"bundle"},{"id":5520,"name":"frostaura","profession":"bundle"},{"id":5521,"name":"obsidianflesh","profession":"bundle"},{"id":5522,"name":"churningearth","profession":"bundle"},{"id":5525,"name":"ringofearth","profession":"bundle"},{"id":5526,"name":"arclightning","profession":"bundle"},{"id":5527,"name":"shockingaura","profession":"bundle"},{"id":5528,"name":"eruption","profession":"bundle"},{"id":5529,"name":"ridethelightning","profession":"bundle"},{"id":5530,"name":"swirlingwinds","profession":"bundle"},{"id":5531,"name":"firestorm","profession":"bundle"},{"id":5532,"name":"flamewave","profession":"bundle"},{"id":5533,"name":"fieryeruption","profession":"bundle"},{"id":5534,"name":"tornado","profession":"bundle"},{"id":5535,"name":"cleansingfire","profession":"bundle"},{"id":5536,"name":"lightningflash","profession":"bundle"},{"id":5537,"name":"coneofcold","profession":"bundle"},{"id":5538,"name":"shatterstone","profession":"bundle"},{"id":5539,"name":"arcaneblast","profession":"bundle"},{"id":5540,"name":"conjureflameaxe","profession":"bundle"},{"id":5541,"name":"lavaaxe","profession":"bundle"},{"id":5542,"name":"signetoffire","profession":"bundle"},{"id":5546,"name":"conjureearthshield","profession":"bundle"},{"id":5547,"name":"magneticsurge","profession":"bundle"},{"id":5548,"name":"lavafont","profession":"bundle"},{"id":5549,"name":"waterblast","profession":"bundle"},{"id":5550,"name":"icespike","profession":"bundle"},{"id":5551,"name":"healingrain","profession":"bundle"},{"id":5552,"name":"lightningsurge","profession":"bundle"},{"id":5553,"name":"gust","profession":"bundle"},{"id":5554,"name":"mistform","profession":"bundle"},{"id":5555,"name":"magneticwave","profession":"bundle"},{"id":5556,"name":"freezinggust","profession":"bundle"},{"id":5557,"name":"firegrab","profession":"bundle"},{"id":5558,"name":"cleansingwave","profession":"bundle"},{"id":5559,"name":"earthenrush","profession":"bundle"},{"id":5561,"name":"lightningstrike","profession":"bundle"},{"id":5562,"name":"gale","profession":"bundle"},{"id":5564,"name":"vaporform","profession":"bundle"},{"id":5566,"name":"steam","profession":"bundle"},{"id":5567,"name":"conjurefrostbow","profession":"bundle"},{"id":5568,"name":"frostfan","profession":"bundle"},{"id":5569,"name":"glyphofelementalharmony","profession":"bundle"},{"id":5570,"name":"signetofwater","profession":"bundle"},{"id":5571,"name":"signetofearth","profession":"bundle"},{"id":5572,"name":"signetofair","profession":"bundle"},{"id":5573,"name":"glyphofrenewal","profession":"bundle"},{"id":5593,"name":"explosivelavaaxe","profession":"bundle"},{"id":5595,"name":"waterarrow","profession":"bundle"},{"id":5597,"name":"boil","profession":"bundle"},{"id":5598,"name":"magmaorb","profession":"bundle"},{"id":5599,"name":"lavachains","profession":"bundle"},{"id":5600,"name":"heatwave","profession":"bundle"},{"id":5602,"name":"whirlpool","profession":"bundle"},{"id":5603,"name":"whirlpool","profession":"bundle"},{"id":5604,"name":"watermissile","profession":"bundle"},{"id":5605,"name":"iceglobe","profession":"bundle"},{"id":5606,"name":"icewall","profession":"bundle"},{"id":5607,"name":"tidalwave","profession":"bundle"},{"id":5608,"name":"waterfist","profession":"bundle"},{"id":5609,"name":"stonekick","profession":"bundle"},{"id":5610,"name":"steamvent","profession":"bundle"},{"id":5621,"name":"shieldsmack","profession":"bundle"},{"id":5623,"name":"fortify","profession":"bundle"},{"id":5624,"name":"conjurelightninghammer","profession":"bundle"},{"id":5625,"name":"lightningleap","profession":"bundle"},{"id":5635,"name":"arcanepower","profession":"bundle"},{"id":5638,"name":"arcanewave","profession":"bundle"},{"id":5639,"name":"armorofearth","profession":"bundle"},{"id":5641,"name":"arcaneshield","profession":"bundle"},{"id":5644,"name":"burningspeed","profession":"bundle"},{"id":5646,"name":"convergence","profession":"bundle"},{"id":5648,"name":"airbubble","profession":"bundle"},{"id":5650,"name":"lightningcage","profession":"bundle"},{"id":5652,"name":"airpocket","profession":"bundle"},{"id":5653,"name":"vacuum","profession":"bundle"},{"id":5655,"name":"electrocute","profession":"bundle"},{"id":5656,"name":"forkedlightning","profession":"bundle"},{"id":5657,"name":"rockblade","profession":"bundle"},{"id":5658,"name":"rockspray","profession":"bundle"},{"id":5659,"name":"rockanchor","profession":"bundle"},{"id":5661,"name":"murkywater","profession":"bundle"},{"id":5662,"name":"magneticcurrent","profession":"bundle"},{"id":5666,"name":"glyphofelementals","profession":"bundle"},{"id":5671,"name":"staticfield","profession":"bundle"},{"id":5675,"name":"phoenix","profession":"bundle"},{"id":5678,"name":"fireshield","profession":"bundle"},{"id":5679,"name":"flameburst","profession":"bundle"},{"id":5680,"name":"burningretreat","profession":"bundle"},{"id":5681,"name":"geyser","profession":"bundle"},{"id":5682,"name":"windbornespeed","profession":"bundle"},{"id":5683,"name":"unsteadyground","profession":"bundle"},{"id":5685,"name":"magneticaura","profession":"bundle"},{"id":5686,"name":"shockwave","profession":"bundle"},{"id":5687,"name":"updraft","profession":"bundle"},{"id":5690,"name":"earthquake","profession":"bundle"},{"id":5691,"name":"ringoffire","profession":"bundle"},{"id":5692,"name":"dragonstooth","profession":"bundle"},{"id":5693,"name":"iceshards","profession":"bundle"},{"id":5694,"name":"blindingflash","profession":"bundle"},{"id":5695,"name":"rockbarrier","profession":"bundle"},{"id":5696,"name":"dustdevil","profession":"bundle"},{"id":5697,"name":"fierywhirl","profession":"bundle"},{"id":5717,"name":"burningretreat","profession":"bundle"},{"id":5718,"name":"ringoffire","profession":"bundle"},{"id":5719,"name":"flameleap","profession":"bundle"},{"id":5720,"name":"frostvolley","profession":"bundle"},{"id":5721,"name":"deepfreeze","profession":"bundle"},{"id":5723,"name":"froststorm","profession":"bundle"},{"id":5725,"name":"invokelightning","profession":"bundle"},{"id":5726,"name":"lightningswing","profession":"bundle"},{"id":5727,"name":"staticswing","profession":"bundle"},{"id":5728,"name":"thunderclap","profession":"bundle"},{"id":5732,"name":"staticfield","profession":"bundle"},{"id":5733,"name":"windblast","profession":"bundle"},{"id":5734,"name":"glyphofstorms","profession":"bundle"},{"id":5735,"name":"icestorm","profession":"bundle"},{"id":5736,"name":"firestorm","profession":"bundle"},{"id":5737,"name":"lightningstorm","profession":"bundle"},{"id":5738,"name":"sandstorm","profession":"bundle"},{"id":5746,"name":"cripplingshield","profession":"bundle"},{"id":5747,"name":"magneticshield","profession":"bundle"},{"id":5748,"name":"undercurrent","profession":"bundle"},{"id":5752,"name":"electrifiedtornado","profession":"bundle"},{"id":5753,"name":"dusttornado","profession":"bundle"},{"id":5754,"name":"debristornado","profession":"bundle"},{"id":5760,"name":"renewalofair","profession":"bundle"},{"id":5761,"name":"renewalofearth","profession":"bundle"},{"id":5762,"name":"renewaloffire","profession":"bundle"},{"id":5763,"name":"renewalofwater","profession":"bundle"},{"id":5777,"name":"armorofearth","profession":"bundle"},{"id":5780,"name":"hurl","profession":"bundle"},{"id":5782,"name":"geyser","profession":"bundle"},{"id":5792,"name":"blindingflash","profession":"bundle"},{"id":5793,"name":"cleansingwave","profession":"bundle"},{"id":5794,"name":"flameburst","profession":"bundle"},{"id":5795,"name":"shockwave","profession":"bundle"},{"id":5802,"name":"medkit","profession":"bundle"},{"id":5805,"name":"grenadekit","profession":"bundle"},{"id":5806,"name":"poisongrenade","profession":"bundle"},{"id":5807,"name":"shrapnelgrenade","profession":"bundle"},{"id":5808,"name":"flashgrenade","profession":"bundle"},{"id":5809,"name":"freezegrenade","profession":"bundle"},{"id":5810,"name":"grenadebarrage","profession":"bundle"},{"id":5811,"name":"personalbatteringram","profession":"bundle"},{"id":5812,"name":"bombkit","profession":"bundle"},{"id":5813,"name":"bigolbomb","profession":"bundle"},{"id":5818,"name":"rifleturret","profession":"bundle"},{"id":5820,"name":"throwjunk","profession":"bundle"},{"id":5821,"name":"elixirb","profession":"bundle"},{"id":5822,"name":"concussionbomb","profession":"bundle"},{"id":5823,"name":"firebomb","profession":"bundle"},{"id":5824,"name":"smokebomb","profession":"bundle"},{"id":5825,"name":"slickshoes","profession":"bundle"},{"id":5827,"name":"fragmentationshot","profession":"bundle"},{"id":5828,"name":"poisondartvolley","profession":"bundle"},{"id":5829,"name":"staticshot","profession":"bundle"},{"id":5830,"name":"glueshot","profession":"bundle"},{"id":5831,"name":"blowtorch","profession":"bundle"},{"id":5832,"name":"elixirx","profession":"bundle"},{"id":5834,"name":"elixirh","profession":"bundle"},{"id":5836,"name":"flameturret","profession":"bundle"},{"id":5837,"name":"netturret","profession":"bundle"},{"id":5838,"name":"thumperturret","profession":"bundle"},{"id":5842,"name":"bomb","profession":"bundle"},{"id":5857,"name":"healingturret","profession":"bundle"},{"id":5860,"name":"elixirc","profession":"bundle"},{"id":5861,"name":"elixirs","profession":"bundle"},{"id":5862,"name":"elixiru","profession":"bundle"},{"id":5865,"name":"utilitygoggles","profession":"bundle"},{"id":5867,"name":"tosselixirr","profession":"bundle"},{"id":5868,"name":"supplycrate","profession":"bundle"},{"id":5874,"name":"automaticfire","profession":"bundle"},{"id":5882,"name":"grenade","profession":"bundle"},{"id":5889,"name":"thump","profession":"bundle"},{"id":5893,"name":"electrifiednet","profession":"bundle"},{"id":5900,"name":"smokescreen","profession":"bundle"},{"id":5904,"name":"toolkit","profession":"bundle"},{"id":5905,"name":"prybar","profession":"bundle"},{"id":5910,"name":"rocketboots","profession":"bundle"},{"id":5912,"name":"rocketturret","profession":"bundle"},{"id":5913,"name":"explosiverockets","profession":"bundle"},{"id":5916,"name":"floatingmine","profession":"bundle"},{"id":5917,"name":"anchor","profession":"bundle"},{"id":5918,"name":"buoy","profession":"bundle"},{"id":5927,"name":"flamethrower","profession":"bundle"},{"id":5928,"name":"flamejet","profession":"bundle"},{"id":5929,"name":"napalm","profession":"bundle"},{"id":5930,"name":"airblast","profession":"bundle"},{"id":5931,"name":"flameblast","profession":"bundle"},{"id":5933,"name":"elixirgun","profession":"bundle"},{"id":5934,"name":"tranquilizerdart","profession":"bundle"},{"id":5935,"name":"globshot","profession":"bundle"},{"id":5936,"name":"acidbomb","profession":"bundle"},{"id":5937,"name":"superelixir","profession":"bundle"},{"id":5939,"name":"gluebomb","profession":"bundle"},{"id":5957,"name":"detonaterifleturret","profession":"bundle"},{"id":5960,"name":"detonatethumperturret","profession":"bundle"},{"id":5961,"name":"detonatehealingturret","profession":"bundle"},{"id":5962,"name":"grapplingline","profession":"bundle"},{"id":5963,"name":"boobytrap","profession":"bundle"},{"id":5965,"name":"fumigate","profession":"bundle"},{"id":5966,"name":"healingmist","profession":"bundle"},{"id":5967,"name":"tosselixirb","profession":"bundle"},{"id":5968,"name":"elixirr","profession":"bundle"},{"id":5969,"name":"tosselixirc","profession":"bundle"},{"id":5970,"name":"tosselixiru","profession":"bundle"},{"id":5972,"name":"tosselixirs","profession":"bundle"},{"id":5973,"name":"superspeed","profession":"bundle"},{"id":5977,"name":"incendiaryammo","profession":"bundle"},{"id":5978,"name":"tosselixirh","profession":"bundle"},{"id":5980,"name":"cleansingburst","profession":"bundle"},{"id":5982,"name":"launchpersonalbatteringram","profession":"bundle"},{"id":5983,"name":"rocketkick","profession":"bundle"},{"id":5984,"name":"detonatenetturret","profession":"bundle"},{"id":5985,"name":"detonateflameturret","profession":"bundle"},{"id":5987,"name":"flameturret","profession":"bundle"},{"id":5988,"name":"netturret","profession":"bundle"},{"id":5989,"name":"rifleturret","profession":"bundle"},{"id":5990,"name":"thumperturret","profession":"bundle"},{"id":5991,"name":"rocketturret","profession":"bundle"},{"id":5992,"name":"smack","profession":"bundle"},{"id":5993,"name":"whack","profession":"bundle"},{"id":5994,"name":"thwack","profession":"bundle"},{"id":5995,"name":"boxofnails","profession":"bundle"},{"id":5996,"name":"magnet","profession":"bundle"},{"id":5998,"name":"gearshield","profession":"bundle"},{"id":5999,"name":"throwwrench","profession":"bundle"},{"id":6003,"name":"hipshot","profession":"bundle"},{"id":6004,"name":"netshot","profession":"bundle"},{"id":6005,"name":"jumpshot","profession":"bundle"},{"id":6020,"name":"grenadekit","profession":"bundle"},{"id":6046,"name":"superelixir","profession":"bundle"},{"id":6047,"name":"elixirf","profession":"bundle"},{"id":6048,"name":"tranquilizerdart","profession":"bundle"},{"id":6050,"name":"lessergrenadebarrage","profession":"bundle"},{"id":6053,"name":"magneticshield","profession":"bundle"},{"id":6054,"name":"staticshield","profession":"bundle"},{"id":6057,"name":"throwshield","profession":"bundle"},{"id":6077,"name":"tosselixirc","profession":"bundle"},{"id":6078,"name":"detonateelixirc","profession":"bundle"},{"id":6082,"name":"detonateelixirb","profession":"bundle"},{"id":6084,"name":"detonateelixirs","profession":"bundle"},{"id":6086,"name":"detonateelixirr","profession":"bundle"},{"id":6088,"name":"detonateelixiru","profession":"bundle"},{"id":6089,"name":"tosselixiru","profession":"bundle"},{"id":6090,"name":"tosselixirs","profession":"bundle"},{"id":6091,"name":"tosselixirr","profession":"bundle"},{"id":6092,"name":"tosselixirb","profession":"bundle"},{"id":6093,"name":"harpoonturret","profession":"bundle"},{"id":6097,"name":"detonateharpoonturret","profession":"bundle"},{"id":6098,"name":"automaticfire","profession":"bundle"},{"id":6102,"name":"superelixir","profession":"bundle"},{"id":6104,"name":"superelixir","profession":"bundle"},{"id":6109,"name":"stowmedkit","profession":"bundle"},{"id":6110,"name":"stowgrenadekit","profession":"bundle"},{"id":6111,"name":"stowbombkit","profession":"bundle"},{"id":6113,"name":"stowtoolkit","profession":"bundle"},{"id":6114,"name":"stowflamethrower","profession":"bundle"},{"id":6115,"name":"stowelixirgun","profession":"bundle"},{"id":6118,"name":"tosselixirh","profession":"bundle"},{"id":6119,"name":"detonateelixirh","profession":"bundle"},{"id":6126,"name":"magneticinversion","profession":"bundle"},{"id":6134,"name":"detonaterocketturret","profession":"bundle"},{"id":6140,"name":"healingturret","profession":"bundle"},{"id":6145,"name":"netwall","profession":"bundle"},{"id":6147,"name":"scattermines","profession":"bundle"},{"id":6148,"name":"homingtorpedo","profession":"bundle"},{"id":6149,"name":"timedcharge","profession":"bundle"},{"id":6153,"name":"blunderbuss","profession":"bundle"},{"id":6154,"name":"overchargedshot","profession":"bundle"},{"id":6159,"name":"smokevent","profession":"bundle"},{"id":6161,"name":"throwmine","profession":"bundle"},{"id":6162,"name":"detonate","profession":"bundle"},{"id":6163,"name":"deploymine","profession":"bundle"},{"id":6164,"name":"minefield","profession":"bundle"},{"id":6166,"name":"detonateminefield","profession":"bundle"},{"id":6167,"name":"poisongrenade","profession":"bundle"},{"id":6168,"name":"freezegrenade","profession":"bundle"},{"id":6169,"name":"flashgrenade","profession":"bundle"},{"id":6170,"name":"shrapnelgrenade","profession":"bundle"},{"id":6171,"name":"grenade","profession":"bundle"},{"id":6172,"name":"grenadebarrage","profession":"bundle"},{"id":6175,"name":"boxofpiranhas","profession":"bundle"},{"id":6176,"name":"regeneratingmist","profession":"bundle"},{"id":6177,"name":"rocket","profession":"bundle"},{"id":6178,"name":"surpriseshot","profession":"bundle"},{"id":6179,"name":"netattack","profession":"bundle"},{"id":6180,"name":"rumble","profession":"bundle"},{"id":6181,"name":"thrownapalm","profession":"bundle"},{"id":6182,"name":"harpoon","profession":"bundle"},{"id":6183,"name":"supplycrate","profession":"bundle"},{"id":9080,"name":"leapoffaith","profession":"bundle"},{"id":9081,"name":"whirlingwrath","profession":"bundle"},{"id":9082,"name":"shieldofwrath","profession":"bundle"},{"id":9083,"name":"receivethelight","profession":"bundle"},{"id":9084,"name":"advance","profession":"bundle"},{"id":9085,"name":"saveyourselves","profession":"bundle"},{"id":9086,"name":"protectorsstrike","profession":"bundle"},{"id":9087,"name":"shieldofjudgment","profession":"bundle"},{"id":9088,"name":"cleansingflame","profession":"bundle"},{"id":9089,"name":"zealotsfire","profession":"bundle"},{"id":9090,"name":"symbolofpunishment","profession":"bundle"},{"id":9091,"name":"shieldofabsorption","profession":"bundle"},{"id":9093,"name":"banesignet","profession":"bundle"},{"id":9095,"name":"symbolofjudgment","profession":"bundle"},{"id":9096,"name":"waveoflight","profession":"bundle"},{"id":9097,"name":"symbolofblades","profession":"bundle"},{"id":9098,"name":"orbofwrath","profession":"bundle"},{"id":9099,"name":"chainsoflight","profession":"bundle"},{"id":9101,"name":"lessersmitecondition","profession":"bundle"},{"id":9102,"name":"shelter","profession":"bundle"},{"id":9104,"name":"zealotsflame","profession":"bundle"},{"id":9105,"name":"swordofwrath","profession":"bundle"},{"id":9106,"name":"swordarc","profession":"bundle"},{"id":9107,"name":"zealotsdefense","profession":"bundle"},{"id":9108,"name":"faithfulstrike","profession":"bundle"},{"id":9109,"name":"truestrike","profession":"bundle"},{"id":9110,"name":"purestrike","profession":"bundle"},{"id":9111,"name":"symboloffaith","profession":"bundle"},{"id":9112,"name":"rayofjudgment","profession":"bundle"},{"id":9115,"name":"virtueofjustice","profession":"bundle"},{"id":9118,"name":"virtueofcourage","profession":"bundle"},{"id":9120,"name":"virtueofresolve","profession":"bundle"},{"id":9122,"name":"boltofwrath","profession":"bundle"},{"id":9124,"name":"banish","profession":"bundle"},{"id":9125,"name":"hammerofwisdom","profession":"bundle"},{"id":9128,"name":"sanctuary","profession":"bundle"},{"id":9137,"name":"strike","profession":"bundle"},{"id":9138,"name":"vengefulstrike","profession":"bundle"},{"id":9139,"name":"wrathfulstrike","profession":"bundle"},{"id":9140,"name":"holystrike","profession":"bundle"},{"id":9143,"name":"symbolofswiftness","profession":"bundle"},{"id":9144,"name":"lineofwarding","profession":"bundle"},{"id":9146,"name":"symbolofresolution","profession":"bundle"},{"id":9147,"name":"bindingblade","profession":"bundle"},{"id":9149,"name":"wrath","profession":"bundle"},{"id":9150,"name":"signetofjudgment","profession":"bundle"},{"id":9151,"name":"signetofwrath","profession":"bundle"},{"id":9152,"name":"holdtheline","profession":"bundle"},{"id":9153,"name":"standyourground","profession":"bundle"},{"id":9154,"name":"renewedfocus","profession":"bundle"},{"id":9158,"name":"signetofresolve","profession":"bundle"},{"id":9159,"name":"hammerswing","profession":"bundle"},{"id":9160,"name":"hammerbash","profession":"bundle"},{"id":9161,"name":"symbolofprotection","profession":"bundle"},{"id":9163,"name":"signetofmercy","profession":"bundle"},{"id":9168,"name":"swordofjustice","profession":"bundle"},{"id":9175,"name":"bowoftruth","profession":"bundle"},{"id":9182,"name":"shieldoftheavenger","profession":"bundle"},{"id":9187,"name":"purgingflames","profession":"bundle"},{"id":9189,"name":"spearoflight","profession":"bundle"},{"id":9190,"name":"zealotsflurry","profession":"bundle"},{"id":9191,"name":"brilliance","profession":"bundle"},{"id":9192,"name":"symbolofspears","profession":"bundle"},{"id":9193,"name":"wrathfulgrasp","profession":"bundle"},{"id":9194,"name":"mightyblow","profession":"bundle"},{"id":9195,"name":"ringofwarding","profession":"bundle"},{"id":9205,"name":"lightball","profession":"bundle"},{"id":9206,"name":"weightofjustice","profession":"bundle"},{"id":9207,"name":"purify","profession":"bundle"},{"id":9208,"name":"symboloflight","profession":"bundle"},{"id":9209,"name":"refraction","profession":"bundle"},{"id":9210,"name":"renewingcurrent","profession":"bundle"},{"id":9211,"name":"revealthedepths","profession":"bundle"},{"id":9212,"name":"shackle","profession":"bundle"},{"id":9224,"name":"shieldofabsorption","profession":"bundle"},{"id":9226,"name":"pull","profession":"bundle"},{"id":9227,"name":"swordwave","profession":"bundle"},{"id":9234,"name":"purifyingblast","profession":"bundle"},{"id":9245,"name":"smitecondition","profession":"bundle"},{"id":9246,"name":"mercifulintervention","profession":"bundle"},{"id":9247,"name":"judgesintervention","profession":"bundle"},{"id":9248,"name":"contemplationofpurity","profession":"bundle"},{"id":9250,"name":"virtueofresolve","profession":"bundle"},{"id":9251,"name":"wallofreflection","profession":"bundle"},{"id":9253,"name":"hallowedground","profession":"bundle"},{"id":9260,"name":"zealotsembrace","profession":"bundle"},{"id":9265,"name":"empower","profession":"bundle"},{"id":9268,"name":"virtueofcourage","profession":"bundle"},{"id":10168,"name":"confusingimages","profession":"bundle"},{"id":10169,"name":"chaosstorm","profession":"bundle"},{"id":10170,"name":"mindslash","profession":"bundle"},{"id":10171,"name":"mindgash","profession":"bundle"},{"id":10172,"name":"mindspike","profession":"bundle"},{"id":10173,"name":"illusionaryleap","profession":"bundle"},{"id":10174,"name":"phantasmalswordsman","profession":"bundle"},{"id":10175,"name":"phantasmalduelist","profession":"bundle"},{"id":10176,"name":"etherfeast","profession":"bundle"},{"id":10177,"name":"mirror","profession":"bundle"},{"id":10180,"name":"kick","profession":"bundle"},{"id":10181,"name":"peck","profession":"bundle"},{"id":10182,"name":"screech","profession":"bundle"},{"id":10183,"name":"claw","profession":"bundle"},{"id":10185,"name":"arcanethievery","profession":"bundle"},{"id":10186,"name":"temporalcurtain","profession":"bundle"},{"id":10187,"name":"veil","profession":"bundle"},{"id":10189,"name":"phantasmalmage","profession":"bundle"},{"id":10190,"name":"cryoffrustration","profession":"bundle"},{"id":10191,"name":"mindwrack","profession":"bundle"},{"id":10192,"name":"distortion","profession":"bundle"},{"id":10196,"name":"mindblast","profession":"bundle"},{"id":10197,"name":"portalentre","profession":"bundle"},{"id":10199,"name":"portalexeunt","profession":"bundle"},{"id":10200,"name":"blink","profession":"bundle"},{"id":10201,"name":"decoy","profession":"bundle"},{"id":10202,"name":"mirrorimages","profession":"bundle"},{"id":10203,"name":"nullfield","profession":"bundle"},{"id":10204,"name":"mantraofdistraction","profession":"bundle"},{"id":10207,"name":"mantraofresolve","profession":"bundle"},{"id":10211,"name":"mantraofpain","profession":"bundle"},{"id":10213,"name":"mantraofrecovery","profession":"bundle"},{"id":10216,"name":"phantasmalwarlock","profession":"bundle"},{"id":10218,"name":"mindstab","profession":"bundle"},{"id":10219,"name":"spatialsurge","profession":"bundle"},{"id":10220,"name":"illusionarywave","profession":"bundle"},{"id":10221,"name":"phantasmalberserker","profession":"bundle"},{"id":10224,"name":"phantasmalrogue","profession":"bundle"},{"id":10229,"name":"magicbullet","profession":"bundle"},{"id":10232,"name":"signetofdomination","profession":"bundle"},{"id":10234,"name":"signetofmidnight","profession":"bundle"},{"id":10236,"name":"signetofinspiration","profession":"bundle"},{"id":10237,"name":"mantraofconcentration","profession":"bundle"},{"id":10244,"name":"illusionoflife","profession":"bundle"},{"id":10245,"name":"massinvisibility","profession":"bundle"},{"id":10247,"name":"signetofillusions","profession":"bundle"},{"id":10251,"name":"phantasmalmariner","profession":"bundle"},{"id":10255,"name":"vortex","profession":"bundle"},{"id":10258,"name":"sirenscall","profession":"bundle"},{"id":10259,"name":"blindingtide","profession":"bundle"},{"id":10260,"name":"illusionofdrowning","profession":"bundle"},{"id":10267,"name":"phantasmaldisenchanter","profession":"bundle"},{"id":10273,"name":"windsofchaos","profession":"bundle"},{"id":10276,"name":"illusionarycounter","profession":"bundle"},{"id":10280,"name":"illusionaryriposte","profession":"bundle"},{"id":10282,"name":"phantasmalwarden","profession":"bundle"},{"id":10285,"name":"theprestige","profession":"bundle"},{"id":10287,"name":"diversion","profession":"bundle"},{"id":10289,"name":"etherbolt","profession":"bundle"},{"id":10290,"name":"etherblast","profession":"bundle"},{"id":10291,"name":"etherclone","profession":"bundle"},{"id":10302,"name":"feedback","profession":"bundle"},{"id":10310,"name":"phaseretreat","profession":"bundle"},{"id":10311,"name":"timewarp","profession":"bundle"},{"id":10314,"name":"counterspell","profession":"bundle"},{"id":10315,"name":"stab","profession":"bundle"},{"id":10316,"name":"jab","profession":"bundle"},{"id":10317,"name":"evasivestrike","profession":"bundle"},{"id":10318,"name":"feignedsurge","profession":"bundle"},{"id":10325,"name":"slipstream","profession":"bundle"},{"id":10327,"name":"imminentvoyage","profession":"bundle"},{"id":10328,"name":"phantasmalwhaler","profession":"bundle"},{"id":10331,"name":"chaosarmor","profession":"bundle"},{"id":10333,"name":"mirrorblade","profession":"bundle"},{"id":10334,"name":"blurredfrenzy","profession":"bundle"},{"id":10337,"name":"swap","profession":"bundle"},{"id":10341,"name":"phantasmaldefender","profession":"bundle"},{"id":10356,"name":"feedback","profession":"bundle"},{"id":10358,"name":"counterblade","profession":"bundle"},{"id":10363,"name":"intothevoid","profession":"bundle"},{"id":10366,"name":"deception","profession":"bundle"},{"id":10372,"name":"bite","profession":"bundle"},{"id":10373,"name":"chomp","profession":"bundle"},{"id":10374,"name":"frenzy","profession":"bundle"},{"id":10375,"name":"flee","profession":"bundle"},{"id":10376,"name":"spit","profession":"bundle"},{"id":10377,"name":"timewarp","profession":"bundle"},{"id":10527,"name":"wellofblood","profession":"bundle"},{"id":10528,"name":"ghastlyclaws","profession":"bundle"},{"id":10529,"name":"darkpact","profession":"bundle"},{"id":10532,"name":"graspingdead","profession":"bundle"},{"id":10533,"name":"summonbonefiend","profession":"bundle"},{"id":10540,"name":"putridexplosion","profession":"bundle"},{"id":10541,"name":"summonboneminions","profession":"bundle"},{"id":10543,"name":"summonfleshwurm","profession":"bundle"},{"id":10544,"name":"bloodispower","profession":"bundle"},{"id":10545,"name":"wellofcorruption","profession":"bundle"},{"id":10546,"name":"wellofsuffering","profession":"bundle"},{"id":10547,"name":"summonbloodfiend","profession":"bundle"},{"id":10548,"name":"consumeconditions","profession":"bundle"},{"id":10549,"name":"plaguelands","profession":"bundle"},{"id":10550,"name":"lichform","profession":"bundle"},{"id":10552,"name":"putridcurse","profession":"bundle"},{"id":10554,"name":"lifeblast","profession":"bundle"},{"id":10555,"name":"spinalshivers","profession":"bundle"},{"id":10556,"name":"wailofdoom","profession":"bundle"},{"id":10557,"name":"locustswarm","profession":"bundle"},{"id":10559,"name":"fetidground","profession":"bundle"},{"id":10560,"name":"lifeleech","profession":"bundle"},{"id":10561,"name":"rendingclaws","profession":"bundle"},{"id":10562,"name":"plaguesignet","profession":"bundle"},{"id":10563,"name":"lifesiphon","profession":"bundle"},{"id":10570,"name":"rigormortis","profession":"bundle"},{"id":10574,"name":"deathshroud","profession":"bundle"},{"id":10577,"name":"tasteofdeath","profession":"bundle"},{"id":10583,"name":"spectralarmor","profession":"bundle"},{"id":10585,"name":"enddeathshroud","profession":"bundle"},{"id":10586,"name":"locked","profession":"bundle"},{"id":10588,"name":"doom","profession":"bundle"},{"id":10589,"name":"summonshadowfiend","profession":"bundle"},{"id":10590,"name":"haunt","profession":"bundle"},{"id":10594,"name":"lifetransfer","profession":"bundle"},{"id":10596,"name":"necroticgrasp","profession":"bundle"},{"id":10600,"name":"necrotictraversal","profession":"bundle"},{"id":10602,"name":"corruptboon","profession":"bundle"},{"id":10604,"name":"darkpath","profession":"bundle"},{"id":10605,"name":"chillblains","profession":"bundle"},{"id":10606,"name":"epidemic","profession":"bundle"},{"id":10607,"name":"wellofdarkness","profession":"bundle"},{"id":10608,"name":"spectralring","profession":"bundle"},{"id":10609,"name":"wellofpower","profession":"bundle"},{"id":10611,"name":"signetofundeath","profession":"bundle"},{"id":10612,"name":"signetofthelocust","profession":"bundle"},{"id":10616,"name":"darkspear","profession":"bundle"},{"id":10617,"name":"reapersscythe","profession":"bundle"},{"id":10619,"name":"deadlyfeast","profession":"bundle"},{"id":10620,"name":"spectralgrasp","profession":"bundle"},{"id":10622,"name":"signetofspite","profession":"bundle"},{"id":10623,"name":"crimsontide","profession":"bundle"},{"id":10624,"name":"feast","profession":"bundle"},{"id":10625,"name":"foulcurrent","profession":"bundle"},{"id":10628,"name":"sinkingtomb","profession":"bundle"},{"id":10629,"name":"frozenabyss","profession":"bundle"},{"id":10632,"name":"grimspecter","profession":"bundle"},{"id":10633,"name":"rippleofhorror","profession":"bundle"},{"id":10634,"name":"deathlyclaws","profession":"bundle"},{"id":10635,"name":"lichsgaze","profession":"bundle"},{"id":10636,"name":"summonmadness","profession":"bundle"},{"id":10640,"name":"lifeleech","profession":"bundle"},{"id":10641,"name":"deathcurse","profession":"bundle"},{"id":10642,"name":"feedingfrenzy","profession":"bundle"},{"id":10643,"name":"gatheringplague","profession":"bundle"},{"id":10644,"name":"darkwater","profession":"bundle"},{"id":10645,"name":"waveoffear","profession":"bundle"},{"id":10646,"name":"summonfleshgolem","profession":"bundle"},{"id":10647,"name":"charge","profession":"bundle"},{"id":10660,"name":"fear","profession":"bundle"},{"id":10661,"name":"witheringplague","profession":"bundle"},{"id":10662,"name":"plagueofdarkness","profession":"bundle"},{"id":10663,"name":"plagueofpestilence","profession":"bundle"},{"id":10670,"name":"wellofblood","profession":"bundle"},{"id":10671,"name":"wellofcorruption","profession":"bundle"},{"id":10672,"name":"wellofdarkness","profession":"bundle"},{"id":10673,"name":"wellofpower","profession":"bundle"},{"id":10674,"name":"wellofsuffering","profession":"bundle"},{"id":10685,"name":"spectralwalk","profession":"bundle"},{"id":10687,"name":"spectralrecall","profession":"bundle"},{"id":10689,"name":"corrosivepoisoncloud","profession":"bundle"},{"id":10690,"name":"plagueblast","profession":"bundle"},{"id":10692,"name":"cruelstrike","profession":"bundle"},{"id":10693,"name":"wickedstrike","profession":"bundle"},{"id":10694,"name":"wickedspiral","profession":"bundle"},{"id":10695,"name":"deadlycatch","profession":"bundle"},{"id":10698,"name":"bloodcurse","profession":"bundle"},{"id":10699,"name":"rendingcurse","profession":"bundle"},{"id":10701,"name":"unholyfeast","profession":"bundle"},{"id":10702,"name":"necroticslash","profession":"bundle"},{"id":10703,"name":"necroticstab","profession":"bundle"},{"id":10704,"name":"necroticbite","profession":"bundle"},{"id":10705,"name":"deathlyswarm","profession":"bundle"},{"id":10706,"name":"enfeeblingblood","profession":"bundle"},{"id":10709,"name":"feastofcorruption","profession":"bundle"},{"id":10800,"name":"mistfirewolf","profession":"bundle"},{"id":11164,"name":"rendinglunge","profession":"bundle"},{"id":12318,"name":"technobabble","profession":"bundle"},{"id":12319,"name":"radiationfield","profession":"bundle"},{"id":12320,"name":"paininverter","profession":"bundle"},{"id":12323,"name":"summonseriesgolem","profession":"bundle"},{"id":12324,"name":"summondseriesgolem","profession":"bundle"},{"id":12325,"name":"summonpowersuit","profession":"bundle"},{"id":12334,"name":"confusingspeech","profession":"bundle"},{"id":12335,"name":"paintransference","profession":"bundle"},{"id":12336,"name":"ventradiation","profession":"bundle"},{"id":12337,"name":"shrapnelmine","profession":"bundle"},{"id":12338,"name":"battleroar","profession":"bundle"},{"id":12339,"name":"hiddenpistol","profession":"bundle"},{"id":12340,"name":"warbandsupport","profession":"bundle"},{"id":12343,"name":"artillerybarrage","profession":"bundle"},{"id":12344,"name":"charrzooka","profession":"bundle"},{"id":12345,"name":"firerocket","profession":"bundle"},{"id":12346,"name":"firerocketbarrage","profession":"bundle"},{"id":12347,"name":"rocketjump","profession":"bundle"},{"id":12348,"name":"rocketspray","profession":"bundle"},{"id":12349,"name":"heatseeker","profession":"bundle"},{"id":12354,"name":"invigoratingroar","profession":"bundle"},{"id":12355,"name":"boobytrap","profession":"bundle"},{"id":12357,"name":"hiddenpistols","profession":"bundle"},{"id":12360,"name":"prayertodwayna","profession":"bundle"},{"id":12361,"name":"prayertokormir","profession":"bundle"},{"id":12362,"name":"prayertolyssa","profession":"bundle"},{"id":12363,"name":"houndsofbalthazar","profession":"bundle"},{"id":12367,"name":"reaperofgrenth","profession":"bundle"},{"id":12370,"name":"oakheartswipe","profession":"bundle"},{"id":12371,"name":"bindingroots","profession":"bundle"},{"id":12372,"name":"removeavatarofmelandru","profession":"bundle"},{"id":12373,"name":"avatarofmelandru","profession":"bundle"},{"id":12374,"name":"cleansingleaves","profession":"bundle"},{"id":12375,"name":"summonhealingspring","profession":"bundle"},{"id":12376,"name":"roaroftheforest","profession":"bundle"},{"id":12377,"name":"blessingofdwayna","profession":"bundle"},{"id":12378,"name":"blessingofkormir","profession":"bundle"},{"id":12379,"name":"blessingoflyssa","profession":"bundle"},{"id":12380,"name":"charge","profession":"bundle"},{"id":12385,"name":"becomethebear","profession":"bundle"},{"id":12386,"name":"releasethebear","profession":"bundle"},{"id":12387,"name":"callowl","profession":"bundle"},{"id":12389,"name":"leap","profession":"bundle"},{"id":12390,"name":"howl","profession":"bundle"},{"id":12391,"name":"becomethewolf","profession":"bundle"},{"id":12392,"name":"releasethewolf","profession":"bundle"},{"id":12399,"name":"prowl","profession":"bundle"},{"id":12401,"name":"becomethesnowleopard","profession":"bundle"},{"id":12402,"name":"releasethesnowleopard","profession":"bundle"},{"id":12403,"name":"becometheraven","profession":"bundle"},{"id":12404,"name":"releasetheraven","profession":"bundle"},{"id":12406,"name":"windblast","profession":"bundle"},{"id":12407,"name":"rendingtalons","profession":"bundle"},{"id":12408,"name":"shriek","profession":"bundle"},{"id":12409,"name":"swoop","profession":"bundle"},{"id":12410,"name":"swipe","profession":"bundle"},{"id":12417,"name":"callwurm","profession":"bundle"},{"id":12421,"name":"cripplingswipe","profession":"bundle"},{"id":12422,"name":"rendingswipe","profession":"bundle"},{"id":12423,"name":"rendingslash","profession":"bundle"},{"id":12424,"name":"bloodfrenzy","profession":"bundle"},{"id":12425,"name":"snarl","profession":"bundle"},{"id":12427,"name":"dash","profession":"bundle"},{"id":12429,"name":"frenzy","profession":"bundle"},{"id":12430,"name":"growl","profession":"bundle"},{"id":12431,"name":"pounce","profession":"bundle"},{"id":12432,"name":"swipe","profession":"bundle"},{"id":12433,"name":"brutalswipe","profession":"bundle"},{"id":12434,"name":"heavyswipe","profession":"bundle"},{"id":12435,"name":"roar","profession":"bundle"},{"id":12436,"name":"maul","profession":"bundle"},{"id":12438,"name":"eatwurmegg","profession":"bundle"},{"id":12439,"name":"eatowlegg","profession":"bundle"},{"id":12440,"name":"healingseed","profession":"bundle"},{"id":12447,"name":"summondruidspirit","profession":"bundle"},{"id":12450,"name":"summonsylvanhound","profession":"bundle"},{"id":12453,"name":"graspingvines","profession":"bundle"},{"id":12456,"name":"seedturret","profession":"bundle"},{"id":12457,"name":"takeroot","profession":"bundle"},{"id":12462,"name":"throwvine","profession":"bundle"},{"id":12463,"name":"vineshield","profession":"bundle"},{"id":12465,"name":"leafybandage","profession":"bundle"},{"id":12466,"name":"ricochet","profession":"bundle"},{"id":12468,"name":"poisonvolley","profession":"bundle"},{"id":12469,"name":"barrage","profession":"bundle"},{"id":12470,"name":"crossfire","profession":"bundle"},{"id":12471,"name":"slash","profession":"bundle"},{"id":12472,"name":"cripplingthrust","profession":"bundle"},{"id":12473,"name":"precisionswipe","profession":"bundle"},{"id":12474,"name":"slash","profession":"bundle"},{"id":12475,"name":"hiltbash","profession":"bundle"},{"id":12476,"name":"spiketrap","profession":"bundle"},{"id":12477,"name":"cripplingtalon","profession":"bundle"},{"id":12478,"name":"stalkersstrike","profession":"bundle"},{"id":12480,"name":"splitblade","profession":"bundle"},{"id":12481,"name":"hornetsting","profession":"bundle"},{"id":12482,"name":"monarchsleap","profession":"bundle"},{"id":12483,"name":"trollunguent","profession":"bundle"},{"id":12485,"name":"thunderclap","profession":"bundle"},{"id":12486,"name":"throwdirt","profession":"bundle"},{"id":12487,"name":"slice","profession":"bundle"},{"id":12488,"name":"enduringswing","profession":"bundle"},{"id":12489,"name":"healingspring","profession":"bundle"},{"id":12490,"name":"wintersbite","profession":"bundle"},{"id":12491,"name":"signetofthewild","profession":"bundle"},{"id":12492,"name":"frosttrap","profession":"bundle"},{"id":12493,"name":"stormspirit","profession":"bundle"},{"id":12494,"name":"lightningreflexes","profession":"bundle"},{"id":12495,"name":"stonespirit","profession":"bundle"},{"id":12496,"name":"vipersnest","profession":"bundle"},{"id":12497,"name":"frostspirit","profession":"bundle"},{"id":12498,"name":"sunspirit","profession":"bundle"},{"id":12499,"name":"flametrap","profession":"bundle"},{"id":12500,"name":"signetofstone","profession":"bundle"},{"id":12501,"name":"muddyterrain","profession":"bundle"},{"id":12502,"name":"signetofrenewal","profession":"bundle"},{"id":12504,"name":"bonfire","profession":"bundle"},{"id":12507,"name":"cripplingshot","profession":"bundle"},{"id":12508,"name":"concussionshot","profession":"bundle"},{"id":12509,"name":"rapidfire","profession":"bundle"},{"id":12510,"name":"longrangeshot","profession":"bundle"},{"id":12511,"name":"pointblankshot","profession":"bundle"},{"id":12515,"name":"lickwounds","profession":"bundle"},{"id":12516,"name":"strengthofthepack","profession":"bundle"},{"id":12517,"name":"quickshot","profession":"bundle"},{"id":12521,"name":"swoop","profession":"bundle"},{"id":12522,"name":"counterattack","profession":"bundle"},{"id":12523,"name":"counterattackkick","profession":"bundle"},{"id":12525,"name":"maul","profession":"bundle"},{"id":12526,"name":"splintershot","profession":"bundle"},{"id":12527,"name":"mercyshot","profession":"bundle"},{"id":12528,"name":"feedingfrenzy","profession":"bundle"},{"id":12529,"name":"coralshot","profession":"bundle"},{"id":12530,"name":"inkblast","profession":"bundle"},{"id":12533,"name":"vipersnest","profession":"bundle"},{"id":12535,"name":"frosttrap","profession":"bundle"},{"id":12537,"name":"sharpeningstone","profession":"bundle"},{"id":12542,"name":"signetofthehunt","profession":"bundle"},{"id":12550,"name":"quickeningzephyr","profession":"bundle"},{"id":12552,"name":"manowar","profession":"bundle"},{"id":12553,"name":"stab","profession":"bundle"},{"id":12555,"name":"jab","profession":"bundle"},{"id":12556,"name":"toxicstrike","profession":"bundle"},{"id":12557,"name":"surgingmaw","profession":"bundle"},{"id":12559,"name":"swirlingstrike","profession":"bundle"},{"id":12561,"name":"counterstrike","profession":"bundle"},{"id":12566,"name":"throwknife","profession":"bundle"},{"id":12569,"name":"spiritofnature","profession":"bundle"},{"id":12570,"name":"flametrap","profession":"bundle"},{"id":12573,"name":"huntersshot","profession":"bundle"},{"id":12580,"name":"entangle","profession":"bundle"},{"id":12592,"name":"solarflare","profession":"bundle"},{"id":12593,"name":"coldsnap","profession":"bundle"},{"id":12594,"name":"calllightning","profession":"bundle"},{"id":12595,"name":"quicksand","profession":"bundle"},{"id":12596,"name":"naturesrenewal","profession":"bundle"},{"id":12620,"name":"hunterscall","profession":"bundle"},{"id":12621,"name":"callofthewild","profession":"bundle"},{"id":12622,"name":"serpentsstrike","profession":"bundle"},{"id":12630,"name":"counterthrow","profession":"bundle"},{"id":12631,"name":"protectme","profession":"bundle"},{"id":12632,"name":"guard","profession":"bundle"},{"id":12633,"name":"sicem","profession":"bundle"},{"id":12635,"name":"throwtorch","profession":"bundle"},{"id":12638,"name":"pathofscars","profession":"bundle"},{"id":12639,"name":"whirlingdefense","profession":"bundle"},{"id":12656,"name":"icybite","profession":"bundle"},{"id":12658,"name":"mightyroar","profession":"bundle"},{"id":12664,"name":"rendingmaul","profession":"bundle"},{"id":12666,"name":"shakeitoff","profession":"bundle"},{"id":12667,"name":"icyroar","profession":"bundle"},{"id":12670,"name":"firebreath","profession":"bundle"},{"id":12674,"name":"poisonbarbs","profession":"bundle"},{"id":12675,"name":"poisonouscloud","profession":"bundle"},{"id":12679,"name":"rendingbarbs","profession":"bundle"},{"id":12680,"name":"rendingpounce","profession":"bundle"},{"id":12681,"name":"stalk","profession":"bundle"},{"id":12685,"name":"enfeeblingroar","profession":"bundle"},{"id":12687,"name":"poisoncloud","profession":"bundle"},{"id":12688,"name":"enfeeblingmaul","profession":"bundle"},{"id":12689,"name":"icymaul","profession":"bundle"},{"id":12690,"name":"poisonousmaul","profession":"bundle"},{"id":12691,"name":"purgeconditions","profession":"bundle"},{"id":12693,"name":"icypounce","profession":"bundle"},{"id":12695,"name":"boil","profession":"bundle"},{"id":12696,"name":"frostbreath","profession":"bundle"},{"id":12697,"name":"frostnova","profession":"bundle"},{"id":12698,"name":"lightningbreath","profession":"bundle"},{"id":12699,"name":"electrocute","profession":"bundle"},{"id":12700,"name":"poisoncloud","profession":"bundle"},{"id":12701,"name":"insectswarm","profession":"bundle"},{"id":12702,"name":"poisoncloud","profession":"bundle"},{"id":12703,"name":"regenerate","profession":"bundle"},{"id":12704,"name":"lashtailvenom","profession":"bundle"},{"id":12708,"name":"dazingscreech","profession":"bundle"},{"id":12709,"name":"dazingscreech","profession":"bundle"},{"id":12711,"name":"icyscreech","profession":"bundle"},{"id":12712,"name":"furiousscreech","profession":"bundle"},{"id":12713,"name":"protectingscreech","profession":"bundle"},{"id":12714,"name":"terrifyinghowl","profession":"bundle"},{"id":12715,"name":"intimidatinghowl","profession":"bundle"},{"id":12716,"name":"chillinghowl","profession":"bundle"},{"id":12717,"name":"regenerate","profession":"bundle"},{"id":12718,"name":"howlofthepack","profession":"bundle"},{"id":12721,"name":"chillingslash","profession":"bundle"},{"id":12722,"name":"laceratingslash","profession":"bundle"},{"id":12723,"name":"blindingslash","profession":"bundle"},{"id":12729,"name":"paralyzingvenom","profession":"bundle"},{"id":12730,"name":"weakeningvenom","profession":"bundle"},{"id":12731,"name":"deadlyvenom","profession":"bundle"},{"id":12732,"name":"forage","profession":"bundle"},{"id":12744,"name":"stunningrush","profession":"bundle"},{"id":12748,"name":"chillingwhirl","profession":"bundle"},{"id":12749,"name":"immobilizingwhirl","profession":"bundle"},{"id":12754,"name":"forage","profession":"bundle"},{"id":12755,"name":"forage","profession":"bundle"},{"id":12756,"name":"forage","profession":"bundle"},{"id":12757,"name":"feedingfrenzy","profession":"bundle"},{"id":13002,"name":"shadowstep","profession":"bundle"},{"id":13003,"name":"trailofknives","profession":"bundle"},{"id":13004,"name":"doublestrike","profession":"bundle"},{"id":13005,"name":"backstab","profession":"bundle"},{"id":13006,"name":"deathblossom","profession":"bundle"},{"id":13007,"name":"larcenousstrike","profession":"bundle"},{"id":13008,"name":"bolashot","profession":"bundle"},{"id":13009,"name":"slice","profession":"bundle"},{"id":13010,"name":"shadowstrike","profession":"bundle"},{"id":13011,"name":"unload","profession":"bundle"},{"id":13012,"name":"headshot","profession":"bundle"},{"id":13014,"name":"steal","profession":"bundle"},{"id":13015,"name":"infiltratorsstrike","profession":"bundle"},{"id":13016,"name":"flankingstrike","profession":"bundle"},{"id":13019,"name":"dancingdagger","profession":"bundle"},{"id":13020,"name":"scorpionwire","profession":"bundle"},{"id":13021,"name":"withdraw","profession":"bundle"},{"id":13022,"name":"trickshot","profession":"bundle"},{"id":13024,"name":"chokinggas","profession":"bundle"},{"id":13025,"name":"infiltratorsarrow","profession":"bundle"},{"id":13026,"name":"preparethousandneedles","profession":"bundle"},{"id":13027,"name":"hideinshadows","profession":"bundle"},{"id":13028,"name":"caltrops","profession":"bundle"},{"id":13031,"name":"pistolwhip","profession":"bundle"},{"id":13033,"name":"smokebomb","profession":"bundle"},{"id":13035,"name":"rollforinitiative","profession":"bundle"},{"id":13037,"name":"spidervenom","profession":"bundle"},{"id":13038,"name":"prepareshadowportal","profession":"bundle"},{"id":13040,"name":"shadowshot","profession":"bundle"},{"id":13041,"name":"clusterbomb","profession":"bundle"},{"id":13043,"name":"detonatecluster","profession":"bundle"},{"id":13044,"name":"blindingpowder","profession":"bundle"},{"id":13046,"name":"assassinssignet","profession":"bundle"},{"id":13050,"name":"signetofmalice","profession":"bundle"},{"id":13055,"name":"skalevenom","profession":"bundle"},{"id":13056,"name":"preparesealarea","profession":"bundle"},{"id":13057,"name":"preparepitfall","profession":"bundle"},{"id":13060,"name":"signetofshadows","profession":"bundle"},{"id":13062,"name":"signetofagility","profession":"bundle"},{"id":13064,"name":"infiltratorssignet","profession":"bundle"},{"id":13065,"name":"smokescreen","profession":"bundle"},{"id":13066,"name":"haste","profession":"bundle"},{"id":13068,"name":"shadowassault","profession":"bundle"},{"id":13069,"name":"flankingdive","profession":"bundle"},{"id":13070,"name":"towline","profession":"bundle"},{"id":13072,"name":"piercingshot","profession":"bundle"},{"id":13073,"name":"deluge","profession":"bundle"},{"id":13074,"name":"escape","profession":"bundle"},{"id":13075,"name":"cripplingshot","profession":"bundle"},{"id":13076,"name":"inkshot","profession":"bundle"},{"id":13078,"name":"smoketrail","profession":"bundle"},{"id":13079,"name":"divingknife","profession":"bundle"},{"id":13080,"name":"vanishinthedeep","profession":"bundle"},{"id":13081,"name":"cheapshot","profession":"bundle"},{"id":13082,"name":"thievesguild","profession":"bundle"},{"id":13083,"name":"disablingshot","profession":"bundle"},{"id":13084,"name":"vitalshot","profession":"bundle"},{"id":13085,"name":"daggerstorm","profession":"bundle"},{"id":13087,"name":"wildstrike","profession":"bundle"},{"id":13088,"name":"slash","profession":"bundle"},{"id":13093,"name":"devourervenom","profession":"bundle"},{"id":13096,"name":"icedrakevenom","profession":"bundle"},{"id":13097,"name":"heartseeker","profession":"bundle"},{"id":13099,"name":"sealarea","profession":"bundle"},{"id":13106,"name":"shadowreturn","profession":"bundle"},{"id":13108,"name":"lotusstrike","profession":"bundle"},{"id":13110,"name":"twistingfangs","profession":"bundle"},{"id":13111,"name":"repeater","profession":"bundle"},{"id":13112,"name":"stab","profession":"bundle"},{"id":13113,"name":"blackpowder","profession":"bundle"},{"id":13114,"name":"tacticalstrike","profession":"bundle"},{"id":13115,"name":"sneakattack","profession":"bundle"},{"id":13116,"name":"cripplingstrike","profession":"bundle"},{"id":13117,"name":"shadowrefuge","profession":"bundle"},{"id":13119,"name":"stab","profession":"bundle"},{"id":13120,"name":"jab","profession":"bundle"},{"id":13121,"name":"poisontipstrike","profession":"bundle"},{"id":13122,"name":"ninetailedstrike","profession":"bundle"},{"id":13125,"name":"deadlystrike","profession":"bundle"},{"id":13126,"name":"theripper","profession":"bundle"},{"id":13128,"name":"infiltratorsreturn","profession":"bundle"},{"id":13129,"name":"surpriseshot","profession":"bundle"},{"id":13130,"name":"breakstance","profession":"bundle"},{"id":13132,"name":"basiliskvenom","profession":"bundle"},{"id":13138,"name":"venomousknife","profession":"bundle"},{"id":13140,"name":"shadowescape","profession":"bundle"},{"id":13334,"name":"flameexpulsion","profession":"bundle"},{"id":13465,"name":"lesserelixirb","profession":"bundle"},{"id":13516,"name":"allyward","profession":"bundle"},{"id":13551,"name":"smokebomb","profession":"bundle"},{"id":13552,"name":"staticdischarge","profession":"bundle"},{"id":13677,"name":"lessersymbolofresolution","profession":"bundle"},{"id":13684,"name":"lessersymbolofprotection","profession":"bundle"},{"id":13688,"name":"lessershieldofabsorption","profession":"bundle"},{"id":13733,"name":"lesserchaosstorm","profession":"bundle"},{"id":13849,"name":"lesserwellofblood","profession":"bundle"},{"id":13906,"name":"lesserspinalshivers","profession":"bundle"},{"id":13907,"name":"lesserenfeeble","profession":"bundle"},{"id":13918,"name":"lessermarkofblood","profession":"bundle"},{"id":13938,"name":"lessermuddyterrain","profession":"bundle"},{"id":14136,"name":"lessercaltrops","profession":"bundle"},{"id":14268,"name":"recklessimpact","profession":"bundle"},{"id":14330,"name":"lesserbalancedstance","profession":"bundle"},{"id":14350,"name":"return","profession":"bundle"},{"id":14353,"name":"eviscerate","profession":"bundle"},{"id":14354,"name":"throwbolas","profession":"bundle"},{"id":14355,"name":"signetofrage","profession":"bundle"},{"id":14356,"name":"greatswordswing","profession":"bundle"},{"id":14358,"name":"hammerswing","profession":"bundle"},{"id":14359,"name":"staggeringblow","profession":"bundle"},{"id":14360,"name":"riflebutt","profession":"bundle"},{"id":14361,"name":"shieldbash","profession":"bundle"},{"id":14362,"name":"shieldstance","profession":"bundle"},{"id":14363,"name":"hamstring","profession":"bundle"},{"id":14364,"name":"severartery","profession":"bundle"},{"id":14365,"name":"gash","profession":"bundle"},{"id":14366,"name":"savageleap","profession":"bundle"},{"id":14367,"name":"flurry","profession":"bundle"},{"id":14368,"name":"frenzy","profession":"bundle"},{"id":14369,"name":"chop","profession":"bundle"},{"id":14370,"name":"doublechop","profession":"bundle"},{"id":14371,"name":"triplechop","profession":"bundle"},{"id":14372,"name":"shakeitoff","profession":"bundle"},{"id":14373,"name":"greatswordslice","profession":"bundle"},{"id":14374,"name":"brutalstrike","profession":"bundle"},{"id":14375,"name":"arcingslice","profession":"bundle"},{"id":14376,"name":"macesmash","profession":"bundle"},{"id":14377,"name":"macebash","profession":"bundle"},{"id":14378,"name":"pulverize","profession":"bundle"},{"id":14381,"name":"arcingarrow","profession":"bundle"},{"id":14384,"name":"hammerbash","profession":"bundle"},{"id":14385,"name":"hammersmash","profession":"bundle"},{"id":14386,"name":"fierceblow","profession":"bundle"},{"id":14387,"name":"earthshaker","profession":"bundle"},{"id":14388,"name":"stomp","profession":"bundle"},{"id":14389,"name":"healingsignet","profession":"bundle"},{"id":14390,"name":"throwrock","profession":"bundle"},{"id":14391,"name":"vengeance","profession":"bundle"},{"id":14392,"name":"endurepain","profession":"bundle"},{"id":14393,"name":"charge","profession":"bundle"},{"id":14394,"name":"callofvalor","profession":"bundle"},{"id":14395,"name":"brutalshot","profession":"bundle"},{"id":14396,"name":"killshot","profession":"bundle"},{"id":14398,"name":"throwaxe","profession":"bundle"},{"id":14399,"name":"whirlingaxe","profession":"bundle"},{"id":14400,"name":"riposte","profession":"bundle"},{"id":14401,"name":"mending","profession":"bundle"},{"id":14402,"name":"tothelimit","profession":"bundle"},{"id":14403,"name":"forgreatjustice","profession":"bundle"},{"id":14404,"name":"signetofmight","profession":"bundle"},{"id":14405,"name":"bannerofstrength","profession":"bundle"},{"id":14406,"name":"berserkerstance","profession":"bundle"},{"id":14407,"name":"bannerofdiscipline","profession":"bundle"},{"id":14408,"name":"banneroftactics","profession":"bundle"},{"id":14409,"name":"fearme","profession":"bundle"},{"id":14410,"name":"signetoffury","profession":"bundle"},{"id":14412,"name":"balancedstance","profession":"bundle"},{"id":14413,"name":"dolyaksignet","profession":"bundle"},{"id":14414,"name":"skullcrack","profession":"bundle"},{"id":14415,"name":"tremor","profession":"bundle"},{"id":14416,"name":"volley","profession":"bundle"},{"id":14418,"name":"dualstrike","profession":"bundle"},{"id":14419,"name":"battlestandard","profession":"bundle"},{"id":14421,"name":"cycloneaxe","profession":"bundle"},{"id":14422,"name":"eviscerate","profession":"bundle"},{"id":14423,"name":"eviscerate","profession":"bundle"},{"id":14424,"name":"eviscerate","profession":"bundle"},{"id":14425,"name":"skullcrack","profession":"bundle"},{"id":14426,"name":"skullcrack","profession":"bundle"},{"id":14427,"name":"skullcrack","profession":"bundle"},{"id":14428,"name":"flurry","profession":"bundle"},{"id":14429,"name":"flurry","profession":"bundle"},{"id":14430,"name":"flurry","profession":"bundle"},{"id":14431,"name":"dualshot","profession":"bundle"},{"id":14432,"name":"fierceshot","profession":"bundle"},{"id":14437,"name":"stab","profession":"bundle"},{"id":14438,"name":"jab","profession":"bundle"},{"id":14439,"name":"impale","profession":"bundle"},{"id":14440,"name":"marinersfrenzy","profession":"bundle"},{"id":14441,"name":"parry","profession":"bundle"},{"id":14443,"name":"whirlingstrike","profession":"bundle"},{"id":14446,"name":"rush","profession":"bundle"},{"id":14447,"name":"whirlwindattack","profession":"bundle"},{"id":14448,"name":"barbedpull","profession":"bundle"},{"id":14463,"name":"punch","profession":"bundle"},{"id":14464,"name":"kick","profession":"bundle"},{"id":14465,"name":"repeatingshot","profession":"bundle"},{"id":14466,"name":"punctureshot","profession":"bundle"},{"id":14467,"name":"knotshot","profession":"bundle"},{"id":14469,"name":"forcefulshot","profession":"bundle"},{"id":14470,"name":"forcefulshot","profession":"bundle"},{"id":14471,"name":"forcefulshot","profession":"bundle"},{"id":14472,"name":"explosiveshell","profession":"bundle"},{"id":14473,"name":"killshot","profession":"bundle"},{"id":14474,"name":"killshot","profession":"bundle"},{"id":14475,"name":"killshot","profession":"bundle"},{"id":14479,"name":"signetofstamina","profession":"bundle"},{"id":14480,"name":"tsunamislash","profession":"bundle"},{"id":14481,"name":"splitshot","profession":"bundle"},{"id":14482,"name":"hammershock","profession":"bundle"},{"id":14483,"name":"rampage","profession":"bundle"},{"id":14485,"name":"smash","profession":"bundle"},{"id":14486,"name":"bash","profession":"bundle"},{"id":14487,"name":"uppercut","profession":"bundle"},{"id":14488,"name":"kick","profession":"bundle"},{"id":14489,"name":"dash","profession":"bundle"},{"id":14490,"name":"seismicleap","profession":"bundle"},{"id":14497,"name":"finalthrust","profession":"bundle"},{"id":14498,"name":"impale","profession":"bundle"},{"id":14501,"name":"rip","profession":"bundle"},{"id":14502,"name":"kick","profession":"bundle"},{"id":14503,"name":"pommelbash","profession":"bundle"},{"id":14504,"name":"pindown","profession":"bundle"},{"id":14505,"name":"smolderingarrow","profession":"bundle"},{"id":14506,"name":"combustiveshot","profession":"bundle"},{"id":14507,"name":"counterblow","profession":"bundle"},{"id":14510,"name":"bladetrail","profession":"bundle"},{"id":14511,"name":"backbreaker","profession":"bundle"},{"id":14512,"name":"earthshaker","profession":"bundle"},{"id":14513,"name":"earthshaker","profession":"bundle"},{"id":14514,"name":"earthshaker","profession":"bundle"},{"id":14515,"name":"hammertoss","profession":"bundle"},{"id":14516,"name":"bullscharge","profession":"bundle"},{"id":14518,"name":"crushingblow","profession":"bundle"},{"id":14519,"name":"fanoffire","profession":"bundle"},{"id":14520,"name":"combustiveshot","profession":"bundle"},{"id":14521,"name":"combustiveshot","profession":"bundle"},{"id":14522,"name":"combustiveshot","profession":"bundle"},{"id":14528,"name":"bannerofdefense","profession":"bundle"},{"id":14544,"name":"forcefulshot","profession":"bundle"},{"id":14545,"name":"arcingslice","profession":"bundle"},{"id":14546,"name":"arcingslice","profession":"bundle"},{"id":14547,"name":"arcingslice","profession":"bundle"},{"id":14548,"name":"adrenalinerush","profession":"bundle"},{"id":14549,"name":"whirlingstrike","profession":"bundle"},{"id":14550,"name":"whirlingstrike","profession":"bundle"},{"id":14551,"name":"whirlingstrike","profession":"bundle"},{"id":14552,"name":"marinersshot","profession":"bundle"},{"id":14554,"name":"hundredblades","profession":"bundle"},{"id":14555,"name":"adrenalinerush","profession":"bundle"},{"id":14556,"name":"throwboulder","profession":"bundle"},{"id":14557,"name":"adrenalinerush","profession":"bundle"},{"id":14568,"name":"shakeitoff","profession":"bundle"},{"id":14569,"name":"battlestandard","profession":"bundle"},{"id":14570,"name":"bannerofdefense","profession":"bundle"},{"id":14571,"name":"bannerofdiscipline","profession":"bundle"},{"id":14572,"name":"bannerofstrength","profession":"bundle"},{"id":14573,"name":"banneroftactics","profession":"bundle"},{"id":14575,"name":"onmymark","profession":"bundle"},{"id":15072,"name":"superelixir","profession":"bundle"},{"id":15716,"name":"vaporblade","profession":"bundle"},{"id":15717,"name":"impale","profession":"bundle"},{"id":15718,"name":"dragonsclaw","profession":"bundle"},{"id":15773,"name":"agony","profession":"bundle"},{"id":15795,"name":"mistform","profession":"bundle"},{"id":15834,"name":"shieldofjudgment","profession":"bundle"},{"id":15861,"name":"return","profession":"bundle"},{"id":15862,"name":"return","profession":"bundle"},{"id":15863,"name":"flee","profession":"bundle"},{"id":16012,"name":"stomp","profession":"bundle"},{"id":16013,"name":"spit","profession":"bundle"},{"id":16014,"name":"stickyspit","profession":"bundle"},{"id":16027,"name":"leap","profession":"bundle"},{"id":16040,"name":"stomp","profession":"bundle"},{"id":16097,"name":"stickyspit","profession":"bundle"},{"id":16098,"name":"stickyspit","profession":"bundle"},{"id":16296,"name":"spin","profession":"bundle"},{"id":16298,"name":"eaten","profession":"bundle"},{"id":16301,"name":"tidalshock","profession":"bundle"},{"id":16426,"name":"sonicshriek","profession":"bundle"},{"id":16427,"name":"sonicbarrier","profession":"bundle"},{"id":16432,"name":"cloakanddagger","profession":"bundle"},{"id":16435,"name":"shadowportal","profession":"bundle"},{"id":16918,"name":"spin","profession":"bundle"},{"id":16919,"name":"punch","profession":"bundle"},{"id":16920,"name":"pound","profession":"bundle"},{"id":16921,"name":"overload","profession":"bundle"},{"id":17008,"name":"magneticleap","profession":"bundle"},{"id":17260,"name":"detonateflameblast","profession":"bundle"},{"id":17810,"name":"dropmine","profession":"bundle"},{"id":17811,"name":"magneticbomb","profession":"bundle"},{"id":17812,"name":"superspeed","profession":"bundle"},{"id":17813,"name":"fireshield","profession":"bundle"},{"id":17814,"name":"magneticaura","profession":"bundle"},{"id":17815,"name":"gluetrail","profession":"bundle"},{"id":18504,"name":"dhuumfire","profession":"bundle"},{"id":19115,"name":"reapersmark","profession":"bundle"},{"id":19116,"name":"putridmark","profession":"bundle"},{"id":19117,"name":"markofblood","profession":"bundle"},{"id":19504,"name":"taintedshackles","profession":"bundle"},{"id":20451,"name":"elixirx","profession":"bundle"},{"id":20975,"name":"laceratingslash","profession":"bundle"},{"id":21646,"name":"shieldsmash","profession":"bundle"},{"id":21647,"name":"stonesheath","profession":"bundle"},{"id":21656,"name":"arcanebrilliance","profession":"bundle"},{"id":21659,"name":"aed","profession":"bundle"},{"id":21661,"name":"staticshock","profession":"bundle"},{"id":21664,"name":"litanyofwrath","profession":"bundle"},{"id":21750,"name":"signetoftheether","profession":"bundle"},{"id":21762,"name":"signetofvampirism","profession":"bundle"},{"id":21773,"name":"waterspirit","profession":"bundle"},{"id":21775,"name":"aquasurge","profession":"bundle"},{"id":21778,"name":"skelkvenom","profession":"bundle"},{"id":21795,"name":"glacialheart","profession":"bundle"},{"id":21813,"name":"lesserendurepain","profession":"bundle"},{"id":21815,"name":"defiantstance","profession":"bundle"},{"id":22221,"name":"mistlockinstabilityearthquake","profession":"bundle"},{"id":22499,"name":"mysticrebuke","profession":"bundle"},{"id":22521,"name":"lessercleansingfire","profession":"bundle"},{"id":22572,"name":"arcanewave","profession":"bundle"},{"id":22573,"name":"rocket","profession":"bundle"},{"id":22574,"name":"rocketturret","profession":"bundle"},{"id":24287,"name":"dhuumfire","profession":"bundle"},{"id":24305,"name":"lightningrod","profession":"bundle"},{"id":24329,"name":"bunkerdown","profession":"bundle"},{"id":24356,"name":"poisonnova","profession":"bundle"},{"id":24407,"name":"renewaloffire","profession":"bundle"},{"id":24409,"name":"renewalofair","profession":"bundle"},{"id":24410,"name":"renewalofwater","profession":"bundle"},{"id":24411,"name":"renewalofearth","profession":"bundle"},{"id":24414,"name":"signetofmercy","profession":"bundle"},{"id":24544,"name":"signetofundeath","profession":"bundle"},{"id":24755,"name":"thousandcuts","profession":"bundle"},{"id":25480,"name":"shockingbolt","profession":"bundle"},{"id":25486,"name":"glyphoflesserelementals","profession":"bundle"},{"id":25487,"name":"glyphoflesserelementals","profession":"bundle"},{"id":25488,"name":"glyphofelementals","profession":"bundle"},{"id":25489,"name":"glyphofelementals","profession":"bundle"},{"id":25490,"name":"glyphofelementals","profession":"bundle"},{"id":25491,"name":"glyphofelementals","profession":"bundle"},{"id":25492,"name":"crashingwaves","profession":"bundle"},{"id":25495,"name":"glyphoflesserelementals","profession":"bundle"},{"id":25497,"name":"glyphoflesserelementals","profession":"bundle"},{"id":25498,"name":"stomp","profession":"bundle"},{"id":25499,"name":"flamebarrage","profession":"bundle"},{"id":25513,"name":"phantasmalblade","profession":"bundle"},{"id":25541,"name":"illusionoflife","profession":"bundle"},{"id":25579,"name":"lesserarcaneshield","profession":"bundle"},{"id":26557,"name":"vengefulhammers","profession":"bundle"},{"id":26644,"name":"facetofstrength","profession":"bundle"},{"id":26666,"name":"manifesttoxin","profession":"bundle"},{"id":26679,"name":"forcedengagement","profession":"bundle"},{"id":26693,"name":"resistthedarkness","profession":"bundle"},{"id":26699,"name":"unrelentingassault","profession":"bundle"},{"id":26730,"name":"anguishswipe","profession":"bundle"},{"id":26821,"name":"protectivesolace","profession":"bundle"},{"id":26937,"name":"enchanteddaggers","profession":"bundle"},{"id":26956,"name":"releasehammers","profession":"bundle"},{"id":27014,"name":"facetofelements","profession":"bundle"},{"id":27025,"name":"naturalharmony","profession":"bundle"},{"id":27063,"name":"forcefuldisplacement","profession":"bundle"},{"id":27066,"name":"miseryswipe","profession":"bundle"},{"id":27074,"name":"deathstrike","profession":"bundle"},{"id":27080,"name":"gazeofdarkness","profession":"bundle"},{"id":27107,"name":"impossibleodds","profession":"bundle"},{"id":27162,"name":"elementalblast","profession":"bundle"},{"id":27198,"name":"domeofthemists","profession":"bundle"},{"id":27220,"name":"facetoflight","profession":"bundle"},{"id":27228,"name":"infuselight","profession":"bundle"},{"id":27280,"name":"leapingslice","profession":"bundle"},{"id":27322,"name":"painabsorption","profession":"bundle"},{"id":27356,"name":"energyexpulsion","profession":"bundle"},{"id":27372,"name":"soothingstone","profession":"bundle"},{"id":27505,"name":"banishenchantment","profession":"bundle"},{"id":27510,"name":"slash","profession":"bundle"},{"id":27628,"name":"diminishsolace","profession":"bundle"},{"id":27665,"name":"fieldofthemists","profession":"bundle"},{"id":27715,"name":"purifyingessence","profession":"bundle"},{"id":27760,"name":"facetofchaos","profession":"bundle"},{"id":27792,"name":"vengefulblast","profession":"bundle"},{"id":27917,"name":"calltoanguish","profession":"bundle"},{"id":27964,"name":"echoingeruption","profession":"bundle"},{"id":27975,"name":"riteofthegreatdwarf","profession":"bundle"},{"id":27976,"name":"phasesmash","profession":"bundle"},{"id":28029,"name":"frigidblitz","profession":"bundle"},{"id":28075,"name":"chaoticrelease","profession":"bundle"},{"id":28085,"name":"legendarydragonstance","profession":"bundle"},{"id":28110,"name":"dropthehammer","profession":"bundle"},{"id":28113,"name":"burstofstrength","profession":"bundle"},{"id":28134,"name":"legendaryassassinstance","profession":"bundle"},{"id":28180,"name":"essencesap","profession":"bundle"},{"id":28195,"name":"legendarycentaurstance","profession":"bundle"},{"id":28219,"name":"empoweringmisery","profession":"bundle"},{"id":28231,"name":"phasetraversal","profession":"bundle"},{"id":28253,"name":"coalescenceofruin","profession":"bundle"},{"id":28262,"name":"crystalhibernation","profession":"bundle"},{"id":28287,"name":"embracethedarkness","profession":"bundle"},{"id":28357,"name":"searingfissure","profession":"bundle"},{"id":28379,"name":"facetofdarkness","profession":"bundle"},{"id":28382,"name":"relinquishpower","profession":"bundle"},{"id":28405,"name":"maul","profession":"bundle"},{"id":28406,"name":"jadewinds","profession":"bundle"},{"id":28409,"name":"temporalrift","profession":"bundle"},{"id":28419,"name":"legendarydwarfstance","profession":"bundle"},{"id":28427,"name":"ventariswill","profession":"bundle"},{"id":28472,"name":"shacklingwave","profession":"bundle"},{"id":28494,"name":"legendarydemonstance","profession":"bundle"},{"id":28516,"name":"inspiringreinforcement","profession":"bundle"},{"id":28549,"name":"hammerbolt","profession":"bundle"},{"id":28571,"name":"duelistspreparation","profession":"bundle"},{"id":28625,"name":"deathstrike","profession":"bundle"},{"id":28692,"name":"ignitingbrand","profession":"bundle"},{"id":28714,"name":"spearofanguish","profession":"bundle"},{"id":28797,"name":"frigiddischarge","profession":"bundle"},{"id":28815,"name":"devourbrand","profession":"bundle"},{"id":28827,"name":"venomoussphere","profession":"bundle"},{"id":28915,"name":"rapidassault","profession":"bundle"},{"id":28930,"name":"riftcontainment","profession":"bundle"},{"id":28964,"name":"riftslash","profession":"bundle"},{"id":28978,"name":"surgeofthemists","profession":"bundle"},{"id":29002,"name":"rejuvenatingassault","profession":"bundle"},{"id":29057,"name":"preparationthrust","profession":"bundle"},{"id":29082,"name":"naturalharmony","profession":"bundle"},{"id":29114,"name":"energyexpulsion","profession":"bundle"},{"id":29145,"name":"mendersrebuke","profession":"bundle"},{"id":29148,"name":"projecttranquility","profession":"bundle"},{"id":29180,"name":"rapidswipe","profession":"bundle"},{"id":29197,"name":"purifyingessence","profession":"bundle"},{"id":29209,"name":"ripostingshadows","profession":"bundle"},{"id":29233,"name":"chillingisolation","profession":"bundle"},{"id":29248,"name":"tailstab","profession":"bundle"},{"id":29256,"name":"brutalblade","profession":"bundle"},{"id":29288,"name":"wardingrift","profession":"bundle"},{"id":29310,"name":"protectivesolace","profession":"bundle"},{"id":29321,"name":"renewingwave","profession":"bundle"},{"id":29331,"name":"forcefulbash","profession":"bundle"},{"id":29371,"name":"facetofnature","profession":"bundle"},{"id":29373,"name":"healingorb","profession":"bundle"},{"id":29386,"name":"envoyofexuberance","profession":"bundle"},{"id":29393,"name":"truenature","profession":"bundle"},{"id":29414,"name":"youareallweaklings","profession":"bundle"},{"id":29415,"name":"overloadwater","profession":"bundle"},{"id":29442,"name":"liferend","profession":"bundle"},{"id":29449,"name":"lessercallofthewild","profession":"bundle"},{"id":29453,"name":"sandsquall","profession":"bundle"},{"id":29458,"name":"lifeslash","profession":"bundle"},{"id":29473,"name":"detonate","profession":"bundle"},{"id":29477,"name":"decoy","profession":"bundle"},{"id":29505,"name":"reconstructionfield","profession":"bundle"},{"id":29515,"name":"tosselixirx","profession":"bundle"},{"id":29516,"name":"impactstrike","profession":"bundle"},{"id":29518,"name":"detonatesupplycrateturrets","profession":"bundle"},{"id":29519,"name":"signetofhumility","profession":"bundle"},{"id":29522,"name":"rocketboots","profession":"bundle"},{"id":29526,"name":"wellofprecognition","profession":"bundle"},{"id":29533,"name":"wildfire","profession":"bundle"},{"id":29535,"name":"washthepainaway","profession":"bundle"},{"id":29547,"name":"bandageblast","profession":"bundle"},{"id":29548,"name":"heatsync","profession":"bundle"},{"id":29558,"name":"glyphofthetides","profession":"bundle"},{"id":29560,"name":"spitefulspirit","profession":"bundle"},{"id":29578,"name":"mimic","profession":"bundle"},{"id":29591,"name":"utilitygoggles","profession":"bundle"},{"id":29604,"name":"chillingnova","profession":"bundle"},{"id":29606,"name":"invisibleanalysis","profession":"bundle"},{"id":29613,"name":"sunderingleap","profession":"bundle"},{"id":29618,"name":"overloadearth","profession":"bundle"},{"id":29630,"name":"deflectingshot","profession":"bundle"},{"id":29639,"name":"finishingblow","profession":"bundle"},{"id":29644,"name":"gunflame","profession":"bundle"},{"id":29649,"name":"dejavu","profession":"bundle"},{"id":29665,"name":"bypasscoating","profession":"bundle"},{"id":29666,"name":"nothingcansaveyou","profession":"bundle"},{"id":29679,"name":"skullgrinder","profession":"bundle"},{"id":29705,"name":"duskstrike","profession":"bundle"},{"id":29706,"name":"overloadfire","profession":"bundle"},{"id":29709,"name":"terrify","profession":"bundle"},{"id":29712,"name":"cleansingpulse","profession":"bundle"},{"id":29716,"name":"medpackdrop","profession":"bundle"},{"id":29719,"name":"overloadair","profession":"bundle"},{"id":29722,"name":"detonateelixirx","profession":"bundle"},{"id":29739,"name":"purgegyro","profession":"bundle"},{"id":29740,"name":"graspingdarkness","profession":"bundle"},{"id":29772,"name":"bandageself","profession":"bundle"},{"id":29785,"name":"negativebash","profession":"bundle"},{"id":29786,"name":"testoffaith","profession":"bundle"},{"id":29789,"name":"symbolofenergy","profession":"bundle"},{"id":29812,"name":"lesserutilitygoggles","profession":"bundle"},{"id":29830,"name":"continuumsplit","profession":"bundle"},{"id":29840,"name":"shockshield","profession":"bundle"},{"id":29845,"name":"blazebreaker","profession":"bundle"},{"id":29852,"name":"arcdivider","profession":"bundle"},{"id":29855,"name":"nightfall","profession":"bundle"},{"id":29856,"name":"wellofrecall","profession":"bundle"},{"id":29867,"name":"chillingscythe","profession":"bundle"},{"id":29887,"name":"spearofjustice","profession":"bundle"},{"id":29889,"name":"aimassistedrocket","profession":"bundle"},{"id":29894,"name":"lessersignetofvampirism","profession":"bundle"},{"id":29902,"name":"dropgunk","profession":"bundle"},{"id":29905,"name":"stowmortarkit","profession":"bundle"},{"id":29911,"name":"weakeningcharge","profession":"bundle"},{"id":29921,"name":"shreddergyro","profession":"bundle"},{"id":29923,"name":"scorchedearth","profession":"bundle"},{"id":29940,"name":"flamesofwar","profession":"bundle"},{"id":29941,"name":"wildblow","profession":"bundle"},{"id":29948,"name":"flashfreeze","profession":"bundle"},{"id":29958,"name":"infusingterror","profession":"bundle"},{"id":29965,"name":"feelmywrath","profession":"bundle"},{"id":29968,"name":"rebound","profession":"bundle"},{"id":29977,"name":"lessersignetofmight","profession":"bundle"},{"id":29991,"name":"personalbatteringram","profession":"bundle"},{"id":30008,"name":"cyclone","profession":"bundle"},{"id":30025,"name":"purification","profession":"bundle"},{"id":30027,"name":"defensefield","profession":"bundle"},{"id":30029,"name":"shieldofcourage","profession":"bundle"},{"id":30032,"name":"elixirshell","profession":"bundle"},{"id":30039,"name":"shieldofcourage","profession":"bundle"},{"id":30047,"name":"eyeofthestorm","profession":"bundle"},{"id":30074,"name":"shatteringblow","profession":"bundle"},{"id":30077,"name":"uppercut","profession":"bundle"},{"id":30083,"name":"wingsofresolve","profession":"bundle"},{"id":30088,"name":"electrowhirl","profession":"bundle"},{"id":30101,"name":"bulwarkgyro","profession":"bundle"},{"id":30105,"name":"chilledtothebone","profession":"bundle"},{"id":30121,"name":"flashshell","profession":"bundle"},{"id":30123,"name":"searchandrescue","profession":"bundle"},{"id":30135,"name":"staffbash","profession":"bundle"},{"id":30142,"name":"bandage","profession":"bundle"},{"id":30163,"name":"gravedigger","profession":"bundle"},{"id":30166,"name":"lesserpowercleanse","profession":"bundle"},{"id":30185,"name":"berserk","profession":"bundle"},{"id":30189,"name":"bloodreckoning","profession":"bundle"},{"id":30192,"name":"lesserphantasmaldefender","profession":"bundle"},{"id":30210,"name":"hookstrike","profession":"bundle"},{"id":30225,"name":"wingsofresolve","profession":"bundle"},{"id":30229,"name":"trueshot","profession":"bundle"},{"id":30230,"name":"overchargesupplycrate","profession":"bundle"},{"id":30238,"name":"glyphofthetides","profession":"bundle"},{"id":30239,"name":"lesserhaste","profession":"bundle"},{"id":30255,"name":"lessersignetofwrath","profession":"bundle"},{"id":30258,"name":"outrage","profession":"bundle"},{"id":30262,"name":"detectionpulse","profession":"bundle"},{"id":30264,"name":"overchargesupplycrate","profession":"bundle"},{"id":30273,"name":"dragonsmaw","profession":"bundle"},{"id":30278,"name":"lifereap","profession":"bundle"},{"id":30279,"name":"chemicalfield","profession":"bundle"},{"id":30286,"name":"wingsofresolve","profession":"bundle"},{"id":30305,"name":"wellofeternity","profession":"bundle"},{"id":30307,"name":"endothermicshell","profession":"bundle"},{"id":30336,"name":"duststorm","profession":"bundle"},{"id":30337,"name":"throwmine","profession":"bundle"},{"id":30343,"name":"headbutt","profession":"bundle"},{"id":30357,"name":"medicgyro","profession":"bundle"},{"id":30359,"name":"gravitywell","profession":"bundle"},{"id":30364,"name":"processionofblades","profession":"bundle"},{"id":30369,"name":"impairingdaggers","profession":"bundle"},{"id":30371,"name":"mortarshot","profession":"bundle"},{"id":30400,"name":"channeledvigor","profession":"bundle"},{"id":30432,"name":"aftershock","profession":"bundle"},{"id":30434,"name":"punishingstrikes","profession":"bundle"},{"id":30435,"name":"berserk","profession":"bundle"},{"id":30446,"name":"waterglobe","profession":"bundle"},{"id":30448,"name":"glyphofthetides","profession":"bundle"},{"id":30461,"name":"signetofcourage","profession":"bundle"},{"id":30471,"name":"punctureshot","profession":"bundle"},{"id":30488,"name":"yoursoulismine","profession":"bundle"},{"id":30489,"name":"equalizingblow","profession":"bundle"},{"id":30501,"name":"positivestrike","profession":"bundle"},{"id":30504,"name":"soulspiral","profession":"bundle"},{"id":30519,"name":"reflexivestrike","profession":"bundle"},{"id":30520,"name":"debilitatingarc","profession":"bundle"},{"id":30521,"name":"medblaster","profession":"bundle"},{"id":30525,"name":"wellofcalamity","profession":"bundle"},{"id":30553,"name":"fragmentsoffaith","profession":"bundle"},{"id":30557,"name":"executionersscythe","profession":"bundle"},{"id":30568,"name":"distractingdaggers","profession":"bundle"},{"id":30588,"name":"medpackdrop","profession":"bundle"},{"id":30597,"name":"vault","profession":"bundle"},{"id":30599,"name":"orbitalstrike","profession":"bundle"},{"id":30614,"name":"staffstrike","profession":"bundle"},{"id":30628,"name":"huntersward","profession":"bundle"},{"id":30643,"name":"tidesoftime","profession":"bundle"},{"id":30661,"name":"banditsdefense","profession":"bundle"},{"id":30662,"name":"feeltheburn","profession":"bundle"},{"id":30665,"name":"rocketcharge","profession":"bundle"},{"id":30670,"name":"suffer","profession":"bundle"},{"id":30682,"name":"flamingflurry","profession":"bundle"},{"id":30686,"name":"longfusedpowderpack","profession":"bundle"},{"id":30693,"name":"palmstrike","profession":"bundle"},{"id":30713,"name":"thunderclap","profession":"bundle"},{"id":30725,"name":"tosselixirx","profession":"bundle"},{"id":30745,"name":"eyeofthestorm","profession":"bundle"},{"id":30747,"name":"continuumshift","profession":"bundle"},{"id":30769,"name":"echoofmemory","profession":"bundle"},{"id":30770,"name":"pulmonaryimpact","profession":"bundle"},{"id":30772,"name":"rise","profession":"bundle"},{"id":30775,"name":"duststrike","profession":"bundle"},{"id":30783,"name":"wingsofresolve","profession":"bundle"},{"id":30792,"name":"reapersshroud","profession":"bundle"},{"id":30795,"name":"lightningorb","profession":"bundle"},{"id":30799,"name":"fadingtwilight","profession":"bundle"},{"id":30800,"name":"elitemortarkit","profession":"bundle"},{"id":30814,"name":"wellofaction","profession":"bundle"},{"id":30815,"name":"sneakgyro","profession":"bundle"},{"id":30825,"name":"deathscharge","profession":"bundle"},{"id":30828,"name":"slickshoes","profession":"bundle"},{"id":30851,"name":"decapitate","profession":"bundle"},{"id":30860,"name":"deathspiral","profession":"bundle"},{"id":30864,"name":"tidalsurge","profession":"bundle"},{"id":30868,"name":"fistflurry","profession":"bundle"},{"id":30871,"name":"lightsjudgment","profession":"bundle"},{"id":30879,"name":"rupturingsmash","profession":"bundle"},{"id":30881,"name":"aed","profession":"bundle"},{"id":30885,"name":"poisongasshell","profession":"bundle"},{"id":30893,"name":"deploymine","profession":"bundle"},{"id":30961,"name":"exitreapersshroud","profession":"bundle"},{"id":30989,"name":"burningshackles","profession":"bundle"},{"id":31048,"name":"wildwhirl","profession":"bundle"},{"id":31100,"name":"calltoanguish","profession":"bundle"},{"id":31129,"name":"bound","profession":"bundle"},{"id":31159,"name":"purgingflames","profession":"bundle"},{"id":31167,"name":"sparecapacitor","profession":"bundle"},{"id":31187,"name":"dash","profession":"bundle"},{"id":31248,"name":"blastgyro","profession":"bundle"},{"id":31267,"name":"impalinglotus","profession":"bundle"},{"id":31294,"name":"jadewinds","profession":"bundle"},{"id":31295,"name":"sanctuary","profession":"bundle"},{"id":31318,"name":"lunarimpact","profession":"bundle"},{"id":31322,"name":"glyphofalignment","profession":"bundle"},{"id":31324,"name":"timebomb","profession":"bundle"},{"id":31340,"name":"distributedmagic","profession":"bundle"},{"id":31344,"name":"ghastlyrampage","profession":"bundle"},{"id":31348,"name":"glyphofalignment","profession":"bundle"},{"id":31367,"name":"spikebarrage","profession":"bundle"},{"id":31375,"name":"magicaura","profession":"bundle"},{"id":31390,"name":"heat","profession":"bundle"},{"id":31391,"name":"distributedmagic","profession":"bundle"},{"id":31392,"name":"unstablemagicspike","profession":"bundle"},{"id":31396,"name":"wickedswipe","profession":"bundle"},{"id":31401,"name":"glyphofequality","profession":"bundle"},{"id":31403,"name":"smash","profession":"bundle"},{"id":31406,"name":"seedoflife","profession":"bundle"},{"id":31407,"name":"glyphofrejuvenation","profession":"bundle"},{"id":31410,"name":"ghastlyrampage","profession":"bundle"},{"id":31411,"name":"releasecelestialavatar","profession":"bundle"},{"id":31419,"name":"magicstorm","profession":"bundle"},{"id":31438,"name":"essencesap","profession":"bundle"},{"id":31442,"name":"punch","profession":"bundle"},{"id":31451,"name":"furiouspounce","profession":"bundle"},{"id":31459,"name":"consumingflame","profession":"bundle"},{"id":31462,"name":"magicaura","profession":"bundle"},{"id":31483,"name":"hauntingaura","profession":"bundle"},{"id":31491,"name":"quickshot","profession":"bundle"},{"id":31496,"name":"sublimeconversion","profession":"bundle"},{"id":31503,"name":"naturalconvergence","profession":"bundle"},{"id":31529,"name":"distributedmagic","profession":"bundle"},{"id":31535,"name":"ancestralgrace","profession":"bundle"},{"id":31539,"name":"unstablepylon","profession":"bundle"},{"id":31544,"name":"flakshot","profession":"bundle"},{"id":31557,"name":"magicaura","profession":"bundle"},{"id":31565,"name":"ghastlyrampage","profession":"bundle"},{"id":31568,"name":"smokecloud","profession":"bundle"},{"id":31582,"name":"glyphofunity","profession":"bundle"},{"id":31607,"name":"glyphofalignment","profession":"bundle"},{"id":31622,"name":"ghastlyrampage","profession":"bundle"},{"id":31623,"name":"ghastlyprison","profession":"bundle"},{"id":31624,"name":"youwilljoinus","profession":"bundle"},{"id":31636,"name":"punch","profession":"bundle"},{"id":31639,"name":"lightningassault","profession":"bundle"},{"id":31643,"name":"cannonbarrage","profession":"bundle"},{"id":31658,"name":"glyphofequality","profession":"bundle"},{"id":31677,"name":"glyphofthestars","profession":"bundle"},{"id":31700,"name":"vinesurge","profession":"bundle"},{"id":31710,"name":"solarbeam","profession":"bundle"},{"id":31720,"name":"kick","profession":"bundle"},{"id":31721,"name":"hailofbullets","profession":"bundle"},{"id":31723,"name":"essencesap","profession":"bundle"},{"id":31727,"name":"forcefuldisplacement","profession":"bundle"},{"id":31740,"name":"glyphofunity","profession":"bundle"},{"id":31746,"name":"glyphofequality","profession":"bundle"},{"id":31747,"name":"ghastlyrampage","profession":"bundle"},{"id":31750,"name":"distributedmagic","profession":"bundle"},{"id":31760,"name":"linkedignition","profession":"bundle"},{"id":31761,"name":"flameblast","profession":"bundle"},{"id":31763,"name":"platformquake","profession":"bundle"},{"id":31765,"name":"shardsoffaith","profession":"bundle"},{"id":31769,"name":"distributedmagic","profession":"bundle"},{"id":31776,"name":"lesserseedoflife","profession":"bundle"},{"id":31788,"name":"explosion","profession":"bundle"},{"id":31792,"name":"ectoplasm","profession":"bundle"},{"id":31793,"name":"bulletstorm","profession":"bundle"},{"id":31796,"name":"cosmicray","profession":"bundle"},{"id":31819,"name":"glyphofrejuvenation","profession":"bundle"},{"id":31820,"name":"heat","profession":"bundle"},{"id":31828,"name":"unstablepylon","profession":"bundle"},{"id":31860,"name":"unstablemagicspike","profession":"bundle"},{"id":31861,"name":"spiritfury","profession":"bundle"},{"id":31867,"name":"glyphofrejuvenation","profession":"bundle"},{"id":31869,"name":"celestialavatar","profession":"bundle"},{"id":31875,"name":"spectralimpact","profession":"bundle"},{"id":31884,"name":"unstablepylon","profession":"bundle"},{"id":31885,"name":"magicaura","profession":"bundle"},{"id":31886,"name":"magicpulse","profession":"bundle"},{"id":31888,"name":"glyphofunity","profession":"bundle"},{"id":31889,"name":"astralwisp","profession":"bundle"},{"id":31894,"name":"rejuvenatingtides","profession":"bundle"},{"id":31914,"name":"wehealasone","profession":"bundle"},{"id":32242,"name":"seedoflife","profession":"bundle"},{"id":32253,"name":"rejuvenatingtides","profession":"bundle"},{"id":32364,"name":"lunarimpact","profession":"bundle"},{"id":32588,"name":"riteofthegreatdwarf","profession":"bundle"},{"id":33134,"name":"huntersverdict","profession":"bundle"},{"id":33387,"name":"cosmicray","profession":"bundle"},{"id":34070,"name":"naturalconvergence","profession":"bundle"},{"id":34112,"name":"platformcrush","profession":"bundle"},{"id":34152,"name":"timebomb","profession":"bundle"},{"id":34174,"name":"platformcrush","profession":"bundle"},{"id":34309,"name":"searchandrescue","profession":"bundle"},{"id":34326,"name":"feedback","profession":"bundle"},{"id":34335,"name":"sweep","profession":"bundle"},{"id":34336,"name":"welloftheprofane","profession":"bundle"},{"id":34343,"name":"swing","profession":"bundle"},{"id":34344,"name":"fieryvortex","profession":"bundle"},{"id":34345,"name":"unrelentingassault","profession":"bundle"},{"id":34353,"name":"swing","profession":"bundle"},{"id":34354,"name":"tormentingbite","profession":"bundle"},{"id":34356,"name":"snowstorm","profession":"bundle"},{"id":34359,"name":"jab","profession":"bundle"},{"id":34363,"name":"spontaneouscombustion","profession":"bundle"},{"id":34368,"name":"bleedingbite","profession":"bundle"},{"id":34371,"name":"oppressivegaze","profession":"bundle"},{"id":34375,"name":"flamespray","profession":"bundle"},{"id":34380,"name":"oppressivegaze","profession":"bundle"},{"id":34383,"name":"hailofbullets","profession":"bundle"},{"id":34387,"name":"volatilepoison","profession":"bundle"},{"id":34388,"name":"swing","profession":"bundle"},{"id":34396,"name":"unrelentingassault","profession":"bundle"},{"id":34398,"name":"snipe","profession":"bundle"},{"id":34404,"name":"shardsofrage","profession":"bundle"},{"id":34411,"name":"shardsofrage","profession":"bundle"},{"id":34413,"name":"surrender","profession":"bundle"},{"id":34417,"name":"flakshot","profession":"bundle"},{"id":34431,"name":"vulnerablespit","profession":"bundle"},{"id":34438,"name":"fieryspit","profession":"bundle"},{"id":34440,"name":"bloodshards","profession":"bundle"},{"id":34448,"name":"overheadsmash","profession":"bundle"},{"id":34450,"name":"unstablebloodmagic","profession":"bundle"},{"id":34455,"name":"sweep","profession":"bundle"},{"id":34460,"name":"poisonousspit","profession":"bundle"},{"id":34462,"name":"slowingthump","profession":"bundle"},{"id":34464,"name":"slowburn","profession":"bundle"},{"id":34466,"name":"fieryvortex","profession":"bundle"},{"id":34473,"name":"corruption","profession":"bundle"},{"id":34479,"name":"tantrum","profession":"bundle"},{"id":34480,"name":"bloodshards","profession":"bundle"},{"id":34481,"name":"volatilepoison","profession":"bundle"},{"id":34482,"name":"sporerelease","profession":"bundle"},{"id":34488,"name":"poisonspatter","profession":"bundle"},{"id":34503,"name":"cripplingthump","profession":"bundle"},{"id":34505,"name":"volatileaura","profession":"bundle"},{"id":34516,"name":"halitosis","profession":"bundle"},{"id":34526,"name":"heatwave","profession":"bundle"},{"id":34528,"name":"zealousbenediction","profession":"bundle"},{"id":34537,"name":"toxiccloud","profession":"bundle"},{"id":34543,"name":"thunder","profession":"bundle"},{"id":34554,"name":"downpour","profession":"bundle"},{"id":34565,"name":"toxiccloud","profession":"bundle"},{"id":34569,"name":"corrosiveresidue","profession":"bundle"},{"id":34609,"name":"glyphofelementalharmony","profession":"bundle"},{"id":34637,"name":"glyphofelementalpower","profession":"bundle"},{"id":34651,"name":"glyphofelementalharmony","profession":"bundle"},{"id":34714,"name":"glyphofelementalpower","profession":"bundle"},{"id":34724,"name":"glyphofelementalharmony","profession":"bundle"},{"id":34736,"name":"glyphofelementalpower","profession":"bundle"},{"id":34743,"name":"glyphofelementalharmony","profession":"bundle"},{"id":34772,"name":"glyphofelementalpower","profession":"bundle"},{"id":34894,"name":"magicblast","profession":"bundle"},{"id":34910,"name":"unravelingtorrent","profession":"bundle"},{"id":34913,"name":"temporalvortex","profession":"bundle"},{"id":34916,"name":"confoundingflurry","profession":"bundle"},{"id":34922,"name":"cerebralslash","profession":"bundle"},{"id":34946,"name":"constructaura","profession":"bundle"},{"id":34953,"name":"slash","profession":"bundle"},{"id":34963,"name":"chaotichaze","profession":"bundle"},{"id":34971,"name":"phantasmalblades","profession":"bundle"},{"id":35009,"name":"confoundingfrenzy","profession":"bundle"},{"id":35031,"name":"xerasfury","profession":"bundle"},{"id":35047,"name":"swipe","profession":"bundle"},{"id":35064,"name":"phantasmalblades","profession":"bundle"},{"id":35077,"name":"hailoffury","profession":"bundle"},{"id":35082,"name":"phantasmalblades","profession":"bundle"},{"id":35086,"name":"towerdrop","profession":"bundle"},{"id":35116,"name":"teleportdisplacementfield","profession":"bundle"},{"id":35128,"name":"temporalshred","profession":"bundle"},{"id":35137,"name":"phantasmalblades","profession":"bundle"},{"id":35139,"name":"tormentingdredge","profession":"bundle"},{"id":35142,"name":"backhand","profession":"bundle"},{"id":35154,"name":"facesmash","profession":"bundle"},{"id":35164,"name":"illusionaryshot","profession":"bundle"},{"id":35167,"name":"overheadsmash","profession":"bundle"},{"id":35224,"name":"elementalrequiem","profession":"bundle"},{"id":35304,"name":"dustcharge","profession":"bundle"},{"id":35637,"name":"swordofdecimation","profession":"bundle"},{"id":35822,"name":"rockthrow","profession":"bundle"},{"id":36281,"name":"summoncrablings","profession":"bundle"},{"id":36488,"name":"slash","profession":"bundle"},{"id":36995,"name":"flurry","profession":"bundle"},{"id":37060,"name":"cyclone","profession":"bundle"},{"id":37197,"name":"leap","profession":"bundle"},{"id":37607,"name":"jab","profession":"bundle"},{"id":37611,"name":"spatialmanipulation","profession":"bundle"},{"id":37613,"name":"mindcrush","profession":"bundle"},{"id":37629,"name":"spatialmanipulation","profession":"bundle"},{"id":37631,"name":"orbitalsweep","profession":"bundle"},{"id":37642,"name":"spatialmanipulation","profession":"bundle"},{"id":37660,"name":"macesmash","profession":"bundle"},{"id":37673,"name":"spatialmanipulation","profession":"bundle"},{"id":37677,"name":"soldiersaura","profession":"bundle"},{"id":37703,"name":"regret","profession":"bundle"},{"id":37716,"name":"rapiddecay","profession":"bundle"},{"id":37775,"name":"sharedagony","profession":"bundle"},{"id":37784,"name":"impact","profession":"bundle"},{"id":37788,"name":"jadeexplosion","profession":"bundle"},{"id":37797,"name":"tramplingrush","profession":"bundle"},{"id":37805,"name":"soulfeast","profession":"bundle"},{"id":37816,"name":"spearimpact","profession":"bundle"},{"id":37843,"name":"claw","profession":"bundle"},{"id":37851,"name":"inevitablebetrayal","profession":"bundle"},{"id":37872,"name":"demonicaura","profession":"bundle"},{"id":37873,"name":"channeledagony","profession":"bundle"},{"id":37881,"name":"demonicprojection","profession":"bundle"},{"id":37892,"name":"soulswarm","profession":"bundle"},{"id":37901,"name":"effigypulse","profession":"bundle"},{"id":37910,"name":"gravitywave","profession":"bundle"},{"id":37927,"name":"spearimpact","profession":"bundle"},{"id":37929,"name":"annihilate","profession":"bundle"},{"id":37940,"name":"anguishedwail","profession":"bundle"},{"id":37952,"name":"punishmentaura","profession":"bundle"},{"id":37974,"name":"tramplingrush","profession":"bundle"},{"id":37980,"name":"demonicshockwave","profession":"bundle"},{"id":37982,"name":"demonicshockwave","profession":"bundle"},{"id":37989,"name":"cosmicaura","profession":"bundle"},{"id":37996,"name":"shockwave","profession":"bundle"},{"id":38006,"name":"corporalpunishment","profession":"bundle"},{"id":38007,"name":"saulsgrace","profession":"bundle"},{"id":38013,"name":"brutalize","profession":"bundle"},{"id":38040,"name":"prisonshank","profession":"bundle"},{"id":38046,"name":"demonicshockwave","profession":"bundle"},{"id":38055,"name":"regret","profession":"bundle"},{"id":38060,"name":"energysurge","profession":"bundle"},{"id":38074,"name":"spatialmanipulation","profession":"bundle"},{"id":38094,"name":"jab","profession":"bundle"},{"id":38102,"name":"impact","profession":"bundle"},{"id":38113,"name":"displacement","profession":"bundle"},{"id":38116,"name":"regret","profession":"bundle"},{"id":38168,"name":"prisonersweep","profession":"bundle"},{"id":38180,"name":"spearreturn","profession":"bundle"},{"id":38184,"name":"enemytile","profession":"bundle"},{"id":38187,"name":"weakminded","profession":"bundle"},{"id":38208,"name":"annihilate","profession":"bundle"},{"id":38210,"name":"sharedagony","profession":"bundle"},{"id":38231,"name":"impalingstab","profession":"bundle"},{"id":38236,"name":"inevitablebetrayal","profession":"bundle"},{"id":38258,"name":"brutalaura","profession":"bundle"},{"id":38260,"name":"inevitablebetrayal","profession":"bundle"},{"id":38266,"name":"","profession":"bundle"},{"id":38268,"name":"inevitablebetrayal","profession":"bundle"},{"id":38273,"name":"cleave","profession":"bundle"},{"id":38302,"name":"spatialmanipulation","profession":"bundle"},{"id":38304,"name":"wrath","profession":"bundle"},{"id":38305,"name":"bludgeon","profession":"bundle"},{"id":38313,"name":"meteorswarm","profession":"bundle"},{"id":38314,"name":"anguishedbolt","profession":"bundle"},{"id":38451,"name":"judgmentofwar","profession":"bundle"},{"id":38748,"name":"detonaterocketturret","profession":"bundle"},{"id":38750,"name":"detonatesupplycrateturrets","profession":"bundle"},{"id":38767,"name":"unholyburst","profession":"bundle"},{"id":38844,"name":"overheadsmash","profession":"bundle"},{"id":38846,"name":"mistchargedchop","profession":"bundle"},{"id":38847,"name":"crimsondawn","profession":"bundle"},{"id":38849,"name":"spiralstrike","profession":"bundle"},{"id":38858,"name":"temporalrealignment","profession":"bundle"},{"id":38863,"name":"bigshot","profession":"bundle"},{"id":38865,"name":"crimsondawn","profession":"bundle"},{"id":38867,"name":"astralsurge","profession":"bundle"},{"id":38874,"name":"diffractiveedge","profession":"bundle"},{"id":38878,"name":"horizonstrike","profession":"bundle"},{"id":38881,"name":"crimsondawn","profession":"bundle"},{"id":38889,"name":"radiantfury","profession":"bundle"},{"id":38894,"name":"headkick","profession":"bundle"},{"id":38896,"name":"punishingkick","profession":"bundle"},{"id":38897,"name":"tawshot","profession":"bundle"},{"id":38920,"name":"solarbolt","profession":"bundle"},{"id":38924,"name":"crimsondawn","profession":"bundle"},{"id":38926,"name":"radiantfury","profession":"bundle"},{"id":38927,"name":"horizonstrike","profession":"bundle"},{"id":38941,"name":"solarbolt","profession":"bundle"},{"id":38942,"name":"whirligig","profession":"bundle"},{"id":38954,"name":"crimsondawn","profession":"bundle"},{"id":38966,"name":"starburstcascade","profession":"bundle"},{"id":38977,"name":"vault","profession":"bundle"},{"id":38982,"name":"starburstcascade","profession":"bundle"},{"id":38986,"name":"pulsarblast","profession":"bundle"},{"id":38987,"name":"crimsondawn","profession":"bundle"},{"id":38991,"name":"tawshot","profession":"bundle"},{"id":39001,"name":"horizonstrike","profession":"bundle"},{"id":39005,"name":"supernova","profession":"bundle"},{"id":39007,"name":"horizonstrike","profession":"bundle"},{"id":39011,"name":"","profession":"bundle"},{"id":39013,"name":"warp","profession":"bundle"},{"id":39018,"name":"starburstcascade","profession":"bundle"},{"id":39019,"name":"horizonstrike","profession":"bundle"},{"id":39021,"name":"cosmicstreaks","profession":"bundle"},{"id":39025,"name":"horizonstrike","profession":"bundle"},{"id":39029,"name":"redmarble","profession":"bundle"},{"id":39031,"name":"horizonstrike","profession":"bundle"},{"id":39033,"name":"crimsondawn","profession":"bundle"},{"id":39035,"name":"astralsurge","profession":"bundle"},{"id":39037,"name":"blindingradiance","profession":"bundle"},{"id":39039,"name":"solarbolt","profession":"bundle"},{"id":39053,"name":"horizonstrike","profession":"bundle"},{"id":39054,"name":"bigshot","profession":"bundle"},{"id":39063,"name":"cranialcascade","profession":"bundle"},{"id":39064,"name":"horizonstrike","profession":"bundle"},{"id":39078,"name":"plunge","profession":"bundle"},{"id":39082,"name":"lightningbolt","profession":"bundle"},{"id":39093,"name":"crimsondawn","profession":"bundle"},{"id":39099,"name":"firebreath","profession":"bundle"},{"id":39103,"name":"electrocute","profession":"bundle"},{"id":39107,"name":"mistbomb","profession":"bundle"},{"id":39110,"name":"horizonstrike","profession":"bundle"},{"id":39116,"name":"jabcombo","profession":"bundle"},{"id":39122,"name":"explode","profession":"bundle"},{"id":39133,"name":"waveofmutilation","profession":"bundle"},{"id":39135,"name":"horizonstrike","profession":"bundle"},{"id":39136,"name":"solarbolt","profession":"bundle"},{"id":39138,"name":"solarblast","profession":"bundle"},{"id":39139,"name":"focusedanger","profession":"bundle"},{"id":39146,"name":"crimsondawn","profession":"bundle"},{"id":39152,"name":"crimsondawn","profession":"bundle"},{"id":39160,"name":"tawshot","profession":"bundle"},{"id":39163,"name":"curvedshot","profession":"bundle"},{"id":39171,"name":"tawshot","profession":"bundle"},{"id":39185,"name":"astralsurge","profession":"bundle"},{"id":39186,"name":"crimsondawn","profession":"bundle"},{"id":39195,"profession":"bundle"},{"id":39198,"name":"focusedanger","profession":"bundle"},{"id":39200,"name":"discharge","profession":"bundle"},{"id":39204,"name":"focusedrage","profession":"bundle"},{"id":39212,"name":"horizonstrike","profession":"bundle"},{"id":39213,"name":"diffractiveedge","profession":"bundle"},{"id":39215,"name":"crimsondawn","profession":"bundle"},{"id":39216,"name":"explode","profession":"bundle"},{"id":39217,"name":"curvedshot","profession":"bundle"},{"id":39220,"name":"cranialcascade","profession":"bundle"},{"id":39222,"name":"bigshot","profession":"bundle"},{"id":39225,"name":"supernova","profession":"bundle"},{"id":39228,"name":"solarcyclone","profession":"bundle"},{"id":39232,"name":"tawshot","profession":"bundle"},{"id":39235,"name":"searingheat","profession":"bundle"},{"id":39238,"name":"beamingsmile","profession":"bundle"},{"id":39242,"name":"horizonstrike","profession":"bundle"},{"id":39247,"name":"obliterate","profession":"bundle"},{"id":39251,"name":"focusedrage","profession":"bundle"},{"id":39253,"name":"diffractiveedge","profession":"bundle"},{"id":39254,"name":"diffractiveedge","profession":"bundle"},{"id":39257,"name":"focusedanger","profession":"bundle"},{"id":39261,"name":"crimsondawn","profession":"bundle"},{"id":39263,"profession":"bundle"},{"id":39267,"name":"horizonstrike","profession":"bundle"},{"id":39274,"name":"starburstcascade","profession":"bundle"},{"id":39275,"name":"corporealreassignment","profession":"bundle"},{"id":39276,"name":"horizonstrike","profession":"bundle"},{"id":39278,"name":"horizonstrike","profession":"bundle"},{"id":39284,"name":"forceofthenightmare","profession":"bundle"},{"id":39291,"name":"rollingchaos","profession":"bundle"},{"id":39297,"name":"horizonstrike","profession":"bundle"},{"id":39298,"name":"solarstomp","profession":"bundle"},{"id":39299,"name":"blindingradiance","profession":"bundle"},{"id":39300,"name":"crimsondawn","profession":"bundle"},{"id":39303,"name":"solarfury","profession":"bundle"},{"id":39306,"name":"tawshot","profession":"bundle"},{"id":39308,"name":"focusedrage","profession":"bundle"},{"id":39313,"name":"solarbolt","profession":"bundle"},{"id":39319,"name":"focusedanger","profession":"bundle"},{"id":39321,"name":"supernova","profession":"bundle"},{"id":39322,"name":"curvedshot","profession":"bundle"},{"id":39323,"name":"horizonstrike","profession":"bundle"},{"id":39332,"name":"crimsondawn","profession":"bundle"},{"id":39335,"name":"horizonstrike","profession":"bundle"},{"id":39345,"name":"diffractiveedge","profession":"bundle"},{"id":39346,"name":"rollingchaos","profession":"bundle"},{"id":39350,"name":"mistbomb","profession":"bundle"},{"id":39357,"name":"globollamarble","profession":"bundle"},{"id":39363,"name":"horizonstrike","profession":"bundle"},{"id":39375,"name":"uppercut","profession":"bundle"},{"id":39377,"name":"combustionrush","profession":"bundle"},{"id":39383,"name":"starburstcascade","profession":"bundle"},{"id":39388,"name":"jabcombo","profession":"bundle"},{"id":39392,"name":"crimsondawn","profession":"bundle"},{"id":39394,"name":"cranialcascade","profession":"bundle"},{"id":39395,"name":"crimsondawn","profession":"bundle"},{"id":39398,"name":"mibring","profession":"bundle"},{"id":39401,"name":"overheadsmash","profession":"bundle"},{"id":39416,"name":"blindingradiance","profession":"bundle"},{"id":39417,"name":"tawshot","profession":"bundle"},{"id":39419,"name":"astralsurge","profession":"bundle"},{"id":39422,"name":"smallshot","profession":"bundle"},{"id":39423,"name":"horizonstrike","profession":"bundle"},{"id":39426,"name":"horizonstrike","profession":"bundle"},{"id":39427,"name":"combustionrush","profession":"bundle"},{"id":39433,"name":"flyingknee","profession":"bundle"},{"id":39434,"name":"radiantfury","profession":"bundle"},{"id":39442,"name":"blindingradiance","profession":"bundle"},{"id":39450,"name":"focusedanger","profession":"bundle"},{"id":39454,"name":"tawshot","profession":"bundle"},{"id":39458,"name":"horizonstrike","profession":"bundle"},{"id":39466,"name":"uppercut","profession":"bundle"},{"id":39469,"name":"teleportlunge","profession":"bundle"},{"id":39470,"name":"obliterate","profession":"bundle"},{"id":39478,"name":"diffractiveedge","profession":"bundle"},{"id":39479,"name":"mistchargedchop","profession":"bundle"},{"id":39482,"name":"punishingkick","profession":"bundle"},{"id":39483,"name":"crimsondawn","profession":"bundle"},{"id":39485,"name":"horizonstrike","profession":"bundle"},{"id":39491,"name":"explode","profession":"bundle"},{"id":39495,"name":"globollamarble","profession":"bundle"},{"id":39504,"name":"flyingknee","profession":"bundle"},{"id":39507,"name":"horizonstrike","profession":"bundle"},{"id":39514,"name":"warp","profession":"bundle"},{"id":39520,"name":"punishingkick","profession":"bundle"},{"id":39521,"name":"mistchargedchop","profession":"bundle"},{"id":39523,"name":"starburstcascade","profession":"bundle"},{"id":39526,"name":"focusedanger","profession":"bundle"},{"id":39534,"name":"cranialcascade","profession":"bundle"},{"id":39539,"name":"sharedshock","profession":"bundle"},{"id":39540,"name":"thwack","profession":"bundle"},{"id":39541,"name":"crimsondawn","profession":"bundle"},{"id":39551,"name":"explode","profession":"bundle"},{"id":39557,"name":"mibring","profession":"bundle"},{"id":39564,"name":"crimsondawn","profession":"bundle"},{"id":39572,"name":"diffractiveedge","profession":"bundle"},{"id":39575,"name":"mistsmash","profession":"bundle"},{"id":39579,"name":"diffractiveedge","profession":"bundle"},{"id":39581,"name":"combustionrush","profession":"bundle"},{"id":39582,"name":"headkick","profession":"bundle"},{"id":39583,"name":"horizonstrike","profession":"bundle"},{"id":39590,"name":"horizonstrike","profession":"bundle"},{"id":39602,"name":"tawshot","profession":"bundle"},{"id":39607,"name":"blindingradiance","profession":"bundle"},{"id":39609,"name":"tawshot","profession":"bundle"},{"id":39615,"name":"combustionrush","profession":"bundle"},{"id":39619,"name":"punishingkick","profession":"bundle"},{"id":39628,"name":"globollamarble","profession":"bundle"},{"id":39638,"name":"mistbomb","profession":"bundle"},{"id":39646,"name":"crimsondawn","profession":"bundle"},{"id":39648,"name":"jab","profession":"bundle"},{"id":39653,"name":"horizonstrike","profession":"bundle"},{"id":39664,"name":"solarbolt","profession":"bundle"},{"id":39667,"name":"solarfury","profession":"bundle"},{"id":39668,"name":"focusedanger","profession":"bundle"},{"id":39673,"name":"crimsondawn","profession":"bundle"},{"id":39674,"name":"rollingchaos","profession":"bundle"},{"id":39684,"name":"solarfury","profession":"bundle"},{"id":39685,"name":"horizonstrike","profession":"bundle"},{"id":39686,"name":"cranialcascade","profession":"bundle"},{"id":39691,"name":"solardischarge","profession":"bundle"},{"id":39694,"name":"focusedanger","profession":"bundle"},{"id":39701,"name":"teleportlunge","profession":"bundle"},{"id":39708,"name":"astralsurge","profession":"bundle"},{"id":39711,"name":"focusedrage","profession":"bundle"},{"id":39713,"name":"crimsondawn","profession":"bundle"},{"id":39714,"name":"horizonstrike","profession":"bundle"},{"id":39728,"name":"solarfury","profession":"bundle"},{"id":39734,"name":"rollingchaos","profession":"bundle"},{"id":39745,"name":"globollamarble","profession":"bundle"},{"id":39746,"name":"crimsondawn","profession":"bundle"},{"id":39748,"name":"tawshot","profession":"bundle"},{"id":39755,"name":"diffractiveedge","profession":"bundle"},{"id":39760,"name":"solarbolt","profession":"bundle"},{"id":39765,"name":"horizonstrike","profession":"bundle"},{"id":39770,"name":"horizonstrike","profession":"bundle"},{"id":39775,"name":"focusedrage","profession":"bundle"},{"id":39782,"name":"supernova","profession":"bundle"},{"id":39787,"name":"diffractiveedge","profession":"bundle"},{"id":39788,"name":"discharge","profession":"bundle"},{"id":39790,"name":"horizonstrike","profession":"bundle"},{"id":39795,"name":"focusedanger","profession":"bundle"},{"id":39801,"name":"corruptedground","profession":"bundle"},{"id":39816,"name":"curvedshot","profession":"bundle"},{"id":39823,"name":"solarblast","profession":"bundle"},{"id":39829,"name":"crimsondawn","profession":"bundle"},{"id":39830,"name":"diffractiveedge","profession":"bundle"},{"id":39839,"name":"horizonstrike","profession":"bundle"},{"id":39845,"name":"radiantfury","profession":"bundle"},{"id":39847,"name":"pulsarblast","profession":"bundle"},{"id":39848,"name":"solarbolt","profession":"bundle"},{"id":39849,"name":"explode","profession":"bundle"},{"id":39853,"name":"horizonstrike","profession":"bundle"},{"id":39854,"name":"horizonstrike","profession":"bundle"},{"id":39857,"name":"solarblast","profession":"bundle"},{"id":39863,"name":"redmarble","profession":"bundle"},{"id":39867,"name":"bowlermarble","profession":"bundle"},{"id":39874,"name":"solarfury","profession":"bundle"},{"id":39875,"name":"focusedanger","profession":"bundle"},{"id":39879,"name":"horizonstrike","profession":"bundle"},{"id":39884,"name":"crimsondawn","profession":"bundle"},{"id":39886,"name":"radiantfury","profession":"bundle"},{"id":39889,"name":"horizonstrike","profession":"bundle"},{"id":39894,"name":"rollingchaos","profession":"bundle"},{"id":39895,"name":"crimsondawn","profession":"bundle"},{"id":39910,"name":"punishingkick","profession":"bundle"},{"id":39911,"name":"spiralstrike","profession":"bundle"},{"id":39915,"name":"jab","profession":"bundle"},{"id":39916,"name":"combustionrush","profession":"bundle"},{"id":39920,"name":"overheadsmash","profession":"bundle"},{"id":39924,"name":"crimsondawn","profession":"bundle"},{"id":39959,"name":"waveofpanic","profession":"bundle"},{"id":39960,"name":"stealwarmth","profession":"bundle"},{"id":39964,"name":"firestrike","profession":"bundle"},{"id":39972,"name":"silencer","profession":"bundle"},{"id":39977,"name":"awakenedsoldierswing","profession":"bundle"},{"id":39981,"name":"soddenswath","profession":"bundle"},{"id":40078,"name":"firebolt","profession":"bundle"},{"id":40084,"name":"crushingblow","profession":"bundle"},{"id":40111,"name":"narcoticspores","profession":"bundle"},{"id":40133,"name":"stealresistance","profession":"bundle"},{"id":40139,"name":"rustfrenzy","profession":"bundle"},{"id":40160,"name":"radiantarc","profession":"bundle"},{"id":40170,"name":"naturalfrenzy","profession":"bundle"},{"id":40175,"name":"bloodbanepath","profession":"bundle"},{"id":40183,"name":"primordialstance","profession":"bundle"},{"id":40184,"name":"chaosvortex","profession":"bundle"},{"id":40200,"name":"falseoasis","profession":"bundle"},{"id":40229,"name":"doublelavaaxe","profession":"bundle"},{"id":40255,"name":"smokeassault","profession":"bundle"},{"id":40274,"name":"trailofanguish","profession":"bundle"},{"id":40275,"name":"keenstrike","profession":"bundle"},{"id":40301,"name":"leadingswipe","profession":"bundle"},{"id":40326,"name":"fireswipe","profession":"bundle"},{"id":40332,"name":"pressureblast","profession":"bundle"},{"id":40378,"name":"hydrothermalvent","profession":"bundle"},{"id":40436,"name":"sniperscover","profession":"bundle"},{"id":40485,"name":"icerazorsire","profession":"bundle"},{"id":40497,"name":"shattershot","profession":"bundle"},{"id":40498,"name":"vulturestance","profession":"bundle"},{"id":40507,"name":"coolantblast","profession":"bundle"},{"id":40533,"name":"launchwall","profession":"bundle"},{"id":40560,"name":"focusedslash","profession":"bundle"},{"id":40588,"name":"primalcry","profession":"bundle"},{"id":40600,"name":"kneel","profession":"bundle"},{"id":40601,"name":"earthshaker","profession":"bundle"},{"id":40614,"name":"phantasmalspinningaxe","profession":"bundle"},{"id":40624,"name":"symbolofvengeance","profession":"bundle"},{"id":40625,"name":"bite","profession":"bundle"},{"id":40643,"name":"intimidatingshout","profession":"bundle"},{"id":40709,"name":"earthenvortex","profession":"bundle"},{"id":40710,"name":"deadlyaim","profession":"bundle"},{"id":40729,"name":"worldlyimpact","profession":"bundle"},{"id":40791,"name":"giantflurry","profession":"bundle"},{"id":40794,"name":"earthensynergy","profession":"bundle"},{"id":40813,"name":"nefariousfavor","profession":"bundle"},{"id":40857,"name":"deadlykick","profession":"bundle"},{"id":40888,"name":"stealprecision","profession":"bundle"},{"id":40903,"name":"stealhealth","profession":"bundle"},{"id":40904,"name":"stealstrength","profession":"bundle"},{"id":40915,"name":"mantraofpotence","profession":"bundle"},{"id":40963,"name":"grindingstones","profession":"bundle"},{"id":41001,"name":"elementalcompression","profession":"bundle"},{"id":41052,"name":"seiche","profession":"bundle"},{"id":41065,"name":"crystalsands","profession":"bundle"},{"id":41068,"name":"freeaction","profession":"bundle"},{"id":41100,"name":"naturalhealing","profession":"bundle"},{"id":41110,"name":"skullcrack","profession":"bundle"},{"id":41119,"name":"reverberantshatter","profession":"bundle"},{"id":41123,"name":"deactivatephotonforge","profession":"bundle"},{"id":41125,"name":"plasmablast","profession":"bundle"},{"id":41156,"name":"fanggrapple","profession":"bundle"},{"id":41158,"name":"shadowflare","profession":"bundle"},{"id":41164,"name":"mirrorstrikes","profession":"bundle"},{"id":41167,"name":"aquasiphon","profession":"bundle"},{"id":41184,"name":"monsoon","profession":"bundle"},{"id":41205,"name":"bindingshadow","profession":"bundle"},{"id":41206,"name":"rainofspikes","profession":"bundle"},{"id":41218,"name":"spectrumshield","profession":"bundle"},{"id":41220,"name":"darkrazorsdaring","profession":"bundle"},{"id":41247,"name":"giantstomp","profession":"bundle"},{"id":41283,"name":"booncrusher","profession":"bundle"},{"id":41294,"name":"citadelbombardment","profession":"bundle"},{"id":41324,"name":"phantasmalseekingaxe","profession":"bundle"},{"id":41330,"name":"forcefulshot","profession":"bundle"},{"id":41372,"name":"mercy","profession":"bundle"},{"id":41380,"name":"stowtome","profession":"bundle"},{"id":41406,"name":"maul","profession":"bundle"},{"id":41422,"name":"brutalaim","profession":"bundle"},{"id":41461,"name":"devourerretreat","profession":"bundle"},{"id":41494,"name":"skirmishersshot","profession":"bundle"},{"id":41513,"name":"citadelbombardment","profession":"bundle"},{"id":41524,"name":"kick","profession":"bundle"},{"id":41537,"name":"chomp","profession":"bundle"},{"id":41543,"name":"woundingstrike","profession":"bundle"},{"id":41571,"name":"shieldoftheavenger","profession":"bundle"},{"id":41575,"name":"tailswipe","profession":"bundle"},{"id":41612,"name":"orbitalcommandstrike","profession":"bundle"},{"id":41615,"name":"serpentsiphon","profession":"bundle"},{"id":41684,"name":"flashcutterstorm","profession":"bundle"},{"id":41712,"name":"plasmicstrike","profession":"bundle"},{"id":41714,"name":"mantraofsolace","profession":"bundle"},{"id":41721,"name":"screech","profession":"bundle"},{"id":41746,"name":"whirlingstrike","profession":"bundle"},{"id":41780,"name":"tomeofresolve","profession":"bundle"},{"id":41800,"name":"serpentstab","profession":"bundle"},{"id":41820,"name":"scorchrazor","profession":"bundle"},{"id":41829,"name":"sevenshot","profession":"bundle"},{"id":41837,"name":"darkwater","profession":"bundle"},{"id":41843,"name":"prismaticsingularity","profession":"bundle"},{"id":41858,"name":"legendaryrenegadestance","profession":"bundle"},{"id":41860,"name":"slash","profession":"bundle"},{"id":41887,"name":"peck","profession":"bundle"},{"id":41908,"name":"wingbuffet","profession":"bundle"},{"id":41919,"name":"imminentthreat","profession":"bundle"},{"id":41937,"name":"deathsretreat","profession":"bundle"},{"id":42009,"name":"primelightbeam","profession":"bundle"},{"id":42041,"name":"killshot","profession":"bundle"},{"id":42042,"name":"quickeningscreech","profession":"bundle"},{"id":42163,"name":"bladeburst","profession":"bundle"},{"id":42180,"name":"blindingroar","profession":"bundle"},{"id":42181,"name":"fieryfrost","profession":"bundle"},{"id":42183,"name":"reformedmiragemirror","profession":"bundle"},{"id":42235,"name":"crystallineimpact","profession":"bundle"},{"id":42259,"name":"tomeofcourage","profession":"bundle"},{"id":42271,"name":"twinstrike","profession":"bundle"},{"id":42297,"name":"manifestsandshade","profession":"bundle"},{"id":42304,"name":"etherbarrage","profession":"bundle"},{"id":42321,"name":"piledriver","profession":"bundle"},{"id":42330,"name":"steamsurge","profession":"bundle"},{"id":42355,"name":"ghastlybreach","profession":"bundle"},{"id":42371,"name":"tomeofcourage","profession":"bundle"},{"id":42379,"name":"ashenblast","profession":"bundle"},{"id":42470,"name":"lessersignetofstone","profession":"bundle"},{"id":42475,"name":"brightslashstorm","profession":"bundle"},{"id":42494,"name":"flurry","profession":"bundle"},{"id":42521,"name":"holographicshockwave","profession":"bundle"},{"id":42575,"name":"batteringslash","profession":"bundle"},{"id":42577,"name":"lunge","profession":"bundle"},{"id":42707,"name":"arcingslice","profession":"bundle"},{"id":42717,"name":"protection","profession":"bundle"},{"id":42745,"name":"precisecut","profession":"bundle"},{"id":42752,"name":"dismisslieutenantsoulcleave","profession":"bundle"},{"id":42797,"name":"chargingbite","profession":"bundle"},{"id":42803,"name":"combustiveshot","profession":"bundle"},{"id":42809,"name":"worldlyimpact","profession":"bundle"},{"id":42836,"name":"citadelbombardment","profession":"bundle"},{"id":42842,"name":"laserdisk","profession":"bundle"},{"id":42851,"name":"mirageadvance","profession":"bundle"},{"id":42863,"name":"stealtime","profession":"bundle"},{"id":42867,"name":"shearingedge","profession":"bundle"},{"id":42894,"name":"brutalcharge","profession":"bundle"},{"id":42907,"name":"takedown","profession":"bundle"},{"id":42913,"name":"lesserstoneresonance","profession":"bundle"},{"id":42917,"name":"sandswell","profession":"bundle"},{"id":42935,"name":"desiccate","profession":"bundle"},{"id":42938,"name":"engagephotonforge","profession":"bundle"},{"id":42944,"name":"beastmode","profession":"bundle"},{"id":42949,"name":"razorclawsrage","profession":"bundle"},{"id":42954,"name":"fracturingstrike","profession":"bundle"},{"id":42963,"name":"savannahstrike","profession":"bundle"},{"id":42965,"name":"hololeap","profession":"bundle"},{"id":43014,"name":"leavebeastmode","profession":"bundle"},{"id":43060,"name":"defypain","profession":"bundle"},{"id":43064,"name":"sandthroughglass","profession":"bundle"},{"id":43068,"name":"taillash","profession":"bundle"},{"id":43074,"name":"pyrovortex","profession":"bundle"},{"id":43080,"name":"crystallinestrike","profession":"bundle"},{"id":43123,"name":"breakenchantments","profession":"bundle"},{"id":43136,"name":"bite","profession":"bundle"},{"id":43148,"name":"sandflare","profession":"bundle"},{"id":43176,"name":"flashspark","profession":"bundle"},{"id":43186,"name":"healingcloud","profession":"bundle"},{"id":43199,"name":"breakingwave","profession":"bundle"},{"id":43343,"name":"bladerenewal","profession":"bundle"},{"id":43357,"name":"mantraofliberation","profession":"bundle"},{"id":43373,"name":"stealdurability","profession":"bundle"},{"id":43375,"name":"preludelash","profession":"bundle"},{"id":43390,"name":"deadeyesmark","profession":"bundle"},{"id":43434,"name":"crystalfling","profession":"bundle"},{"id":43448,"name":"sandcascade","profession":"bundle"},{"id":43459,"name":"tarfont","profession":"bundle"},{"id":43476,"name":"sunedge","profession":"bundle"},{"id":43488,"name":"fleetingstability","profession":"bundle"},{"id":43532,"name":"magebanetether","profession":"bundle"},{"id":43536,"name":"doublearc","profession":"bundle"},{"id":43548,"name":"frenziedattack","profession":"bundle"},{"id":43565,"name":"bowoftruth","profession":"bundle"},{"id":43566,"name":"eviscerate","profession":"bundle"},{"id":43576,"name":"plasmabeam","profession":"bundle"},{"id":43616,"name":"crystalslash","profession":"bundle"},{"id":43630,"name":"ventexhaust","profession":"bundle"},{"id":43636,"name":"headtoss","profession":"bundle"},{"id":43638,"name":"weaveself","profession":"bundle"},{"id":43657,"name":"searingslash","profession":"bundle"},{"id":43671,"name":"poisongas","profession":"bundle"},{"id":43701,"name":"photosynthesize","profession":"bundle"},{"id":43726,"name":"cripplingleap","profession":"bundle"},{"id":43739,"name":"photonwall","profession":"bundle"},{"id":43745,"name":"sightbeyondsight","profession":"bundle"},{"id":43761,"name":"axesofsymmetry","profession":"bundle"},{"id":43762,"name":"pyroclasticblast","profession":"bundle"},{"id":43766,"name":"reverberantshatter","profession":"bundle"},{"id":43768,"name":"stealdefenses","profession":"bundle"},{"id":43788,"name":"calllightning","profession":"bundle"},{"id":43803,"name":"quantumstrike","profession":"bundle"},{"id":43815,"name":"frenziedpeck","profession":"bundle"},{"id":43826,"name":"searingslash","profession":"bundle"},{"id":43845,"name":"cauterize","profession":"bundle"},{"id":43916,"name":"doubletap","profession":"bundle"},{"id":43937,"name":"overheat","profession":"bundle"},{"id":43993,"name":"spiritcrush","profession":"bundle"},{"id":44004,"name":"wastrelsruin","profession":"bundle"},{"id":44076,"name":"heroiccommand","profession":"bundle"},{"id":44080,"name":"mantraoftruth","profession":"bundle"},{"id":44087,"name":"deathsjudgment","profession":"bundle"},{"id":44097,"name":"entanglingweb","profession":"bundle"},{"id":44110,"name":"refractioncutter","profession":"bundle"},{"id":44165,"name":"fullcounter","profession":"bundle"},{"id":44239,"name":"aquaticstance","profession":"bundle"},{"id":44240,"name":"lesserquickeningzephyr","profession":"bundle"},{"id":44241,"name":"splitsurge","profession":"bundle"},{"id":44260,"name":"lightstrikestorm","profession":"bundle"},{"id":44278,"name":"deadlydelivery","profession":"bundle"},{"id":44296,"name":"oppressivecollapse","profession":"bundle"},{"id":44305,"name":"needleshot","profession":"bundle"},{"id":44321,"name":"imaginaryaxes","profession":"bundle"},{"id":44360,"name":"fear","profession":"bundle"},{"id":44364,"name":"tomeofjustice","profession":"bundle"},{"id":44384,"name":"cripplinganguish","profession":"bundle"},{"id":44386,"name":"holoforgeoverheated","profession":"bundle"},{"id":44397,"name":"dissonance","profession":"bundle"},{"id":44405,"name":"riptide","profession":"bundle"},{"id":44428,"name":"garishpillar","profession":"bundle"},{"id":44451,"name":"cauterizingstrike","profession":"bundle"},{"id":44467,"name":"throwboulder","profession":"bundle"},{"id":44514,"name":"maul","profession":"bundle"},{"id":44526,"name":"stealmobility","profession":"bundle"},{"id":44530,"name":"coronaburst","profession":"bundle"},{"id":44550,"name":"lahar","profession":"bundle"},{"id":44588,"name":"lightstrike","profession":"bundle"},{"id":44591,"name":"spottersshot","profession":"bundle"},{"id":44602,"name":"bleedingedge","profession":"bundle"},{"id":44612,"name":"unravel","profession":"bundle"},{"id":44617,"name":"harmoniccry","profession":"bundle"},{"id":44626,"name":"spiritualreprieve","profession":"bundle"},{"id":44637,"name":"tailoredvictory","profession":"bundle"},{"id":44646,"name":"hardlightarena","profession":"bundle"},{"id":44652,"name":"plasmaburst","profession":"bundle"},{"id":44663,"name":"desertshroud","profession":"bundle"},{"id":44677,"name":"miragemirror","profession":"bundle"},{"id":44681,"name":"chargedstrike","profession":"bundle"},{"id":44695,"name":"threeroundburst","profession":"bundle"},{"id":44791,"name":"laceratingchop","profession":"bundle"},{"id":44840,"name":"etherealchop","profession":"bundle"},{"id":44846,"name":"swordofjustice","profession":"bundle"},{"id":44864,"name":"ambushassault","profession":"bundle"},{"id":44876,"name":"fireblast","profession":"bundle"},{"id":44885,"name":"chomp","profession":"bundle"},{"id":44918,"name":"lesserfieryeruption","profession":"bundle"},{"id":44926,"name":"stoneresonance","profession":"bundle"},{"id":44937,"name":"disruptingstab","profession":"bundle"},{"id":44946,"name":"manifestsandshade","profession":"bundle"},{"id":44948,"name":"bearstance","profession":"bundle"},{"id":44980,"name":"jacarandasembrace","profession":"bundle"},{"id":44991,"name":"swoop","profession":"bundle"},{"id":44998,"name":"polaricleap","profession":"bundle"},{"id":45010,"name":"giantkick","profession":"bundle"},{"id":45023,"name":"tomeofresolve","profession":"bundle"},{"id":45046,"name":"illusionaryambush","profession":"bundle"},{"id":45047,"name":"corecleave","profession":"bundle"},{"id":45088,"name":"maliciousrestoration","profession":"bundle"},{"id":45094,"name":"throwgunk","profession":"bundle"},{"id":45142,"name":"griffonstance","profession":"bundle"},{"id":45160,"name":"bladestorm","profession":"bundle"},{"id":45216,"name":"calllightning","profession":"bundle"},{"id":45219,"name":"deactivatephotonforge","profession":"bundle"},{"id":45230,"name":"miragethrust","profession":"bundle"},{"id":45243,"name":"lingeringthoughts","profession":"bundle"},{"id":45252,"name":"breachingstrike","profession":"bundle"},{"id":45259,"name":"polaricslash","profession":"bundle"},{"id":45313,"name":"flameuprising","profession":"bundle"},{"id":45333,"name":"windsofdisenchantment","profession":"bundle"},{"id":45353,"name":"bite","profession":"bundle"},{"id":45380,"name":"featherfootgrace","profession":"bundle"},{"id":45402,"name":"blazingedge","profession":"bundle"},{"id":45425,"name":"rainofswords","profession":"bundle"},{"id":45426,"name":"groundworkgouge","profession":"bundle"},{"id":45449,"name":"jaunt","profession":"bundle"},{"id":45460,"name":"mantraoflore","profession":"bundle"},{"id":45479,"name":"sharpenspines","profession":"bundle"},{"id":45508,"name":"shadowmeld","profession":"bundle"},{"id":45537,"name":"ordersfromabove","profession":"bundle"},{"id":45581,"name":"sunripper","profession":"bundle"},{"id":45666,"name":"mirageretreat","profession":"bundle"},{"id":45672,"name":"shadowswap","profession":"bundle"},{"id":45686,"name":"breakrazorsbastion","profession":"bundle"},{"id":45709,"name":"controlledanalysis","profession":"bundle"},{"id":45711,"name":"sandshards","profession":"bundle"},{"id":45717,"name":"onewolfpack","profession":"bundle"},{"id":45732,"name":"particleaccelerator","profession":"bundle"},{"id":45742,"name":"glacialdrift","profession":"bundle"},{"id":45743,"name":"charge","profession":"bundle"},{"id":45746,"name":"twistoffate","profession":"bundle"},{"id":45756,"name":"brightslash","profession":"bundle"},{"id":45773,"name":"soulcleavessummit","profession":"bundle"},{"id":45780,"name":"marchofundeath","profession":"bundle"},{"id":45783,"name":"photonblitz","profession":"bundle"},{"id":45789,"name":"dolyakstance","profession":"bundle"},{"id":45797,"name":"unflinchingfortitude","profession":"bundle"},{"id":45846,"name":"harrowingwave","profession":"bundle"},{"id":45890,"name":"flashcutter","profession":"bundle"},{"id":45962,"name":"intimidatingslam","profession":"bundle"},{"id":45970,"name":"moastance","profession":"bundle"},{"id":45979,"name":"gleamsaber","profession":"bundle"},{"id":45983,"name":"clapotis","profession":"bundle"},{"id":46014,"name":"stonetide","profession":"bundle"},{"id":46018,"name":"mudslide","profession":"bundle"},{"id":46024,"name":"crystallinesunder","profession":"bundle"},{"id":46044,"name":"magehunterstrike","profession":"bundle"},{"id":46123,"name":"instinctiveengage","profession":"bundle"},{"id":46140,"name":"katabaticwind","profession":"bundle"},{"id":46148,"name":"mantraofflame","profession":"bundle"},{"id":46170,"name":"hammerofwisdom","profession":"bundle"},{"id":46183,"name":"empoweringroar","profession":"bundle"},{"id":46185,"name":"moltenburst","profession":"bundle"},{"id":46233,"name":"auraslicer","profession":"bundle"},{"id":46271,"name":"needleexplosion","profession":"bundle"},{"id":46295,"name":"galestrike","profession":"bundle"},{"id":46335,"name":"shadowgust","profession":"bundle"},{"id":46360,"name":"absolutezero","profession":"bundle"},{"id":46386,"name":"taillash","profession":"bundle"},{"id":46409,"name":"legendaryrenegadestance","profession":"bundle"},{"id":46432,"name":"brutalcharge","profession":"bundle"},{"id":46447,"name":"lavaskin","profession":"bundle"},{"id":46473,"name":"manifestsandshade","profession":"bundle"},{"id":46474,"name":"manifestsandshade","profession":"bundle"},{"id":46487,"name":"blindingradiance","profession":"bundle"},{"id":46547,"name":"","profession":"bundle"},{"id":46600,"name":"bowoftruth","profession":"bundle"},{"id":46627,"name":"blindingradiance","profession":"bundle"},{"id":46629,"name":"maul","profession":"bundle"},{"id":46732,"name":"blindingradiance","profession":"bundle"},{"id":46737,"name":"blindingradiance","profession":"bundle"},{"id":46750,"name":"bowoftruth","profession":"bundle"},{"id":46843,"name":"callofthedwarf","profession":"bundle"},{"id":46847,"name":"callofthecentaur","profession":"bundle"},{"id":46849,"name":"calloftherenegade","profession":"bundle"},{"id":46854,"name":"calloftheassassin","profession":"bundle"},{"id":46856,"name":"callofthedemon","profession":"bundle"},{"id":46857,"name":"callofthedragon","profession":"bundle"},{"id":46862,"name":"flameshot","profession":"bundle"},{"id":46901,"name":"sunderingsmash","profession":"bundle"},{"id":46916,"name":"shieldbash","profession":"bundle"},{"id":46923,"name":"hundredblades","profession":"bundle"},{"id":46930,"name":"scytheassault","profession":"bundle"},{"id":46934,"name":"dwaynastempest","profession":"bundle"},{"id":46941,"name":"smite","profession":"bundle"},{"id":46980,"name":"portaltrap","profession":"bundle"},{"id":46999,"name":"scytheslash","profession":"bundle"},{"id":47005,"name":"kingswrath","profession":"bundle"},{"id":47013,"name":"hailstorm","profession":"bundle"},{"id":47022,"name":"glaciate","profession":"bundle"},{"id":47053,"profession":"bundle"},{"id":47080,"name":"scytheslash","profession":"bundle"},{"id":47115,"name":"bayonetthrust","profession":"bundle"},{"id":47120,"name":"darkaura","profession":"bundle"},{"id":47123,"name":"scytheswing","profession":"bundle"},{"id":47164,"name":"soulshackle","profession":"bundle"},{"id":47186,"profession":"bundle"},{"id":47191,"name":"soulscourge","profession":"bundle"},{"id":47205,"name":"charge","profession":"bundle"},{"id":47224,"name":"","profession":"bundle"},{"id":47245,"name":"pounce","profession":"bundle"},{"id":47258,"name":"soullesstorrent","profession":"bundle"},{"id":47260,"profession":"bundle"},{"id":47303,"name":"hungeringmiasma","profession":"bundle"},{"id":47327,"name":"vortexslash","profession":"bundle"},{"id":47331,"name":"fingersofthedead","profession":"bundle"},{"id":47356,"name":"corpsedetonation","profession":"bundle"},{"id":47360,"name":"breathofdeath","profession":"bundle"},{"id":47363,"name":"spinningslash","profession":"bundle"},{"id":47365,"name":"shatterearth","profession":"bundle"},{"id":47371,"name":"righteousflames","profession":"bundle"},{"id":47387,"name":"putridbomb","profession":"bundle"},{"id":47430,"name":"soulrift","profession":"bundle"},{"id":47453,"name":"wallofearth","profession":"bundle"},{"id":47468,"name":"dwaynaslightning","profession":"bundle"},{"id":47470,"name":"soulsiphon","profession":"bundle"},{"id":47518,"name":"piercingshadow","profession":"bundle"},{"id":47531,"name":"numbingbreach","profession":"bundle"},{"id":47533,"name":"portaltrap","profession":"bundle"},{"id":47536,"name":"portaltrap","profession":"bundle"},{"id":47561,"name":"slash","profession":"bundle"},{"id":47572,"name":"fingersofthedead","profession":"bundle"},{"id":47590,"name":"soulspiral","profession":"bundle"},{"id":47607,"name":"slice","profession":"bundle"},{"id":47626,"name":"slice","profession":"bundle"},{"id":47632,"name":"chargedshot","profession":"bundle"},{"id":47662,"name":"mysticwave","profession":"bundle"},{"id":47666,"name":"pummel","profession":"bundle"},{"id":47671,"name":"electricbomb","profession":"bundle"},{"id":47679,"name":"icebreaker","profession":"bundle"},{"id":47686,"name":"executionersscythe","profession":"bundle"},{"id":47694,"name":"triumphofwar","profession":"bundle"},{"id":47697,"name":"pummel","profession":"bundle"},{"id":47714,"name":"polymorphmoa","profession":"bundle"},{"id":47723,"name":"frozendemise","profession":"bundle"},{"id":47725,"name":"fist","profession":"bundle"},{"id":47726,"name":"slash","profession":"bundle"},{"id":47736,"name":"hailstorm","profession":"bundle"},{"id":47747,"name":"scytheshock","profession":"bundle"},{"id":47756,"name":"wurmspit","profession":"bundle"},{"id":47769,"name":"cull","profession":"bundle"},{"id":47771,"profession":"bundle"},{"id":47784,"name":"chargedshot","profession":"bundle"},{"id":47815,"name":"executionersscythe","profession":"bundle"},{"id":47824,"name":"sonicblast","profession":"bundle"},{"id":47830,"name":"razordust","profession":"bundle"},{"id":47837,"name":"chillingaura","profession":"bundle"},{"id":47842,"name":"slice","profession":"bundle"},{"id":47846,"name":"eruption","profession":"bundle"},{"id":47847,"name":"wingsofdwayna","profession":"bundle"},{"id":47867,"name":"cascadingearth","profession":"bundle"},{"id":47907,"name":"twistedlight","profession":"bundle"},{"id":47908,"name":"fingersofthedead","profession":"bundle"},{"id":47915,"name":"quadslash","profession":"bundle"},{"id":47933,"name":"rendearth","profession":"bundle"},{"id":47939,"name":"soulsiphon","profession":"bundle"},{"id":47941,"name":"balthazarsflame","profession":"bundle"},{"id":47988,"name":"avataroflyssa","profession":"bundle"},{"id":48007,"name":"imbibe","profession":"bundle"},{"id":48009,"name":"corpsedetonation","profession":"bundle"},{"id":48010,"name":"unbridledfear","profession":"bundle"},{"id":48020,"profession":"bundle"},{"id":48023,"name":"","profession":"bundle"},{"id":48038,"name":"mysticdetonation","profession":"bundle"},{"id":48066,"name":"kingswrath","profession":"bundle"},{"id":48093,"name":"razordust","profession":"bundle"},{"id":48106,"name":"shieldbash","profession":"bundle"},{"id":48108,"name":"kingswrath","profession":"bundle"},{"id":48116,"name":"","profession":"bundle"},{"id":48121,"name":"arcingaffliction","profession":"bundle"},{"id":48126,"name":"firebreath","profession":"bundle"},{"id":48128,"name":"scytheslam","profession":"bundle"},{"id":48138,"profession":"bundle"},{"id":48147,"name":"earthquake","profession":"bundle"},{"id":48150,"name":"deepabyss","profession":"bundle"},{"id":48167,"name":"scytheslash","profession":"bundle"},{"id":48172,"name":"hatefulephemera","profession":"bundle"},{"id":48176,"name":"deathmark","profession":"bundle"},{"id":48188,"profession":"bundle"},{"id":48210,"name":"greaterdeathmark","profession":"bundle"},{"id":48218,"name":"bitingaura","profession":"bundle"},{"id":48222,"name":"wingsofrage","profession":"bundle"},{"id":48235,"profession":"bundle"},{"id":48238,"name":"deathlyaura","profession":"bundle"},{"id":48260,"name":"scytheslash","profession":"bundle"},{"id":48269,"name":"ragebomb","profession":"bundle"},{"id":48272,"name":"bombshell","profession":"bundle"},{"id":48284,"name":"rendearth","profession":"bundle"},{"id":48285,"name":"shockwave","profession":"bundle"},{"id":48289,"name":"callmeteor","profession":"bundle"},{"id":48305,"name":"deathsreprise","profession":"bundle"},{"id":48309,"name":"cull","profession":"bundle"},{"id":48318,"name":"windsofchaos","profession":"bundle"},{"id":48327,"name":"corrupttheliving","profession":"bundle"},{"id":48339,"name":"righteouslightning","profession":"bundle"},{"id":48363,"name":"quadslash","profession":"bundle"},{"id":48377,"name":"deepfreeze","profession":"bundle"},{"id":48386,"name":"scytheswipe","profession":"bundle"},{"id":48387,"name":"shoot","profession":"bundle"},{"id":48389,"name":"twistedshadow","profession":"bundle"},{"id":48398,"name":"cataclysmiccycle","profession":"bundle"},{"id":48417,"name":"despairingdarkness","profession":"bundle"},{"id":48419,"profession":"bundle"},{"id":48423,"name":"callmeteor","profession":"bundle"},{"id":48432,"name":"vortexslash","profession":"bundle"},{"id":48437,"name":"jaggederuption","profession":"bundle"},{"id":48448,"name":"scytheslash","profession":"bundle"},{"id":48489,"name":"dwaynaslightning","profession":"bundle"},{"id":48500,"name":"deathbloom","profession":"bundle"},{"id":48531,"name":"rendingswipe","profession":"bundle"},{"id":48563,"profession":"bundle"},{"id":48584,"name":"conjureflame","profession":"bundle"},{"id":48601,"name":"bite","profession":"bundle"},{"id":48641,"name":"slash","profession":"bundle"},{"id":48642,"name":"slice","profession":"bundle"},{"id":48662,"name":"howlingdeath","profession":"bundle"},{"id":48664,"name":"scythespin","profession":"bundle"},{"id":48666,"name":"scytheslash","profession":"bundle"},{"id":48673,"name":"callmeteor","profession":"bundle"},{"id":48682,"name":"chargedshot","profession":"bundle"},{"id":48690,"name":"throwboulder","profession":"bundle"},{"id":48692,"name":"pathetic","profession":"bundle"},{"id":48752,"name":"cull","profession":"bundle"},{"id":48758,"name":"cull","profession":"bundle"},{"id":48760,"name":"putridbomb","profession":"bundle"},{"id":48770,"name":"avataroflyssa","profession":"bundle"},{"id":48794,"name":"hungeringaura","profession":"bundle"},{"id":48841,"name":"wurmspit","profession":"bundle"},{"id":48851,"name":"windsofchaos","profession":"bundle"},{"id":48865,"name":"razordust","profession":"bundle"},{"id":48875,"name":"fissure","profession":"bundle"},{"id":49045,"name":"cleansingfield","profession":"bundle"},{"id":49056,"name":"signetofwater","profession":"bundle"},{"id":49068,"name":"mindwrack","profession":"bundle"},{"id":49082,"name":"vitalburst","profession":"bundle"},{"id":49097,"name":"lesserelixirc","profession":"bundle"},{"id":49142,"name":"uppercut","profession":"bundle"},{"id":49154,"name":"arclightning","profession":"bundle"},{"id":49176,"name":"noxiousreek","profession":"bundle"},{"id":49237,"name":"uppercut","profession":"bundle"},{"id":49245,"name":"brandedbreath","profession":"bundle"},{"id":49722,"name":"jab","profession":"bundle"},{"id":49740,"name":"voidtail","profession":"bundle"},{"id":49765,"name":"leylinesurge","profession":"bundle"},{"id":49786,"name":"uppercut","profession":"bundle"},{"id":49794,"name":"executionersscythe","profession":"bundle"},{"id":50043,"name":"headkick","profession":"bundle"},{"id":50197,"name":"frontalblock","profession":"bundle"},{"id":50200,"name":"flyingslam","profession":"bundle"},{"id":50212,"name":"ringofcrags","profession":"bundle"},{"id":50245,"name":"jabcombo","profession":"bundle"},{"id":50255,"name":"furiousretaliation","profession":"bundle"},{"id":50373,"name":"agony","profession":"bundle"},{"id":50379,"name":"hookedspear","profession":"bundle"},{"id":50380,"name":"captureline","profession":"bundle"},{"id":50383,"name":"inspiringreinforcement","profession":"bundle"},{"id":50390,"name":"riftofpain","profession":"bundle"},{"id":50392,"name":"judgmentoflight","profession":"bundle"},{"id":50395,"name":"mistsfire","profession":"bundle"},{"id":50399,"name":"detonatelight","profession":"bundle"},{"id":50408,"name":"burstofshadows","profession":"bundle"},{"id":50410,"name":"reckoningblast","profession":"bundle"},{"id":50414,"name":"veil","profession":"bundle"},{"id":50417,"name":"maliciousdeadlystrike","profession":"bundle"},{"id":50419,"name":"mirageadvance","profession":"bundle"},{"id":50438,"name":"rocketboots","profession":"bundle"},{"id":50440,"name":"nullfield","profession":"bundle"},{"id":50441,"name":"rocketboots","profession":"bundle"},{"id":50444,"name":"infusionbomb","profession":"bundle"},{"id":50447,"name":"lightningflash","profession":"bundle"},{"id":50449,"name":"maliciousripper","profession":"bundle"},{"id":50451,"name":"malicioussurpriseshot","profession":"bundle"},{"id":50456,"name":"portalfire","profession":"bundle"},{"id":50466,"name":"malicioussneakattack","profession":"bundle"},{"id":50472,"name":"slickshoes","profession":"bundle"},{"id":50481,"name":"maliciousbackstab","profession":"bundle"},{"id":50483,"name":"torrentialmists","profession":"bundle"},{"id":50484,"name":"malicioustacticalstrike","profession":"bundle"},{"id":50491,"name":"slickshoes","profession":"bundle"},{"id":50520,"name":"drain","profession":"bundle"},{"id":50523,"name":"pulverizingleap","profession":"bundle"},{"id":50594,"name":"lightningstorm","profession":"bundle"},{"id":50601,"name":"lightningbolt","profession":"bundle"},{"id":50630,"name":"shadowsiphon","profession":"bundle"},{"id":50637,"name":"webspray","profession":"bundle"},{"id":50660,"name":"clingingshadows","profession":"bundle"},{"id":50661,"name":"charge","profession":"bundle"},{"id":50668,"name":"pulverizingleap","profession":"bundle"},{"id":50685,"name":"lifeslash","profession":"bundle"},{"id":50752,"name":"slashingwinds","profession":"bundle"},{"id":50771,"name":"stormsummoning","profession":"bundle"},{"id":50787,"name":"savagestrike","profession":"bundle"},{"id":50801,"name":"shadowbolt","profession":"bundle"},{"id":50817,"name":"corruptedclaws","profession":"bundle"},{"id":50823,"name":"agonizingswipe","profession":"bundle"},{"id":50828,"name":"disintegrationblast","profession":"bundle"},{"id":50833,"name":"venomousfangs","profession":"bundle"},{"id":50858,"name":"lifereap","profession":"bundle"},{"id":50859,"name":"slash","profession":"bundle"},{"id":50861,"name":"shadowbolt","profession":"bundle"},{"id":50926,"name":"webnet","profession":"bundle"},{"id":50928,"name":"venomousfangs","profession":"bundle"},{"id":50930,"name":"webpull","profession":"bundle"},{"id":50960,"name":"bloodyspin","profession":"bundle"},{"id":50970,"name":"bloodyfeed","profession":"bundle"},{"id":50978,"name":"spectralflame","profession":"bundle"},{"id":50984,"name":"pulverizingleap","profession":"bundle"},{"id":50999,"name":"stormblast","profession":"bundle"},{"id":51004,"name":"shadeclaw","profession":"bundle"},{"id":51039,"name":"disintegrationblast","profession":"bundle"},{"id":51074,"name":"shadedart","profession":"bundle"},{"id":51086,"name":"stormsummoning","profession":"bundle"},{"id":51093,"name":"agonizingrune","profession":"bundle"},{"id":51105,"name":"bloodyleap","profession":"bundle"},{"id":51120,"name":"agonizingrune","profession":"bundle"},{"id":51138,"name":"wakeofdisintegration","profession":"bundle"},{"id":51155,"name":"lightningstorm","profession":"bundle"},{"id":51169,"name":"bloodyslice","profession":"bundle"},{"id":51202,"name":"shadowrift","profession":"bundle"},{"id":51273,"name":"liferend","profession":"bundle"},{"id":51321,"name":"soulleach","profession":"bundle"},{"id":51349,"name":"shadowblast","profession":"bundle"},{"id":51364,"name":"agonizingswipe","profession":"bundle"},{"id":51380,"name":"slash","profession":"bundle"},{"id":51385,"name":"pounce","profession":"bundle"},{"id":51395,"name":"spiketrap","profession":"bundle"},{"id":51635,"profession":"bundle"},{"id":51638,"profession":"bundle"},{"id":51639,"profession":"bundle"},{"id":51641,"profession":"bundle"},{"id":51645,"name":"seekingjudgment","profession":"bundle"},{"id":51646,"name":"transmutefrost","profession":"bundle"},{"id":51647,"name":"devouringdarkness","profession":"bundle"},{"id":51660,"name":"searinglight","profession":"bundle"},{"id":51662,"name":"transmutelightning","profession":"bundle"},{"id":51667,"name":"truenature","profession":"bundle"},{"id":51675,"name":"truenature","profession":"bundle"},{"id":51684,"name":"transmuteearth","profession":"bundle"},{"id":51696,"name":"truenature","profession":"bundle"},{"id":51698,"name":"elementalblast","profession":"bundle"},{"id":51711,"name":"transmutefire","profession":"bundle"},{"id":51713,"name":"truenature","profession":"bundle"},{"id":51714,"name":"truenature","profession":"bundle"},{"id":51718,"name":"flameslash","profession":"bundle"},{"id":51721,"name":"lavarift","profession":"bundle"},{"id":51727,"name":"aquaticassassin","profession":"bundle"},{"id":51735,"name":"junkfall","profession":"bundle"},{"id":51738,"name":"wingbuffet","profession":"bundle"},{"id":51759,"name":"waveofforce","profession":"bundle"},{"id":51761,"name":"mistmeteorite","profession":"bundle"},{"id":51771,"name":"aidofthewaterdjinn","profession":"bundle"},{"id":51776,"name":"aquaticslash","profession":"bundle"},{"id":51802,"name":"incinerationorb","profession":"bundle"},{"id":51823,"name":"teleport","profession":"bundle"},{"id":51825,"name":"tidalsurge","profession":"bundle"},{"id":51828,"name":"thornypredicament","profession":"bundle"},{"id":51843,"name":"buoyancy","profession":"bundle"},{"id":51849,"name":"aidofthewaterdjinn","profession":"bundle"},{"id":51879,"name":"bodyofflame","profession":"bundle"},{"id":51909,"profession":"bundle"},{"id":51918,"name":"flamingcascade","profession":"bundle"},{"id":51923,"name":"shatteredearth","profession":"bundle"},{"id":51937,"name":"scepterbeam","profession":"bundle"},{"id":51952,"name":"candyburst","profession":"bundle"},{"id":51956,"name":"ripper","profession":"bundle"},{"id":51958,"name":"slash","profession":"bundle"},{"id":51961,"name":"meteor","profession":"bundle"},{"id":51963,"name":"sunderedplatform","profession":"bundle"},{"id":51965,"name":"vaporjet","profession":"bundle"},{"id":51969,"name":"fireball","profession":"bundle"},{"id":51975,"name":"djinnsgaze","profession":"bundle"},{"id":51977,"name":"aquaticbarrage","profession":"bundle"},{"id":51979,"name":"dualbite","profession":"bundle"},{"id":51989,"name":"dregdetritus","profession":"bundle"},{"id":51999,"name":"cycloneburst","profession":"bundle"},{"id":52005,"name":"aquaticaura","profession":"bundle"},{"id":52013,"name":"brandedvortex","profession":"bundle"},{"id":52030,"name":"incinerationorb","profession":"bundle"},{"id":52054,"name":"summon","profession":"bundle"},{"id":52057,"name":"fireball","profession":"bundle"},{"id":52063,"name":"mythwrightdischarge","profession":"bundle"},{"id":52082,"profession":"bundle"},{"id":52086,"name":"junkabsorption","profession":"bundle"},{"id":52116,"name":"largosdomain","profession":"bundle"},{"id":52120,"name":"junkfall","profession":"bundle"},{"id":52123,"name":"slash","profession":"bundle"},{"id":52125,"name":"brandstoneimpact","profession":"bundle"},{"id":52130,"name":"aquaticvortex","profession":"bundle"},{"id":52131,"name":"wintersdayaura","profession":"bundle"},{"id":52135,"name":"sharksplash","profession":"bundle"},{"id":52150,"name":"junktorrent","profession":"bundle"},{"id":52159,"name":"fireball","profession":"bundle"},{"id":52161,"name":"rupturedground","profession":"bundle"},{"id":52167,"name":"plop","profession":"bundle"},{"id":52173,"name":"pulverize","profession":"bundle"},{"id":52191,"name":"ectoplasmicflame","profession":"bundle"},{"id":52200,"name":"teleport","profession":"bundle"},{"id":52202,"name":"belch","profession":"bundle"},{"id":52221,"name":"claw","profession":"bundle"},{"id":52224,"name":"firewave","profession":"bundle"},{"id":52242,"name":"shatteringimpact","profession":"bundle"},{"id":52248,"name":"whiplash","profession":"bundle"},{"id":52254,"name":"brandstoneslash","profession":"bundle"},{"id":52265,"name":"riposte","profession":"bundle"},{"id":52281,"name":"swap","profession":"bundle"},{"id":52294,"name":"presentsforall","profession":"bundle"},{"id":52310,"name":"bighit","profession":"bundle"},{"id":52320,"name":"aidofthewaterdjinn","profession":"bundle"},{"id":52321,"name":"fracturedbrand","profession":"bundle"},{"id":52323,"name":"volcanicgeyser","profession":"bundle"},{"id":52330,"name":"seismicstomp","profession":"bundle"},{"id":52333,"name":"flameslash","profession":"bundle"},{"id":52334,"name":"flameslash","profession":"bundle"},{"id":52361,"name":"sharksplash","profession":"bundle"},{"id":52365,"name":"foostivooflail","profession":"bundle"},{"id":52370,"name":"conjuredslash","profession":"bundle"},{"id":52374,"name":"aquaticdomain","profession":"bundle"},{"id":52383,"name":"firedance","profession":"bundle"},{"id":52389,"name":"blaze","profession":"bundle"},{"id":52406,"name":"heavyimpact","profession":"bundle"},{"id":52415,"name":"icybreath","profession":"bundle"},{"id":52416,"name":"noxiousperfume","profession":"bundle"},{"id":52422,"name":"shatter","profession":"bundle"},{"id":52428,"name":"heavylanding","profession":"bundle"},{"id":52444,"name":"spiritscream","profession":"bundle"},{"id":52446,"name":"fallingdebris","profession":"bundle"},{"id":52452,"name":"firetrail","profession":"bundle"},{"id":52461,"name":"seaofflame","profession":"bundle"},{"id":52462,"name":"bighit","profession":"bundle"},{"id":52471,"name":"swap","profession":"bundle"},{"id":52477,"name":"aquaticdetainment","profession":"bundle"},{"id":52479,"name":"pulverize","profession":"bundle"},{"id":52489,"name":"aquaticassassin","profession":"bundle"},{"id":52493,"name":"whirlingslash","profession":"bundle"},{"id":52507,"name":"sharksplash","profession":"bundle"},{"id":52512,"name":"incinerationorb","profession":"bundle"},{"id":52520,"name":"elementalbreath","profession":"bundle"},{"id":52522,"name":"burningcrucible","profession":"bundle"},{"id":52525,"name":"leap","profession":"bundle"},{"id":52528,"name":"flameslash","profession":"bundle"},{"id":52583,"name":"throwminion","profession":"bundle"},{"id":52587,"name":"inferno","profession":"bundle"},{"id":52612,"name":"fireball","profession":"bundle"},{"id":52613,"name":"seismicstomp","profession":"bundle"},{"id":52614,"name":"firedance","profession":"bundle"},{"id":52636,"profession":"bundle"},{"id":52637,"profession":"bundle"},{"id":52646,"name":"aquaticslash","profession":"bundle"},{"id":52654,"name":"crystallineimpact","profession":"bundle"},{"id":52656,"name":"tremor","profession":"bundle"},{"id":52665,"name":"brandstoneslash","profession":"bundle"},{"id":52669,"name":"bouquettoss","profession":"bundle"},{"id":52672,"profession":"bundle"},{"id":52673,"name":"incinerationorb","profession":"bundle"},{"id":52692,"name":"wingbuffet","profession":"bundle"},{"id":52695,"name":"aidofthewaterdjinn","profession":"bundle"},{"id":52700,"name":"plop","profession":"bundle"},{"id":52705,"name":"tailswipe","profession":"bundle"},{"id":52716,"name":"vaporousstrike","profession":"bundle"},{"id":52726,"name":"firebreath","profession":"bundle"},{"id":52734,"name":"wingbuffet","profession":"bundle"},{"id":52748,"name":"firebreath","profession":"bundle"},{"id":52775,"name":"seaofflame","profession":"bundle"},{"id":52779,"name":"aquaticaura","profession":"bundle"},{"id":52791,"name":"meteor","profession":"bundle"},{"id":52793,"name":"leap","profession":"bundle"},{"id":52811,"name":"aidofthewaterdjinn","profession":"bundle"},{"id":52812,"name":"tidalpool","profession":"bundle"},{"id":52814,"name":"flamewave","profession":"bundle"},{"id":52820,"name":"firewave","profession":"bundle"},{"id":52843,"name":"thunderclap","profession":"bundle"},{"id":52862,"name":"teleport","profession":"bundle"},{"id":52864,"name":"firedance","profession":"bundle"},{"id":52876,"name":"vaporrush","profession":"bundle"},{"id":52878,"name":"junkfall","profession":"bundle"},{"id":52884,"profession":"bundle"},{"id":52892,"name":"pull","profession":"bundle"},{"id":52906,"name":"incinerationorb","profession":"bundle"},{"id":52931,"name":"aquaticdetainment","profession":"bundle"},{"id":52933,"name":"swordspin","profession":"bundle"},{"id":52934,"name":"geyserslam","profession":"bundle"},{"id":52941,"name":"fierymeteor","profession":"bundle"},{"id":52956,"name":"dregflop","profession":"bundle"},{"id":52969,"name":"firestreak","profession":"bundle"},{"id":53011,"name":"claw","profession":"bundle"},{"id":53013,"name":"fireball","profession":"bundle"},{"id":53018,"name":"seaswell","profession":"bundle"},{"id":53038,"name":"sear","profession":"bundle"},{"id":53047,"name":"fireball","profession":"bundle"},{"id":53051,"name":"teleport","profession":"bundle"},{"id":53064,"name":"meteor","profession":"bundle"},{"id":53065,"name":"risingheat","profession":"bundle"},{"id":53072,"name":"detonate","profession":"bundle"},{"id":53089,"name":"aidofthewaterdjinn","profession":"bundle"},{"id":53093,"name":"incinerationorb","profession":"bundle"},{"id":53100,"name":"vaporousstrike","profession":"bundle"},{"id":53101,"profession":"bundle"},{"id":53102,"name":"firedance","profession":"bundle"},{"id":53105,"name":"tailswipe","profession":"bundle"},{"id":53130,"name":"geyser","profession":"bundle"},{"id":53134,"name":"frigidaura","profession":"bundle"},{"id":53146,"name":"fireball","profession":"bundle"},{"id":53153,"name":"firedance","profession":"bundle"},{"id":53446,"name":"frostpatch","profession":"bundle"},{"id":53452,"name":"frosttomb","profession":"bundle"},{"id":53463,"name":"icecone","profession":"bundle"},{"id":53464,"name":"blizzard","profession":"bundle"},{"id":53475,"name":"juttingicespikes","profession":"bundle"},{"id":53478,"name":"coldheartedaura","profession":"bundle"},{"id":53482,"name":"glacialblow","profession":"bundle"},{"id":53496,"name":"numbingbreach","profession":"bundle"},{"id":53511,"name":"giantsnowball","profession":"bundle"},{"id":53514,"name":"giantsnowball","profession":"bundle"},{"id":53520,"name":"snowball","profession":"bundle"},{"id":53531,"name":"juttingicespikes","profession":"bundle"},{"id":53537,"name":"slam","profession":"bundle"},{"id":53540,"name":"frostpatch","profession":"bundle"},{"id":53544,"name":"juttingicespikes","profession":"bundle"},{"id":53548,"name":"elixire","profession":"bundle"},{"id":53549,"name":"aurorabeam","profession":"bundle"},{"id":53567,"name":"fetidfog","profession":"bundle"},{"id":53585,"name":"mineexplosion","profession":"bundle"},{"id":53586,"name":"explosivelongshot","profession":"bundle"},{"id":53591,"name":"deathlychill","profession":"bundle"},{"id":53598,"name":"scattergrenade","profession":"bundle"},{"id":53601,"name":"brandgust","profession":"bundle"},{"id":53649,"name":"staticgrenade","profession":"bundle"},{"id":53663,"name":"frostshard","profession":"bundle"},{"id":53675,"name":"brandgust","profession":"bundle"},{"id":53678,"name":"brandstoneimpact","profession":"bundle"},{"id":53707,"name":"comet","profession":"bundle"},{"id":53727,"name":"cindercyclone","profession":"bundle"},{"id":53749,"name":"throwaxe","profession":"bundle"},{"id":53758,"name":"phantomblast","profession":"bundle"},{"id":53762,"name":"brandsquall","profession":"bundle"},{"id":53784,"name":"piranhasofthedeep","profession":"bundle"},{"id":53797,"name":"brandgust","profession":"bundle"},{"id":53828,"name":"deathlychill","profession":"bundle"},{"id":53847,"name":"smash","profession":"bundle"},{"id":53867,"name":"roaringbrand","profession":"bundle"},{"id":53926,"name":"lifesiphon","profession":"bundle"},{"id":53934,"name":"cadaversconfetti","profession":"bundle"},{"id":53968,"name":"sharedshock","profession":"bundle"},{"id":53983,"name":"cripplingdagger","profession":"bundle"},{"id":54011,"name":"doublestrike","profession":"bundle"},{"id":54029,"name":"brandsquall","profession":"bundle"},{"id":54050,"name":"grimlagoon","profession":"bundle"},{"id":54053,"name":"webleedfire","profession":"bundle"},{"id":54070,"name":"slash","profession":"bundle"},{"id":54083,"name":"piercingpeck","profession":"bundle"},{"id":54109,"name":"piranhasofthedeep","profession":"bundle"},{"id":54120,"name":"heartseeker","profession":"bundle"},{"id":54123,"name":"brandstoneslash","profession":"bundle"},{"id":54125,"name":"piranhasofthedeep","profession":"bundle"},{"id":54133,"name":"bloodybludgeon","profession":"bundle"},{"id":54139,"profession":"bundle"},{"id":54164,"name":"phantomdamnation","profession":"bundle"},{"id":54201,"name":"charge","profession":"bundle"},{"id":54243,"name":"stormfall","profession":"bundle"},{"id":54261,"name":"throwbomb","profession":"bundle"},{"id":54284,"name":"buccaneersboot","profession":"bundle"},{"id":54293,"name":"lotusstrike","profession":"bundle"},{"id":54295,"name":"cindercyclone","profession":"bundle"},{"id":54300,"name":"piranhasofthedeep","profession":"bundle"},{"id":54324,"name":"freezegrenade","profession":"bundle"},{"id":54348,"name":"webleedfire","profession":"bundle"},{"id":54394,"name":"cindercyclone","profession":"bundle"},{"id":54410,"name":"tailswipe","profession":"bundle"},{"id":54413,"name":"disruptingdagger","profession":"bundle"},{"id":54428,"name":"chop","profession":"bundle"},{"id":54445,"name":"cutlasscarve","profession":"bundle"},{"id":54463,"name":"scurvyprick","profession":"bundle"},{"id":54496,"profession":"bundle"},{"id":54532,"name":"greatbludgeoning","profession":"bundle"},{"id":54544,"name":"steadfaststrike","profession":"bundle"},{"id":54581,"name":"waterblast","profession":"bundle"},{"id":54585,"name":"brandgust","profession":"bundle"},{"id":54619,"name":"wraithslightning","profession":"bundle"},{"id":54620,"name":"energywave","profession":"bundle"},{"id":54626,"name":"flameseeker","profession":"bundle"},{"id":54688,"name":"throwanchor","profession":"bundle"},{"id":54699,"name":"deathlychill","profession":"bundle"},{"id":54700,"name":"wildstrike","profession":"bundle"},{"id":54744,"name":"tailslam","profession":"bundle"},{"id":54748,"name":"hack","profession":"bundle"},{"id":54749,"name":"teethfromthedeep","profession":"bundle"},{"id":54804,"name":"brandstoneslash","profession":"bundle"},{"id":54806,"name":"macesmash","profession":"bundle"},{"id":54823,"name":"crushingblow","profession":"bundle"},{"id":54849,"name":"frostblades","profession":"bundle"},{"id":54870,"name":"sandstormshroud","profession":"bundle"},{"id":55019,"name":"swordofjustice","profession":"bundle"},{"id":55024,"name":"glyphofthestars","profession":"bundle"},{"id":55027,"name":"swordofjustice","profession":"bundle"},{"id":55029,"name":"ancientecho","profession":"bundle"},{"id":55031,"name":"swipe","profession":"bundle"},{"id":55035,"name":"shieldoftheavenger","profession":"bundle"},{"id":55037,"name":"shieldoftheavenger","profession":"bundle"},{"id":55038,"name":"soulgrasp","profession":"bundle"},{"id":55040,"name":"hammerofwisdom","profession":"bundle"},{"id":55046,"name":"glyphofthestars","profession":"bundle"},{"id":55050,"name":"soulgrasp","profession":"bundle"},{"id":55053,"name":"hammerofwisdom","profession":"bundle"},{"id":55131,"name":"wispofwill","profession":"bundle"},{"id":55244,"name":"unearthlyfissure","profession":"bundle"},{"id":55258,"name":"hungeringmiasma","profession":"bundle"},{"id":55316,"name":"barrage","profession":"bundle"},{"id":55342,"name":"ambush","profession":"bundle"},{"id":55406,"name":"icebomb","profession":"bundle"},{"id":55549,"name":"crushingblow","profession":"bundle"},{"id":55596,"name":"slash","profession":"bundle"},{"id":55845,"name":"unearthlyfissure","profession":"bundle"},{"id":55907,"name":"wispofwill","profession":"bundle"},{"id":55941,"name":"markofanguish","profession":"bundle"},{"id":56012,"profession":"bundle"},{"id":56017,"name":"forceofhavoc","profession":"bundle"},{"id":56020,"name":"energizedaffliction","profession":"bundle"},{"id":56035,"name":"quantumquake","profession":"bundle"},{"id":56038,"name":"unbearablepower","profession":"bundle"},{"id":56040,"name":"blindingradiance","profession":"bundle"},{"id":56042,"name":"sandgeyser","profession":"bundle"},{"id":56047,"profession":"bundle"},{"id":56049,"name":"terraform","profession":"bundle"},{"id":56055,"name":"dynamicdeterrent","profession":"bundle"},{"id":56056,"name":"brandstoneslash","profession":"bundle"},{"id":56064,"profession":"bundle"},{"id":56068,"name":"chaoticsurcharge","profession":"bundle"},{"id":56070,"profession":"bundle"},{"id":56072,"profession":"bundle"},{"id":56077,"profession":"bundle"},{"id":56078,"name":"etherstrikes","profession":"bundle"},{"id":56083,"name":"","profession":"bundle"},{"id":56092,"profession":"bundle"},{"id":56093,"name":"exponentialrepercussion","profession":"bundle"},{"id":56094,"name":"wallopingwind","profession":"bundle"},{"id":56098,"name":"ruinousnova","profession":"bundle"},{"id":56105,"name":"","profession":"bundle"},{"id":56114,"name":"diamondpalisade","profession":"bundle"},{"id":56128,"profession":"bundle"},{"id":56134,"name":"forceofretaliation","profession":"bundle"},{"id":56141,"name":"stalagmites","profession":"bundle"},{"id":56143,"name":"","profession":"bundle"},{"id":56145,"name":"chaoscalled","profession":"bundle"},{"id":56148,"profession":"bundle"},{"id":56162,"name":"","profession":"bundle"},{"id":56173,"name":"brandstoneimpact","profession":"bundle"},{"id":56179,"name":"boulderbarrage","profession":"bundle"},{"id":56180,"name":"residualimpact","profession":"bundle"},{"id":56187,"profession":"bundle"},{"id":56194,"profession":"bundle"},{"id":56196,"name":"dynamicdeterrent","profession":"bundle"},{"id":56199,"name":"unbridledchaos","profession":"bundle"},{"id":56202,"name":"diredrafts","profession":"bundle"},{"id":56206,"name":"tremorwave","profession":"bundle"},{"id":56218,"name":"chaoticoverflow","profession":"bundle"},{"id":56222,"profession":"bundle"},{"id":56232,"profession":"bundle"},{"id":56237,"name":"cleansedconductor","profession":"bundle"},{"id":56242,"profession":"bundle"},{"id":56246,"profession":"bundle"},{"id":56254,"name":"exponentialrepercussion","profession":"bundle"},{"id":56273,"name":"tempestsspike","profession":"bundle"},{"id":56277,"profession":"bundle"},{"id":56288,"name":"tectonicupheaval","profession":"bundle"},{"id":56303,"profession":"bundle"},{"id":56307,"name":"stormsedge","profession":"bundle"},{"id":56316,"name":"eclipsedbacklash","profession":"bundle"},{"id":56332,"name":"causticchaos","profession":"bundle"},{"id":56338,"profession":"bundle"},{"id":56340,"name":"venomousvoltage","profession":"bundle"},{"id":56341,"profession":"bundle"},{"id":56349,"profession":"bundle"},{"id":56351,"name":"seismicsuffering","profession":"bundle"},{"id":56354,"name":"stoneclaw","profession":"bundle"},{"id":56359,"profession":"bundle"},{"id":56372,"name":"furyofthestorm","profession":"bundle"},{"id":56378,"name":"residualimpact","profession":"bundle"},{"id":56381,"name":"quantumquake","profession":"bundle"},{"id":56387,"name":"","profession":"bundle"},{"id":56390,"name":"perilouspulse","profession":"bundle"},{"id":56391,"name":"electricalrepulsion","profession":"bundle"},{"id":56412,"name":"","profession":"bundle"},{"id":56414,"name":"quantumquake","profession":"bundle"},{"id":56420,"profession":"bundle"},{"id":56431,"name":"boltbreak","profession":"bundle"},{"id":56435,"name":"volatilefusion","profession":"bundle"},{"id":56441,"name":"forceofhavoc","profession":"bundle"},{"id":56444,"profession":"bundle"},{"id":56451,"name":"electrospark","profession":"bundle"},{"id":56455,"name":"stonefist","profession":"bundle"},{"id":56467,"name":"unbridledchaos","profession":"bundle"},{"id":56474,"name":"electrorepulsion","profession":"bundle"},{"id":56487,"name":"brandstoneslash","profession":"bundle"},{"id":56492,"name":"","profession":"bundle"},{"id":56496,"name":"stonefist","profession":"bundle"},{"id":56501,"name":"stonevolley","profession":"bundle"},{"id":56502,"name":"","profession":"bundle"},{"id":56513,"name":"shockingbarrage","profession":"bundle"},{"id":56516,"name":"diamondpalisade","profession":"bundle"},{"id":56521,"name":"stonefist","profession":"bundle"},{"id":56523,"name":"boltbreak","profession":"bundle"},{"id":56527,"name":"rainofchaos","profession":"bundle"},{"id":56528,"profession":"bundle"},{"id":56529,"profession":"bundle"},{"id":56537,"name":"brandstormlightning","profession":"bundle"},{"id":56541,"name":"pylondebrisfield","profession":"bundle"},{"id":56543,"name":"causticchaos","profession":"bundle"},{"id":56551,"name":"residualimpact","profession":"bundle"},{"id":56552,"name":"","profession":"bundle"},{"id":56555,"name":"recharging","profession":"bundle"},{"id":56558,"name":"tectonicupheaval","profession":"bundle"},{"id":56569,"profession":"bundle"},{"id":56579,"profession":"bundle"},{"id":56580,"name":"boulderbarrage","profession":"bundle"},{"id":56586,"name":"erodingcurse","profession":"bundle"},{"id":56588,"profession":"bundle"},{"id":56590,"name":"energyeclipse","profession":"bundle"},{"id":56598,"name":"showerofchaos","profession":"bundle"},{"id":56599,"name":"sandcall","profession":"bundle"},{"id":56611,"profession":"bundle"},{"id":56614,"name":"residualimpact","profession":"bundle"},{"id":56617,"name":"","profession":"bundle"},{"id":56620,"name":"stormsedge","profession":"bundle"},{"id":56629,"name":"chainlightning","profession":"bundle"},{"id":56638,"name":"stoneclaw","profession":"bundle"},{"id":56642,"name":"boltbreak","profession":"bundle"},{"id":56643,"name":"unbridledtempest","profession":"bundle"},{"id":56648,"name":"boulderbarrage","profession":"bundle"},{"id":56649,"name":"stalagmites","profession":"bundle"},{"id":56652,"name":"","profession":"bundle"},{"id":56653,"profession":"bundle"},{"id":56655,"name":"poisonedpower","profession":"bundle"},{"id":56656,"name":"brandstormlightning","profession":"bundle"},{"id":56713,"name":"bonusinspiration","profession":"bundle"},{"id":56723,"name":"holographicstrain","profession":"bundle"},{"id":56833,"name":"energizedhologram","profession":"bundle"},{"id":56873,"name":"timesink","profession":"bundle"},{"id":56880,"name":"pitfall","profession":"bundle"},{"id":56883,"name":"sunspot","profession":"bundle"},{"id":56898,"name":"thousandneedles","profession":"bundle"},{"id":56916,"name":"darkpursuit","profession":"bundle"},{"id":56920,"name":"functiongyro","profession":"bundle"},{"id":56921,"name":"functiongyro","profession":"bundle"},{"id":56925,"name":"splitsecond","profession":"bundle"},{"id":56928,"name":"rewinder","profession":"bundle"},{"id":56930,"name":"splitsecond","profession":"bundle"},{"id":56971,"name":"waterbolt","profession":"bundle"},{"id":56994,"name":"gnawed","profession":"bundle"},{"id":57011,"name":"electrifiedshield","profession":"bundle"},{"id":57012,"name":"eruption","profession":"bundle"},{"id":57014,"name":"stab","profession":"bundle"},{"id":57025,"name":"gnawed","profession":"bundle"},{"id":57593,"name":"frostbiteaura","profession":"bundle"},{"id":57690,"name":"iceshatter","profession":"bundle"},{"id":57951,"name":"charrvolley","profession":"bundle"},{"id":58000,"name":"globollamarble","profession":"bundle"},{"id":58073,"name":"","profession":"bundle"},{"id":58076,"name":"charrvolley","profession":"bundle"},{"id":58090,"name":"medblaster","profession":"bundle"},{"id":58104,"name":"infusionbomb","profession":"bundle"},{"id":58132,"name":"hammerspin","profession":"bundle"},{"id":58139,"name":"unrelentingpain","profession":"bundle"},{"id":58160,"name":"aberrantwill","profession":"bundle"},{"id":58174,"name":"vengefulaura","profession":"bundle"},{"id":58179,"name":"barrage","profession":"bundle"},{"id":58184,"name":"iceshockwave","profession":"bundle"},{"id":58199,"name":"torrentofice","profession":"bundle"},{"id":58219,"name":"frostbiteaura","profession":"bundle"},{"id":58230,"name":"iceshockwave","profession":"bundle"},{"id":58262,"name":"ghostlygrasp","profession":"bundle"},{"id":58276,"name":"snowblind","profession":"bundle"},{"id":58300,"name":"slash","profession":"bundle"},{"id":58301,"name":"barrage","profession":"bundle"},{"id":58310,"name":"aberrantwill","profession":"bundle"},{"id":58392,"name":"aberrantwill","profession":"bundle"},{"id":58429,"name":"slice","profession":"bundle"},{"id":58450,"name":"jab","profession":"bundle"},{"id":58458,"name":"escape","profession":"bundle"},{"id":58489,"name":"daggerstrike","profession":"bundle"},{"id":58497,"name":"hammerlunge","profession":"bundle"},{"id":58501,"name":"iceflail","profession":"bundle"},{"id":58518,"name":"seismiccrush","profession":"bundle"},{"id":58520,"name":"frozenmissile","profession":"bundle"},{"id":58546,"name":"deathwind","profession":"bundle"},{"id":58605,"name":"lunge","profession":"bundle"},{"id":58606,"name":"aberrantwill","profession":"bundle"},{"id":58638,"name":"ghostlyarrow","profession":"bundle"},{"id":58645,"name":"aberrantwill","profession":"bundle"},{"id":58647,"name":"iceflail","profession":"bundle"},{"id":58664,"name":"ambush","profession":"bundle"},{"id":58669,"name":"barrage","profession":"bundle"},{"id":58694,"name":"frostbiteaura","profession":"bundle"},{"id":58736,"name":"unnaturalaura","profession":"bundle"},{"id":58740,"name":"iceshockwave","profession":"bundle"},{"id":58746,"name":"cyclone","profession":"bundle"},{"id":58750,"name":"ambush","profession":"bundle"},{"id":58809,"name":"douseindarkness","profession":"bundle"},{"id":58811,"name":"icequake","profession":"bundle"},{"id":58828,"name":"daggerstrike","profession":"bundle"},{"id":58833,"name":"aberrantwill","profession":"bundle"},{"id":58854,"name":"daggerstrike","profession":"bundle"},{"id":58861,"name":"tormentingaura","profession":"bundle"},{"id":58886,"name":"snowball","profession":"bundle"},{"id":58954,"name":"aurorabeam","profession":"bundle"},{"id":59029,"name":"mistbomb","profession":"bundle"},{"id":59059,"name":"icedrop","profession":"bundle"},{"id":59078,"name":"iceshatter","profession":"bundle"},{"id":59082,"name":"icetempest","profession":"bundle"},{"id":59089,"name":"supernova","profession":"bundle"},{"id":59096,"name":"iceshatter","profession":"bundle"},{"id":59101,"name":"noxiouswind","profession":"bundle"},{"id":59102,"name":"spreadingice","profession":"bundle"},{"id":59147,"name":"iceshatter","profession":"bundle"},{"id":59149,"name":"iceshatter","profession":"bundle"},{"id":59155,"name":"icetempest","profession":"bundle"},{"id":59158,"name":"iceshatter","profession":"bundle"},{"id":59159,"name":"chainsoffrost","profession":"bundle"},{"id":59174,"name":"flurry","profession":"bundle"},{"id":59192,"name":"fallingice","profession":"bundle"},{"id":59202,"name":"frostbiteaura","profession":"bundle"},{"id":59213,"name":"frigidvortex","profession":"bundle"},{"id":59220,"name":"supernova","profession":"bundle"},{"id":59236,"name":"smash","profession":"bundle"},{"id":59255,"name":"icetempest","profession":"bundle"},{"id":59288,"name":"fallingice","profession":"bundle"},{"id":59308,"name":"iceshatter","profession":"bundle"},{"id":59321,"name":"supernova","profession":"bundle"},{"id":59331,"name":"corruptedground","profession":"bundle"},{"id":59339,"name":"supernova","profession":"bundle"},{"id":59340,"name":"leap","profession":"bundle"},{"id":59345,"name":"icetempest","profession":"bundle"},{"id":59347,"name":"leapingstrike","profession":"bundle"},{"id":59391,"name":"spiralstrike","profession":"bundle"},{"id":59408,"name":"coldfront","profession":"bundle"},{"id":59425,"name":"iceshatter","profession":"bundle"},{"id":59441,"name":"lethalcoalescence","profession":"bundle"},{"id":59450,"name":"vortexofhail","profession":"bundle"},{"id":59455,"name":"fallingice","profession":"bundle"},{"id":59462,"name":"iceshatter","profession":"bundle"},{"id":59468,"name":"spreadingice","profession":"bundle"},{"id":59489,"name":"iceshatter","profession":"bundle"},{"id":59493,"name":"supernova","profession":"bundle"},{"id":59526,"name":"repeater","profession":"bundle"},{"id":59562,"name":"explosiveentrance","profession":"bundle"},{"id":59591,"name":"invoketorment","profession":"bundle"},{"id":59627,"profession":"bundle"},{"id":59656,"name":"bombdrop","profession":"bundle"},{"id":59837,"profession":"bundle"},{"id":59961,"name":"shadowaura","profession":"bundle"},{"id":59989,"name":"icetempest","profession":"bundle"},{"id":60006,"name":"detonate","profession":"bundle"},{"id":60067,"name":"frozenbarrier","profession":"bundle"},{"id":60080,"name":"frostblast","profession":"bundle"},{"id":60085,"name":"clawsofice","profession":"bundle"},{"id":60089,"name":"flurryofice","profession":"bundle"},{"id":60132,"name":"charge","profession":"bundle"},{"id":60133,"name":"flamewall","profession":"bundle"},{"id":60138,"name":"slash","profession":"bundle"},{"id":60171,"name":"flamewall","profession":"bundle"},{"id":60174,"name":"mightyspin","profession":"bundle"},{"id":60193,"name":"frostbiteaura","profession":"bundle"},{"id":60195,"name":"icestorm","profession":"bundle"},{"id":60200,"name":"icewhip","profession":"bundle"},{"id":60208,"name":"giantstomp","profession":"bundle"},{"id":60222,"name":"breathofcorruption","profession":"bundle"},{"id":60233,"name":"thrust","profession":"bundle"},{"id":60289,"name":"bloodcharge","profession":"bundle"},{"id":60308,"name":"callassassins","profession":"bundle"},{"id":60315,"name":"frigidtrail","profession":"bundle"},{"id":60328,"name":"conjureflame","profession":"bundle"},{"id":60344,"name":"boonofflame","profession":"bundle"},{"id":60354,"name":"icyechoes","profession":"bundle"},{"id":60369,"name":"bodyslam","profession":"bundle"},{"id":60370,"name":"mightyspin","profession":"bundle"},{"id":60379,"name":"mightyslashes","profession":"bundle"},{"id":60473,"name":"giantkick","profession":"bundle"},{"id":60524,"name":"giantflurry","profession":"bundle"},{"id":60527,"name":"bloodcharge","profession":"bundle"},{"id":60545,"name":"lethalcoalescence","profession":"bundle"},{"id":60574,"name":"slash","profession":"bundle"},{"id":60577,"name":"lunge","profession":"bundle"},{"id":60633,"name":"bombardment","profession":"bundle"},{"id":60664,"name":"leap","profession":"bundle"},{"id":60673,"name":"icebreath","profession":"bundle"},{"id":60696,"name":"avalanche","profession":"bundle"},{"id":60842,"name":"claw","profession":"bundle"},{"id":60856,"name":"callmeteor","profession":"bundle"},{"id":60871,"name":"clawsmash","profession":"bundle"},{"id":60896,"name":"avalanche","profession":"bundle"},{"id":60902,"name":"avalanche","profession":"bundle"},{"id":60907,"name":"avalanche","profession":"bundle"},{"id":60932,"name":"crash","profession":"bundle"},{"id":60947,"name":"icebreath","profession":"bundle"},{"id":60990,"name":"clawsmash","profession":"bundle"},{"id":61060,"name":"avalanche","profession":"bundle"},{"id":61118,"name":"windsofjormag","profession":"bundle"},{"id":61132,"name":"crash","profession":"bundle"},{"id":61137,"name":"clawsmash","profession":"bundle"},{"id":61172,"name":"elementalmanipulation","profession":"bundle"},{"id":61173,"name":"elementalwhirl","profession":"bundle"},{"id":61175,"profession":"bundle"},{"id":61176,"name":"callmeteor","profession":"bundle"},{"id":61177,"name":"torrentialbolt","profession":"bundle"},{"id":61179,"name":"elementalsweep","profession":"bundle"},{"id":61181,"name":"aquajet","profession":"bundle"},{"id":61182,"name":"rush","profession":"bundle"},{"id":61184,"name":"terrorstorm","profession":"bundle"},{"id":61185,"profession":"bundle"},{"id":61186,"name":"fulgorsphere","profession":"bundle"},{"id":61189,"name":"elementalwhirl","profession":"bundle"},{"id":61190,"name":"callofstorms","profession":"bundle"},{"id":61194,"name":"roilingflames","profession":"bundle"},{"id":61195,"name":"aquajet","profession":"bundle"},{"id":61196,"name":"elementalmanipulation","profession":"bundle"},{"id":61197,"name":"lightningstrikes","profession":"bundle"},{"id":61199,"name":"aquajet","profession":"bundle"},{"id":61203,"name":"callmeteor","profession":"bundle"},{"id":61204,"name":"elementalwhirl","profession":"bundle"},{"id":61205,"name":"windburst","profession":"bundle"},{"id":61207,"name":"elementalmanipulation","profession":"bundle"},{"id":61208,"name":"crushingguilt","profession":"bundle"},{"id":61210,"name":"aquajet","profession":"bundle"},{"id":61211,"name":"surgeofdarkness","profession":"bundle"},{"id":61212,"name":"rush","profession":"bundle"},{"id":61214,"name":"aquajet","profession":"bundle"},{"id":61215,"name":"elementalsweep","profession":"bundle"},{"id":61216,"name":"elementalmanipulation","profession":"bundle"},{"id":61217,"name":"empathicmanipulation","profession":"bundle"},{"id":61222,"name":"aquajet","profession":"bundle"},{"id":61228,"profession":"bundle"},{"id":61230,"name":"roilingflames","profession":"bundle"},{"id":61231,"name":"firestorm","profession":"bundle"},{"id":61234,"name":"fulgorsphere","profession":"bundle"},{"id":61235,"name":"fulgorsphere","profession":"bundle"},{"id":61239,"name":"elementalsurge","profession":"bundle"},{"id":61240,"name":"tempestofflame","profession":"bundle"},{"id":61241,"name":"overwhelmingsorrow","profession":"bundle"},{"id":61243,"name":"callmeteor","profession":"bundle"},{"id":61245,"name":"callmeteor","profession":"bundle"},{"id":61246,"name":"pleaoftides","profession":"bundle"},{"id":61247,"name":"empathicmanipulation","profession":"bundle"},{"id":61248,"name":"flameburst","profession":"bundle"},{"id":61251,"name":"aquaticburst","profession":"bundle"},{"id":61255,"name":"aquajet","profession":"bundle"},{"id":61256,"name":"elementalmanipulation","profession":"bundle"},{"id":61258,"name":"aquajet","profession":"bundle"},{"id":61260,"name":"empathicmanipulation","profession":"bundle"},{"id":61261,"name":"arcdivider","profession":"bundle"},{"id":61263,"name":"voltaicexpulsion","profession":"bundle"},{"id":61264,"name":"aquajet","profession":"bundle"},{"id":61265,"name":"callmeteor","profession":"bundle"},{"id":61266,"name":"uppercut","profession":"bundle"},{"id":61268,"name":"elementalwhirl","profession":"bundle"},{"id":61270,"name":"elementalwhirl","profession":"bundle"},{"id":61271,"name":"elementalmanipulation","profession":"bundle"},{"id":61273,"name":"roilingflames","profession":"bundle"},{"id":61275,"profession":"bundle"},{"id":61276,"name":"brutalstrike","profession":"bundle"},{"id":61279,"name":"elementalmanipulation","profession":"bundle"},{"id":61280,"name":"torrentialbolt","profession":"bundle"},{"id":61282,"name":"explosion","profession":"bundle"},{"id":61284,"name":"callmeteor","profession":"bundle"},{"id":61287,"name":"elementalmanipulation","profession":"bundle"},{"id":61288,"name":"callofstorms","profession":"bundle"},{"id":61289,"name":"negativeburst","profession":"bundle"},{"id":61292,"name":"empathicmanipulation","profession":"bundle"},{"id":61293,"name":"callmeteor","profession":"bundle"},{"id":61294,"name":"aquajet","profession":"bundle"},{"id":61299,"name":"aquajet","profession":"bundle"},{"id":61305,"name":"aquajet","profession":"bundle"},{"id":61308,"name":"elementalsweep","profession":"bundle"},{"id":61309,"name":"elementalwhirl","profession":"bundle"},{"id":61313,"name":"tidalbargain","profession":"bundle"},{"id":61317,"name":"explosion","profession":"bundle"},{"id":61318,"name":"elementalsurge","profession":"bundle"},{"id":61321,"name":"callmeteor","profession":"bundle"},{"id":61323,"name":"fulgorsphere","profession":"bundle"},{"id":61325,"name":"surgeofdarkness","profession":"bundle"},{"id":61329,"name":"callmeteor","profession":"bundle"},{"id":61330,"name":"elementalsweep","profession":"bundle"},{"id":61336,"name":"elementalmanipulation","profession":"bundle"},{"id":61340,"name":"callmeteor","profession":"bundle"},{"id":61341,"name":"callmeteor","profession":"bundle"},{"id":61343,"name":"callmeteor","profession":"bundle"},{"id":61344,"name":"focusedwrath","profession":"bundle"},{"id":61345,"name":"callmeteor","profession":"bundle"},{"id":61346,"name":"elementalsweep","profession":"bundle"},{"id":61347,"name":"greatswordslice","profession":"bundle"},{"id":61348,"name":"callmeteor","profession":"bundle"},{"id":61349,"name":"torrentialbolt","profession":"bundle"},{"id":61352,"name":"aquajet","profession":"bundle"},{"id":61356,"name":"surgeofdarkness","profession":"bundle"},{"id":61362,"name":"empathicmanipulation","profession":"bundle"},{"id":61364,"name":"torrentialbolt","profession":"bundle"},{"id":61365,"name":"elementalsurge","profession":"bundle"},{"id":61366,"name":"callmeteor","profession":"bundle"},{"id":61367,"name":"callmeteor","profession":"bundle"},{"id":61369,"name":"elementalsurge","profession":"bundle"},{"id":61370,"name":"elementalmanipulation","profession":"bundle"},{"id":61376,"name":"elementalsurge","profession":"bundle"},{"id":61378,"name":"aquajet","profession":"bundle"},{"id":61382,"name":"rushend","profession":"bundle"},{"id":61384,"name":"aquaticburst","profession":"bundle"},{"id":61387,"name":"elementalsweep","profession":"bundle"},{"id":61394,"name":"voltaicexpulsion","profession":"bundle"},{"id":61396,"name":"aquaticburst","profession":"bundle"},{"id":61398,"name":"elementalwhirl","profession":"bundle"},{"id":61400,"name":"aquajet","profession":"bundle"},{"id":61401,"name":"pleaoftides","profession":"bundle"},{"id":61407,"name":"elementalsweep","profession":"bundle"},{"id":61409,"profession":"bundle"},{"id":61411,"name":"callmeteor","profession":"bundle"},{"id":61412,"name":"tidalbarrier","profession":"bundle"},{"id":61414,"profession":"bundle"},{"id":61417,"name":"elementalsurge","profession":"bundle"},{"id":61418,"name":"torrentialbolt","profession":"bundle"},{"id":61419,"name":"volatilewaters","profession":"bundle"},{"id":61423,"name":"elementalmanipulation","profession":"bundle"},{"id":61425,"profession":"bundle"},{"id":61428,"name":"aquajet","profession":"bundle"},{"id":61429,"name":"aquajet","profession":"bundle"},{"id":61431,"name":"elementalmanipulation","profession":"bundle"},{"id":61434,"profession":"bundle"},{"id":61436,"profession":"bundle"},{"id":61438,"name":"callmeteor","profession":"bundle"},{"id":61439,"name":"callmeteor","profession":"bundle"},{"id":61440,"name":"hundredblades","profession":"bundle"},{"id":61441,"name":"elementalsweep","profession":"bundle"},{"id":61442,"name":"callmeteor","profession":"bundle"},{"id":61445,"name":"firestorm","profession":"bundle"},{"id":61449,"name":"elementalwhirl","profession":"bundle"},{"id":61453,"name":"elementalmanipulation","profession":"bundle"},{"id":61454,"name":"elementalsurge","profession":"bundle"},{"id":61455,"name":"greatswordswing","profession":"bundle"},{"id":61456,"name":"elementalwhirl","profession":"bundle"},{"id":61457,"name":"callmeteor","profession":"bundle"},{"id":61463,"name":"elementalwhirl","profession":"bundle"},{"id":61466,"name":"aquajet","profession":"bundle"},{"id":61469,"name":"elementalwhirl","profession":"bundle"},{"id":61470,"name":"volatilewind","profession":"bundle"},{"id":61480,"name":"empathicmanipulation","profession":"bundle"},{"id":61484,"profession":"bundle"},{"id":61486,"name":"elementalsurge","profession":"bundle"},{"id":61487,"name":"fulgorsphere","profession":"bundle"},{"id":61489,"profession":"bundle"},{"id":61491,"name":"fulgorsphere","profession":"bundle"},{"id":61495,"name":"roilingflames","profession":"bundle"},{"id":61498,"name":"tempestofflame","profession":"bundle"},{"id":61499,"name":"focusedwrath","profession":"bundle"},{"id":61500,"name":"elementalwhirl","profession":"bundle"},{"id":61504,"name":"aquajet","profession":"bundle"},{"id":61505,"name":"elementalsurge","profession":"bundle"},{"id":61507,"name":"elementalsweep","profession":"bundle"},{"id":61508,"name":"empathicmanipulation","profession":"bundle"},{"id":61510,"name":"callmeteor","profession":"bundle"},{"id":61512,"name":"tidalbargain","profession":"bundle"},{"id":61513,"name":"callmeteor","profession":"bundle"},{"id":61519,"name":"elementalmanipulation","profession":"bundle"},{"id":61520,"profession":"bundle"},{"id":61525,"name":"surgeofdarkness","profession":"bundle"},{"id":61526,"profession":"bundle"},{"id":61527,"name":"empathicmanipulation","profession":"bundle"},{"id":61528,"name":"rush","profession":"bundle"},{"id":61529,"name":"empathicmanipulation","profession":"bundle"},{"id":61530,"name":"callmeteor","profession":"bundle"},{"id":61533,"name":"elementalmanipulation","profession":"bundle"},{"id":61534,"name":"elementalmanipulation","profession":"bundle"},{"id":61539,"name":"aquajet","profession":"bundle"},{"id":61541,"name":"aquaticburst","profession":"bundle"},{"id":61542,"name":"voltaicexpulsion","profession":"bundle"},{"id":61548,"name":"volatilefire","profession":"bundle"},{"id":61549,"name":"callmeteor","profession":"bundle"},{"id":61551,"name":"airblast","profession":"bundle"},{"id":61554,"name":"callmeteor","profession":"bundle"},{"id":61555,"name":"rush","profession":"bundle"},{"id":61556,"name":"elementalmanipulation","profession":"bundle"},{"id":61559,"profession":"bundle"},{"id":61560,"name":"elementalsurge","profession":"bundle"},{"id":61561,"name":"fulgorsphere","profession":"bundle"},{"id":61562,"profession":"bundle"},{"id":61565,"name":"fulgorsphere","profession":"bundle"},{"id":61567,"name":"elementalsweep","profession":"bundle"},{"id":61569,"name":"callmeteor","profession":"bundle"},{"id":61573,"name":"elementalwhirl","profession":"bundle"},{"id":61574,"name":"elementalmanipulation","profession":"bundle"},{"id":61576,"name":"aquaticburst","profession":"bundle"},{"id":61581,"name":"callmeteor","profession":"bundle"},{"id":61582,"name":"roilingflames","profession":"bundle"},{"id":61587,"name":"explosion","profession":"bundle"},{"id":61590,"name":"elementalsweep","profession":"bundle"},{"id":61591,"name":"elementalwhirl","profession":"bundle"},{"id":61592,"name":"lightningstrikes","profession":"bundle"},{"id":61597,"name":"aquajet","profession":"bundle"},{"id":61600,"name":"empathicmanipulation","profession":"bundle"},{"id":61601,"name":"pleaoftides","profession":"bundle"},{"id":61602,"name":"empathicmanipulation","profession":"bundle"},{"id":61603,"name":"pleaoftides","profession":"bundle"},{"id":61604,"name":"empathicmanipulation","profession":"bundle"},{"id":61606,"name":"empathicmanipulation","profession":"bundle"},{"id":61609,"profession":"bundle"},{"id":61614,"profession":"bundle"},{"id":61686,"name":"slash","profession":"bundle"},{"id":61741,"name":"claw","profession":"bundle"},{"id":61758,"name":"leap","profession":"bundle"},{"id":61762,"name":"leap","profession":"bundle"},{"id":61782,"name":"leap","profession":"bundle"},{"id":61799,"name":"bursterexplosion","profession":"bundle"},{"id":62027,"name":"firebreath","profession":"bundle"},{"id":62076,"name":"giantkick","profession":"bundle"},{"id":62123,"name":"frostblast","profession":"bundle"},{"id":62183,"name":"cataclysm","profession":"bundle"},{"id":62216,"name":"cataclysm","profession":"bundle"},{"id":62262,"name":"cataclysm","profession":"bundle"},{"id":62335,"name":"apocalypserain","profession":"bundle"},{"id":62338,"name":"cataclysm","profession":"bundle"},{"id":62340,"name":"cataclysm","profession":"bundle"},{"id":62358,"name":"cataclysm","profession":"bundle"},{"id":62454,"name":"deception","profession":"bundle"},{"id":62510,"name":"flyingcutter","profession":"bundle"},{"id":62511,"name":"vileblast","profession":"bundle"},{"id":62513,"name":"weepingshots","profession":"bundle"},{"id":62514,"name":"elixirofbliss","profession":"bundle"},{"id":62517,"name":"viciousshot","profession":"bundle"},{"id":62521,"name":"roilinglight","profession":"bundle"},{"id":62522,"name":"twinbladerestoration","profession":"bundle"},{"id":62525,"name":"executionerscalling","profession":"bundle"},{"id":62528,"name":"willbenderflames","profession":"bundle"},{"id":62530,"name":"elixirofrisk","profession":"bundle"},{"id":62532,"name":"crashingcourage","profession":"bundle"},{"id":62539,"name":"voraciousarc","profession":"bundle"},{"id":62540,"name":"exitharbingershroud","profession":"bundle"},{"id":62549,"name":"heelcrack","profession":"bundle"},{"id":62552,"name":"willbenderflames","profession":"bundle"},{"id":62553,"name":"rainofswords","profession":"bundle"},{"id":62555,"name":"crashingcourage","profession":"bundle"},{"id":62558,"name":"approachingdoom","profession":"bundle"},{"id":62560,"name":"bladecall","profession":"bundle"},{"id":62561,"name":"heavenspalm","profession":"bundle"},{"id":62563,"name":"vitaldraw","profession":"bundle"},{"id":62565,"name":"whirlinglight","profession":"bundle"},{"id":62567,"name":"harbingershroud","profession":"bundle"},{"id":62568,"name":"bladeleap","profession":"bundle"},{"id":62573,"name":"psychicforce","profession":"bundle"},{"id":62586,"name":"bladesongharmony","profession":"bundle"},{"id":62596,"name":"crashingcourage","profession":"bundle"},{"id":62597,"name":"bladeturnrequiem","profession":"bundle"},{"id":62602,"name":"bladesongdissonance","profession":"bundle"},{"id":62603,"name":"flowingresolve","profession":"bundle"},{"id":62607,"name":"unstablebladestorm","profession":"bundle"},{"id":62608,"name":"flashcombo","profession":"bundle"},{"id":62611,"name":"taintedbolts","profession":"bundle"},{"id":62616,"name":"bladesongsorrow","profession":"bundle"},{"id":62617,"name":"bladesongharmony","profession":"bundle"},{"id":62618,"name":"willbenderflames","profession":"bundle"},{"id":62621,"name":"darkbarrage","profession":"bundle"},{"id":62622,"name":"reversaloffortune","profession":"bundle"},{"id":62635,"name":"flowingresolve","profession":"bundle"},{"id":62646,"name":"elixirofignorance","profession":"bundle"},{"id":62648,"name":"crashingcourage","profession":"bundle"},{"id":62650,"name":"advancingstrike","profession":"bundle"},{"id":62655,"name":"elixirofambition","profession":"bundle"},{"id":62660,"name":"cascadingcorruption","profession":"bundle"},{"id":62662,"name":"elixirofanguish","profession":"bundle"},{"id":62664,"name":"ripostingblade","profession":"bundle"},{"id":62667,"name":"elixirofpromise","profession":"bundle"},{"id":62668,"name":"rushingjustice","profession":"bundle"},{"id":62669,"name":"repose","profession":"bundle"},{"id":62671,"name":"deathlyhaste","profession":"bundle"},{"id":62672,"name":"devouringcut","profession":"bundle"},{"id":62675,"name":"returningedge","profession":"bundle"},{"id":62676,"name":"quickretribution","profession":"bundle"}]
+[
+  {
+    "id": 1110,
+    "name": "throwgunk"
+  },
+  {
+    "id": 1115,
+    "name": "branchleap"
+  },
+  {
+    "id": 1118,
+    "name": "throwchain"
+  },
+  {
+    "id": 1123,
+    "name": "consumeplasma"
+  },
+  {
+    "id": 1125,
+    "name": "eategg"
+  },
+  {
+    "id": 1129,
+    "name": "iceshardstab"
+  },
+  {
+    "id": 1131,
+    "name": "maceheadcrack"
+  },
+  {
+    "id": 1139,
+    "name": "healingseed"
+  },
+  {
+    "id": 1141,
+    "name": "skullfear"
+  },
+  {
+    "id": 1148,
+    "name": "blindingtuft"
+  },
+  {
+    "id": 1162,
+    "name": "whirlingaxe"
+  },
+  {
+    "id": 1167,
+    "name": "whirlingstrike"
+  },
+  {
+    "id": 1175,
+    "name": "bandage",
+    "profession": "guardian"
+  },
+  {
+    "id": 1279,
+    "name": "bindingroots",
+    "profession": "bundle"
+  },
+  {
+    "id": 1355,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 1359,
+    "name": "flurry",
+    "profession": "bundle"
+  },
+  {
+    "id": 1364,
+    "name": "whirlwind",
+    "profession": "bundle"
+  },
+  {
+    "id": 1408,
+    "name": "gallopingslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 1510,
+    "name": "dualattack",
+    "profession": "bundle"
+  },
+  {
+    "id": 1512,
+    "name": "shoot",
+    "profession": "bundle"
+  },
+  {
+    "id": 1531,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 1539,
+    "name": "stab",
+    "profession": "bundle"
+  },
+  {
+    "id": 1541,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 1626,
+    "name": "throw",
+    "profession": "bundle"
+  },
+  {
+    "id": 1628,
+    "name": "skullbolas",
+    "profession": "bundle"
+  },
+  {
+    "id": 1629,
+    "name": "stab",
+    "profession": "bundle"
+  },
+  {
+    "id": 1631,
+    "name": "throwjavelin",
+    "profession": "bundle"
+  },
+  {
+    "id": 1641,
+    "name": "stab",
+    "profession": "bundle"
+  },
+  {
+    "id": 1642,
+    "name": "lunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 1644,
+    "name": "smash",
+    "profession": "bundle"
+  },
+  {
+    "id": 1691,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 1932,
+    "name": "trample",
+    "profession": "bundle"
+  },
+  {
+    "id": 1940,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 1991,
+    "name": "counterattack",
+    "profession": "bundle"
+  },
+  {
+    "id": 1996,
+    "name": "frosttrap",
+    "profession": "bundle"
+  },
+  {
+    "id": 2013,
+    "name": "axe",
+    "profession": "bundle"
+  },
+  {
+    "id": 2014,
+    "name": "cyclonespin",
+    "profession": "bundle"
+  },
+  {
+    "id": 2131,
+    "name": "severartery",
+    "profession": "bundle"
+  },
+  {
+    "id": 2132,
+    "name": "gash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2133,
+    "name": "finalthrust",
+    "profession": "bundle"
+  },
+  {
+    "id": 2134,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2135,
+    "name": "savageleap",
+    "profession": "bundle"
+  },
+  {
+    "id": 2136,
+    "name": "whirlwindattack",
+    "profession": "bundle"
+  },
+  {
+    "id": 2302,
+    "name": "flurry",
+    "profession": "bundle"
+  },
+  {
+    "id": 2365,
+    "name": "punch",
+    "profession": "bundle"
+  },
+  {
+    "id": 2367,
+    "name": "brandedcrystals",
+    "profession": "bundle"
+  },
+  {
+    "id": 2397,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2399,
+    "name": "slice",
+    "profession": "bundle"
+  },
+  {
+    "id": 2400,
+    "name": "ambush",
+    "profession": "bundle"
+  },
+  {
+    "id": 2401,
+    "name": "ambush",
+    "profession": "bundle"
+  },
+  {
+    "id": 2403,
+    "name": "ambush",
+    "profession": "bundle"
+  },
+  {
+    "id": 2433,
+    "name": "spit",
+    "profession": "bundle"
+  },
+  {
+    "id": 2434,
+    "name": "tarpool",
+    "profession": "bundle"
+  },
+  {
+    "id": 2446,
+    "name": "shred",
+    "profession": "bundle"
+  },
+  {
+    "id": 2498,
+    "name": "firebolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 2503,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2504,
+    "name": "lunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 2505,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2760,
+    "name": "fireblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 2783,
+    "name": "hit",
+    "profession": "bundle"
+  },
+  {
+    "id": 2784,
+    "name": "glueshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 2800,
+    "name": "eyebeam",
+    "profession": "bundle"
+  },
+  {
+    "id": 2804,
+    "name": "tentacleslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2806,
+    "name": "shoot",
+    "profession": "bundle"
+  },
+  {
+    "id": 2823,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2824,
+    "name": "throwaxe",
+    "profession": "bundle"
+  },
+  {
+    "id": 2839,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2843,
+    "name": "pawswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 2845,
+    "name": "brutalmauling",
+    "profession": "bundle"
+  },
+  {
+    "id": 2871,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 2879,
+    "name": "bite",
+    "profession": "bundle"
+  },
+  {
+    "id": 2880,
+    "name": "eyeblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 2881,
+    "name": "petrifyinggaze",
+    "profession": "bundle"
+  },
+  {
+    "id": 2904,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2905,
+    "name": "swoop",
+    "profession": "bundle"
+  },
+  {
+    "id": 2907,
+    "name": "shred",
+    "profession": "bundle"
+  },
+  {
+    "id": 2919,
+    "name": "thump",
+    "profession": "bundle"
+  },
+  {
+    "id": 2920,
+    "name": "lunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 2922,
+    "name": "charge",
+    "profession": "bundle"
+  },
+  {
+    "id": 2924,
+    "name": "oakheartswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 2937,
+    "name": "vomit",
+    "profession": "bundle"
+  },
+  {
+    "id": 2939,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 2961,
+    "name": "rockshards",
+    "profession": "bundle"
+  },
+  {
+    "id": 2962,
+    "name": "bite",
+    "profession": "bundle"
+  },
+  {
+    "id": 3032,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 3080,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 3096,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 3101,
+    "name": "diseasedbite",
+    "profession": "bundle"
+  },
+  {
+    "id": 3102,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 3103,
+    "name": "screech",
+    "profession": "bundle"
+  },
+  {
+    "id": 3717,
+    "name": "frostspit",
+    "profession": "bundle"
+  },
+  {
+    "id": 3777,
+    "name": "buffpassiveoakheart",
+    "profession": "bundle"
+  },
+  {
+    "id": 3786,
+    "name": "maul",
+    "profession": "bundle"
+  },
+  {
+    "id": 3787,
+    "name": "lunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 3788,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 3789,
+    "name": "frozenburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 5487,
+    "name": "frozenburst",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5489,
+    "name": "lightningwhip",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5490,
+    "name": "comet",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5491,
+    "name": "fireball",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5492,
+    "name": "fireattunement",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5493,
+    "name": "waterattunement",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5494,
+    "name": "airattunement",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5495,
+    "name": "earthattunement",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5496,
+    "name": "drakesbreath",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5497,
+    "name": "flamewall",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5500,
+    "name": "stoneshards",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5501,
+    "name": "meteorshower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5502,
+    "name": "glyphoflesserelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5503,
+    "name": "signetofrestoration",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5504,
+    "name": "dischargelightning",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5505,
+    "name": "graspingearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5506,
+    "name": "glyphofelementalpower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5507,
+    "name": "etherrenewal",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5508,
+    "name": "flamestrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5510,
+    "name": "watertrident",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5515,
+    "name": "frozenground",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5516,
+    "name": "conjurefierygreatsword",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5517,
+    "name": "fieryrush",
+    "profession": "thief"
+  },
+  {
+    "id": 5518,
+    "name": "chainlightning",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5519,
+    "name": "stoning",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5520,
+    "name": "frostaura",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5521,
+    "name": "obsidianflesh",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5522,
+    "name": "churningearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5525,
+    "name": "ringofearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5526,
+    "name": "arclightning",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5527,
+    "name": "shockingaura",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5528,
+    "name": "eruption",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5529,
+    "name": "ridethelightning",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5530,
+    "name": "swirlingwinds",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5531,
+    "name": "firestorm",
+    "profession": "thief"
+  },
+  {
+    "id": 5532,
+    "name": "flamewave",
+    "profession": "thief"
+  },
+  {
+    "id": 5533,
+    "name": "fieryeruption",
+    "profession": "thief"
+  },
+  {
+    "id": 5534,
+    "name": "tornado",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5535,
+    "name": "cleansingfire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5536,
+    "name": "lightningflash",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5537,
+    "name": "coneofcold",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5538,
+    "name": "shatterstone",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5539,
+    "name": "arcaneblast",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5540,
+    "name": "conjureflameaxe",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5541,
+    "name": "lavaaxe",
+    "profession": "thief"
+  },
+  {
+    "id": 5542,
+    "name": "signetoffire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5546,
+    "name": "conjureearthshield",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5547,
+    "name": "magneticsurge"
+  },
+  {
+    "id": 5548,
+    "name": "lavafont",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5549,
+    "name": "waterblast",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5550,
+    "name": "icespike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5551,
+    "name": "healingrain",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5552,
+    "name": "lightningsurge",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5553,
+    "name": "gust",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5554,
+    "name": "mistform",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5555,
+    "name": "magneticwave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5556,
+    "name": "freezinggust",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5557,
+    "name": "firegrab",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5558,
+    "name": "cleansingwave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5559,
+    "name": "earthenrush",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5561,
+    "name": "lightningstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5562,
+    "name": "gale",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5564,
+    "name": "vaporform",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5566,
+    "name": "steam",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5567,
+    "name": "conjurefrostbow",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5568,
+    "name": "frostfan",
+    "profession": "thief"
+  },
+  {
+    "id": 5569,
+    "name": "glyphofelementalharmony",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5570,
+    "name": "signetofwater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5571,
+    "name": "signetofearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5572,
+    "name": "signetofair",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5573,
+    "name": "glyphofrenewal",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5593,
+    "name": "explosivelavaaxe",
+    "profession": "thief"
+  },
+  {
+    "id": 5595,
+    "name": "waterarrow",
+    "profession": "thief"
+  },
+  {
+    "id": 5597,
+    "name": "boil",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5598,
+    "name": "magmaorb",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5599,
+    "name": "lavachains",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5600,
+    "name": "heatwave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5602,
+    "name": "whirlpool",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5603,
+    "name": "whirlpool",
+    "profession": "thief"
+  },
+  {
+    "id": 5604,
+    "name": "watermissile",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5605,
+    "name": "iceglobe",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5606,
+    "name": "icewall",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5607,
+    "name": "tidalwave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5608,
+    "name": "waterfist",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5609,
+    "name": "stonekick",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5610,
+    "name": "steamvent",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5621,
+    "name": "shieldsmack"
+  },
+  {
+    "id": 5623,
+    "name": "fortify"
+  },
+  {
+    "id": 5624,
+    "name": "conjurelightninghammer",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5625,
+    "name": "lightningleap"
+  },
+  {
+    "id": 5635,
+    "name": "arcanepower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5638,
+    "name": "arcanewave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5639,
+    "name": "armorofearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5641,
+    "name": "arcaneshield",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5644,
+    "name": "burningspeed",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5646,
+    "name": "convergence",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5648,
+    "name": "airbubble",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5650,
+    "name": "lightningcage",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5652,
+    "name": "airpocket",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5653,
+    "name": "vacuum",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5655,
+    "name": "electrocute",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5656,
+    "name": "forkedlightning",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5657,
+    "name": "rockblade",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5658,
+    "name": "rockspray",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5659,
+    "name": "rockanchor",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5661,
+    "name": "murkywater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5662,
+    "name": "magneticcurrent",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5666,
+    "name": "glyphofelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5671,
+    "name": "staticfield",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5675,
+    "name": "phoenix",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5678,
+    "name": "fireshield",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5679,
+    "name": "flameburst",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5680,
+    "name": "burningretreat",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5681,
+    "name": "geyser",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5682,
+    "name": "windbornespeed",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5683,
+    "name": "unsteadyground",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5685,
+    "name": "magneticaura",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5686,
+    "name": "shockwave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5687,
+    "name": "updraft",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5690,
+    "name": "earthquake",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5691,
+    "name": "ringoffire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5692,
+    "name": "dragonstooth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5693,
+    "name": "iceshards",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5694,
+    "name": "blindingflash",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5695,
+    "name": "rockbarrier",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5696,
+    "name": "dustdevil",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5697,
+    "name": "fierywhirl",
+    "profession": "thief"
+  },
+  {
+    "id": 5717,
+    "name": "burningretreat",
+    "profession": "thief"
+  },
+  {
+    "id": 5718,
+    "name": "ringoffire",
+    "profession": "thief"
+  },
+  {
+    "id": 5719,
+    "name": "flameleap",
+    "profession": "thief"
+  },
+  {
+    "id": 5720,
+    "name": "frostvolley",
+    "profession": "thief"
+  },
+  {
+    "id": 5721,
+    "name": "deepfreeze",
+    "profession": "thief"
+  },
+  {
+    "id": 5723,
+    "name": "froststorm",
+    "profession": "thief"
+  },
+  {
+    "id": 5725,
+    "name": "invokelightning"
+  },
+  {
+    "id": 5726,
+    "name": "lightningswing"
+  },
+  {
+    "id": 5727,
+    "name": "staticswing"
+  },
+  {
+    "id": 5728,
+    "name": "thunderclap"
+  },
+  {
+    "id": 5732,
+    "name": "staticfield"
+  },
+  {
+    "id": 5733,
+    "name": "windblast"
+  },
+  {
+    "id": 5734,
+    "name": "glyphofstorms",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5735,
+    "name": "icestorm",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5736,
+    "name": "firestorm",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5737,
+    "name": "lightningstorm",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5738,
+    "name": "sandstorm",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5746,
+    "name": "cripplingshield"
+  },
+  {
+    "id": 5747,
+    "name": "magneticshield"
+  },
+  {
+    "id": 5748,
+    "name": "undercurrent",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5752,
+    "name": "electrifiedtornado",
+    "profession": "thief"
+  },
+  {
+    "id": 5753,
+    "name": "dusttornado",
+    "profession": "thief"
+  },
+  {
+    "id": 5754,
+    "name": "debristornado",
+    "profession": "thief"
+  },
+  {
+    "id": 5760,
+    "name": "renewalofair",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5761,
+    "name": "renewalofearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5762,
+    "name": "renewaloffire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5763,
+    "name": "renewalofwater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5777,
+    "name": "armorofearth",
+    "profession": "bundle"
+  },
+  {
+    "id": 5780,
+    "name": "hurl",
+    "profession": "elementalist"
+  },
+  {
+    "id": 5782,
+    "name": "geyser",
+    "profession": "bundle"
+  },
+  {
+    "id": 5792,
+    "name": "blindingflash",
+    "profession": "bundle"
+  },
+  {
+    "id": 5793,
+    "name": "cleansingwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 5794,
+    "name": "flameburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 5795,
+    "name": "shockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 5802,
+    "name": "medkit",
+    "profession": "engineer"
+  },
+  {
+    "id": 5805,
+    "name": "grenadekit",
+    "profession": "engineer"
+  },
+  {
+    "id": 5806,
+    "name": "poisongrenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 5807,
+    "name": "shrapnelgrenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 5808,
+    "name": "flashgrenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 5809,
+    "name": "freezegrenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 5810,
+    "name": "grenadebarrage",
+    "profession": "engineer"
+  },
+  {
+    "id": 5811,
+    "name": "personalbatteringram",
+    "profession": "engineer"
+  },
+  {
+    "id": 5812,
+    "name": "bombkit",
+    "profession": "engineer"
+  },
+  {
+    "id": 5813,
+    "name": "bigolbomb",
+    "profession": "engineer"
+  },
+  {
+    "id": 5818,
+    "name": "rifleturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5820,
+    "name": "throwjunk",
+    "profession": "engineer"
+  },
+  {
+    "id": 5821,
+    "name": "elixirb",
+    "profession": "engineer"
+  },
+  {
+    "id": 5822,
+    "name": "concussionbomb",
+    "profession": "thief"
+  },
+  {
+    "id": 5823,
+    "name": "firebomb",
+    "profession": "thief"
+  },
+  {
+    "id": 5824,
+    "name": "smokebomb",
+    "profession": "thief"
+  },
+  {
+    "id": 5825,
+    "name": "slickshoes",
+    "profession": "engineer"
+  },
+  {
+    "id": 5827,
+    "name": "fragmentationshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 5828,
+    "name": "poisondartvolley",
+    "profession": "engineer"
+  },
+  {
+    "id": 5829,
+    "name": "staticshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 5830,
+    "name": "glueshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 5831,
+    "name": "blowtorch",
+    "profession": "engineer"
+  },
+  {
+    "id": 5832,
+    "name": "elixirx",
+    "profession": "engineer"
+  },
+  {
+    "id": 5834,
+    "name": "elixirh",
+    "profession": "engineer"
+  },
+  {
+    "id": 5836,
+    "name": "flameturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5837,
+    "name": "netturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5838,
+    "name": "thumperturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5842,
+    "name": "bomb",
+    "profession": "thief"
+  },
+  {
+    "id": 5857,
+    "name": "healingturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5860,
+    "name": "elixirc",
+    "profession": "engineer"
+  },
+  {
+    "id": 5861,
+    "name": "elixirs",
+    "profession": "engineer"
+  },
+  {
+    "id": 5862,
+    "name": "elixiru",
+    "profession": "engineer"
+  },
+  {
+    "id": 5865,
+    "name": "utilitygoggles",
+    "profession": "engineer"
+  },
+  {
+    "id": 5867,
+    "name": "tosselixirr",
+    "profession": "engineer"
+  },
+  {
+    "id": 5868,
+    "name": "supplycrate",
+    "profession": "engineer"
+  },
+  {
+    "id": 5874,
+    "name": "automaticfire",
+    "profession": "engineer"
+  },
+  {
+    "id": 5882,
+    "name": "grenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 5889,
+    "name": "thump",
+    "profession": "engineer"
+  },
+  {
+    "id": 5893,
+    "name": "electrifiednet",
+    "profession": "engineer"
+  },
+  {
+    "id": 5900,
+    "name": "smokescreen",
+    "profession": "engineer"
+  },
+  {
+    "id": 5904,
+    "name": "toolkit",
+    "profession": "engineer"
+  },
+  {
+    "id": 5905,
+    "name": "prybar",
+    "profession": "engineer"
+  },
+  {
+    "id": 5910,
+    "name": "rocketboots",
+    "profession": "engineer"
+  },
+  {
+    "id": 5912,
+    "name": "rocketturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5913,
+    "name": "explosiverockets",
+    "profession": "engineer"
+  },
+  {
+    "id": 5916,
+    "name": "floatingmine",
+    "profession": "engineer"
+  },
+  {
+    "id": 5917,
+    "name": "anchor",
+    "profession": "engineer"
+  },
+  {
+    "id": 5918,
+    "name": "buoy",
+    "profession": "engineer"
+  },
+  {
+    "id": 5927,
+    "name": "flamethrower",
+    "profession": "engineer"
+  },
+  {
+    "id": 5928,
+    "name": "flamejet",
+    "profession": "thief"
+  },
+  {
+    "id": 5929,
+    "name": "napalm",
+    "profession": "thief"
+  },
+  {
+    "id": 5930,
+    "name": "airblast",
+    "profession": "thief"
+  },
+  {
+    "id": 5931,
+    "name": "flameblast",
+    "profession": "thief"
+  },
+  {
+    "id": 5933,
+    "name": "elixirgun",
+    "profession": "engineer"
+  },
+  {
+    "id": 5934,
+    "name": "tranquilizerdart",
+    "profession": "engineer"
+  },
+  {
+    "id": 5935,
+    "name": "globshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 5936,
+    "name": "acidbomb",
+    "profession": "engineer"
+  },
+  {
+    "id": 5937,
+    "name": "superelixir",
+    "profession": "engineer"
+  },
+  {
+    "id": 5939,
+    "name": "gluebomb",
+    "profession": "thief"
+  },
+  {
+    "id": 5957,
+    "name": "detonaterifleturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5960,
+    "name": "detonatethumperturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5961,
+    "name": "detonatehealingturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5962,
+    "name": "grapplingline",
+    "profession": "engineer"
+  },
+  {
+    "id": 5963,
+    "name": "boobytrap",
+    "profession": "engineer"
+  },
+  {
+    "id": 5965,
+    "name": "fumigate",
+    "profession": "engineer"
+  },
+  {
+    "id": 5966,
+    "name": "healingmist",
+    "profession": "engineer"
+  },
+  {
+    "id": 5967,
+    "name": "tosselixirb",
+    "profession": "engineer"
+  },
+  {
+    "id": 5968,
+    "name": "elixirr",
+    "profession": "engineer"
+  },
+  {
+    "id": 5969,
+    "name": "tosselixirc",
+    "profession": "engineer"
+  },
+  {
+    "id": 5970,
+    "name": "tosselixiru",
+    "profession": "engineer"
+  },
+  {
+    "id": 5972,
+    "name": "tosselixirs",
+    "profession": "engineer"
+  },
+  {
+    "id": 5973,
+    "name": "superspeed",
+    "profession": "engineer"
+  },
+  {
+    "id": 5977,
+    "name": "incendiaryammo",
+    "profession": "engineer"
+  },
+  {
+    "id": 5978,
+    "name": "tosselixirh",
+    "profession": "engineer"
+  },
+  {
+    "id": 5980,
+    "name": "cleansingburst",
+    "profession": "engineer"
+  },
+  {
+    "id": 5982,
+    "name": "launchpersonalbatteringram",
+    "profession": "engineer"
+  },
+  {
+    "id": 5983,
+    "name": "rocketkick",
+    "profession": "engineer"
+  },
+  {
+    "id": 5984,
+    "name": "detonatenetturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5985,
+    "name": "detonateflameturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5987,
+    "name": "flameturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5988,
+    "name": "netturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5989,
+    "name": "rifleturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5990,
+    "name": "thumperturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5991,
+    "name": "rocketturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 5992,
+    "name": "smack",
+    "profession": "engineer"
+  },
+  {
+    "id": 5993,
+    "name": "whack",
+    "profession": "engineer"
+  },
+  {
+    "id": 5994,
+    "name": "thwack",
+    "profession": "engineer"
+  },
+  {
+    "id": 5995,
+    "name": "boxofnails",
+    "profession": "engineer"
+  },
+  {
+    "id": 5996,
+    "name": "magnet",
+    "profession": "engineer"
+  },
+  {
+    "id": 5998,
+    "name": "gearshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 5999,
+    "name": "throwwrench",
+    "profession": "engineer"
+  },
+  {
+    "id": 6003,
+    "name": "hipshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 6004,
+    "name": "netshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 6005,
+    "name": "jumpshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 6020,
+    "name": "grenadekit",
+    "profession": "engineer"
+  },
+  {
+    "id": 6046,
+    "name": "superelixir",
+    "profession": "engineer"
+  },
+  {
+    "id": 6047,
+    "name": "elixirf",
+    "profession": "engineer"
+  },
+  {
+    "id": 6048,
+    "name": "tranquilizerdart",
+    "profession": "engineer"
+  },
+  {
+    "id": 6050,
+    "name": "lessergrenadebarrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 6053,
+    "name": "magneticshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 6054,
+    "name": "staticshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 6057,
+    "name": "throwshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 6077,
+    "name": "tosselixirc",
+    "profession": "engineer"
+  },
+  {
+    "id": 6078,
+    "name": "detonateelixirc",
+    "profession": "engineer"
+  },
+  {
+    "id": 6082,
+    "name": "detonateelixirb",
+    "profession": "engineer"
+  },
+  {
+    "id": 6084,
+    "name": "detonateelixirs",
+    "profession": "engineer"
+  },
+  {
+    "id": 6086,
+    "name": "detonateelixirr",
+    "profession": "engineer"
+  },
+  {
+    "id": 6088,
+    "name": "detonateelixiru",
+    "profession": "engineer"
+  },
+  {
+    "id": 6089,
+    "name": "tosselixiru",
+    "profession": "engineer"
+  },
+  {
+    "id": 6090,
+    "name": "tosselixirs",
+    "profession": "engineer"
+  },
+  {
+    "id": 6091,
+    "name": "tosselixirr",
+    "profession": "engineer"
+  },
+  {
+    "id": 6092,
+    "name": "tosselixirb",
+    "profession": "engineer"
+  },
+  {
+    "id": 6093,
+    "name": "harpoonturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 6097,
+    "name": "detonateharpoonturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 6098,
+    "name": "automaticfire",
+    "profession": "engineer"
+  },
+  {
+    "id": 6102,
+    "name": "superelixir",
+    "profession": "engineer"
+  },
+  {
+    "id": 6104,
+    "name": "superelixir",
+    "profession": "engineer"
+  },
+  {
+    "id": 6109,
+    "name": "stowmedkit",
+    "profession": "engineer"
+  },
+  {
+    "id": 6110,
+    "name": "stowgrenadekit",
+    "profession": "engineer"
+  },
+  {
+    "id": 6111,
+    "name": "stowbombkit",
+    "profession": "engineer"
+  },
+  {
+    "id": 6113,
+    "name": "stowtoolkit",
+    "profession": "engineer"
+  },
+  {
+    "id": 6114,
+    "name": "stowflamethrower",
+    "profession": "engineer"
+  },
+  {
+    "id": 6115,
+    "name": "stowelixirgun",
+    "profession": "engineer"
+  },
+  {
+    "id": 6118,
+    "name": "tosselixirh",
+    "profession": "engineer"
+  },
+  {
+    "id": 6119,
+    "name": "detonateelixirh",
+    "profession": "engineer"
+  },
+  {
+    "id": 6126,
+    "name": "magneticinversion",
+    "profession": "engineer"
+  },
+  {
+    "id": 6134,
+    "name": "detonaterocketturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 6140,
+    "name": "healingturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 6145,
+    "name": "netwall",
+    "profession": "engineer"
+  },
+  {
+    "id": 6147,
+    "name": "scattermines",
+    "profession": "engineer"
+  },
+  {
+    "id": 6148,
+    "name": "homingtorpedo",
+    "profession": "engineer"
+  },
+  {
+    "id": 6149,
+    "name": "timedcharge",
+    "profession": "engineer"
+  },
+  {
+    "id": 6153,
+    "name": "blunderbuss",
+    "profession": "engineer"
+  },
+  {
+    "id": 6154,
+    "name": "overchargedshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 6159,
+    "name": "smokevent",
+    "profession": "thief"
+  },
+  {
+    "id": 6161,
+    "name": "throwmine",
+    "profession": "engineer"
+  },
+  {
+    "id": 6162,
+    "name": "detonate",
+    "profession": "engineer"
+  },
+  {
+    "id": 6163,
+    "name": "deploymine",
+    "profession": "engineer"
+  },
+  {
+    "id": 6164,
+    "name": "minefield",
+    "profession": "engineer"
+  },
+  {
+    "id": 6166,
+    "name": "detonateminefield",
+    "profession": "engineer"
+  },
+  {
+    "id": 6167,
+    "name": "poisongrenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 6168,
+    "name": "freezegrenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 6169,
+    "name": "flashgrenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 6170,
+    "name": "shrapnelgrenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 6171,
+    "name": "grenade",
+    "profession": "engineer"
+  },
+  {
+    "id": 6172,
+    "name": "grenadebarrage",
+    "profession": "engineer"
+  },
+  {
+    "id": 6175,
+    "name": "boxofpiranhas",
+    "profession": "engineer"
+  },
+  {
+    "id": 6176,
+    "name": "regeneratingmist",
+    "profession": "engineer"
+  },
+  {
+    "id": 6177,
+    "name": "rocket",
+    "profession": "engineer"
+  },
+  {
+    "id": 6178,
+    "name": "surpriseshot",
+    "profession": "engineer"
+  },
+  {
+    "id": 6179,
+    "name": "netattack",
+    "profession": "engineer"
+  },
+  {
+    "id": 6180,
+    "name": "rumble",
+    "profession": "engineer"
+  },
+  {
+    "id": 6181,
+    "name": "thrownapalm",
+    "profession": "engineer"
+  },
+  {
+    "id": 6182,
+    "name": "harpoon",
+    "profession": "engineer"
+  },
+  {
+    "id": 6183,
+    "name": "supplycrate",
+    "profession": "engineer"
+  },
+  {
+    "id": 9080,
+    "name": "leapoffaith",
+    "profession": "guardian"
+  },
+  {
+    "id": 9081,
+    "name": "whirlingwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 9082,
+    "name": "shieldofwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 9083,
+    "name": "receivethelight",
+    "profession": "guardian"
+  },
+  {
+    "id": 9084,
+    "name": "advance",
+    "profession": "guardian"
+  },
+  {
+    "id": 9085,
+    "name": "saveyourselves",
+    "profession": "guardian"
+  },
+  {
+    "id": 9086,
+    "name": "protectorsstrike",
+    "profession": "guardian"
+  },
+  {
+    "id": 9087,
+    "name": "shieldofjudgment",
+    "profession": "guardian"
+  },
+  {
+    "id": 9088,
+    "name": "cleansingflame",
+    "profession": "guardian"
+  },
+  {
+    "id": 9089,
+    "name": "zealotsfire",
+    "profession": "guardian"
+  },
+  {
+    "id": 9090,
+    "name": "symbolofpunishment",
+    "profession": "guardian"
+  },
+  {
+    "id": 9091,
+    "name": "shieldofabsorption",
+    "profession": "guardian"
+  },
+  {
+    "id": 9093,
+    "name": "banesignet",
+    "profession": "guardian"
+  },
+  {
+    "id": 9095,
+    "name": "symbolofjudgment",
+    "profession": "guardian"
+  },
+  {
+    "id": 9096,
+    "name": "waveoflight",
+    "profession": "guardian"
+  },
+  {
+    "id": 9097,
+    "name": "symbolofblades",
+    "profession": "guardian"
+  },
+  {
+    "id": 9098,
+    "name": "orbofwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 9099,
+    "name": "chainsoflight",
+    "profession": "guardian"
+  },
+  {
+    "id": 9101,
+    "name": "lessersmitecondition",
+    "profession": "bundle"
+  },
+  {
+    "id": 9102,
+    "name": "shelter",
+    "profession": "guardian"
+  },
+  {
+    "id": 9104,
+    "name": "zealotsflame",
+    "profession": "guardian"
+  },
+  {
+    "id": 9105,
+    "name": "swordofwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 9106,
+    "name": "swordarc",
+    "profession": "guardian"
+  },
+  {
+    "id": 9107,
+    "name": "zealotsdefense",
+    "profession": "guardian"
+  },
+  {
+    "id": 9108,
+    "name": "faithfulstrike",
+    "profession": "guardian"
+  },
+  {
+    "id": 9109,
+    "name": "truestrike",
+    "profession": "guardian"
+  },
+  {
+    "id": 9110,
+    "name": "purestrike",
+    "profession": "guardian"
+  },
+  {
+    "id": 9111,
+    "name": "symboloffaith",
+    "profession": "guardian"
+  },
+  {
+    "id": 9112,
+    "name": "rayofjudgment",
+    "profession": "guardian"
+  },
+  {
+    "id": 9115,
+    "name": "virtueofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 9118,
+    "name": "virtueofcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 9120,
+    "name": "virtueofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 9122,
+    "name": "boltofwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 9124,
+    "name": "banish",
+    "profession": "guardian"
+  },
+  {
+    "id": 9125,
+    "name": "hammerofwisdom",
+    "profession": "guardian"
+  },
+  {
+    "id": 9128,
+    "name": "sanctuary",
+    "profession": "guardian"
+  },
+  {
+    "id": 9137,
+    "name": "strike",
+    "profession": "guardian"
+  },
+  {
+    "id": 9138,
+    "name": "vengefulstrike",
+    "profession": "guardian"
+  },
+  {
+    "id": 9139,
+    "name": "wrathfulstrike",
+    "profession": "guardian"
+  },
+  {
+    "id": 9140,
+    "name": "holystrike",
+    "profession": "guardian"
+  },
+  {
+    "id": 9143,
+    "name": "symbolofswiftness",
+    "profession": "guardian"
+  },
+  {
+    "id": 9144,
+    "name": "lineofwarding",
+    "profession": "guardian"
+  },
+  {
+    "id": 9146,
+    "name": "symbolofresolution",
+    "profession": "guardian"
+  },
+  {
+    "id": 9147,
+    "name": "bindingblade",
+    "profession": "guardian"
+  },
+  {
+    "id": 9149,
+    "name": "wrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 9150,
+    "name": "signetofjudgment",
+    "profession": "guardian"
+  },
+  {
+    "id": 9151,
+    "name": "signetofwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 9152,
+    "name": "holdtheline",
+    "profession": "guardian"
+  },
+  {
+    "id": 9153,
+    "name": "standyourground",
+    "profession": "guardian"
+  },
+  {
+    "id": 9154,
+    "name": "renewedfocus",
+    "profession": "guardian"
+  },
+  {
+    "id": 9158,
+    "name": "signetofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 9159,
+    "name": "hammerswing",
+    "profession": "guardian"
+  },
+  {
+    "id": 9160,
+    "name": "hammerbash",
+    "profession": "guardian"
+  },
+  {
+    "id": 9161,
+    "name": "symbolofprotection",
+    "profession": "guardian"
+  },
+  {
+    "id": 9163,
+    "name": "signetofmercy",
+    "profession": "guardian"
+  },
+  {
+    "id": 9168,
+    "name": "swordofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 9175,
+    "name": "bowoftruth",
+    "profession": "guardian"
+  },
+  {
+    "id": 9182,
+    "name": "shieldoftheavenger",
+    "profession": "guardian"
+  },
+  {
+    "id": 9187,
+    "name": "purgingflames",
+    "profession": "guardian"
+  },
+  {
+    "id": 9189,
+    "name": "spearoflight",
+    "profession": "guardian"
+  },
+  {
+    "id": 9190,
+    "name": "zealotsflurry",
+    "profession": "guardian"
+  },
+  {
+    "id": 9191,
+    "name": "brilliance",
+    "profession": "guardian"
+  },
+  {
+    "id": 9192,
+    "name": "symbolofspears",
+    "profession": "guardian"
+  },
+  {
+    "id": 9193,
+    "name": "wrathfulgrasp",
+    "profession": "guardian"
+  },
+  {
+    "id": 9194,
+    "name": "mightyblow",
+    "profession": "guardian"
+  },
+  {
+    "id": 9195,
+    "name": "ringofwarding",
+    "profession": "guardian"
+  },
+  {
+    "id": 9205,
+    "name": "lightball",
+    "profession": "guardian"
+  },
+  {
+    "id": 9206,
+    "name": "weightofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 9207,
+    "name": "purify",
+    "profession": "guardian"
+  },
+  {
+    "id": 9208,
+    "name": "symboloflight",
+    "profession": "guardian"
+  },
+  {
+    "id": 9209,
+    "name": "refraction",
+    "profession": "guardian"
+  },
+  {
+    "id": 9210,
+    "name": "renewingcurrent",
+    "profession": "guardian"
+  },
+  {
+    "id": 9211,
+    "name": "revealthedepths",
+    "profession": "guardian"
+  },
+  {
+    "id": 9212,
+    "name": "shackle",
+    "profession": "guardian"
+  },
+  {
+    "id": 9224,
+    "name": "shieldofabsorption",
+    "profession": "guardian"
+  },
+  {
+    "id": 9226,
+    "name": "pull",
+    "profession": "guardian"
+  },
+  {
+    "id": 9227,
+    "name": "swordwave",
+    "profession": "guardian"
+  },
+  {
+    "id": 9234,
+    "name": "purifyingblast",
+    "profession": "guardian"
+  },
+  {
+    "id": 9245,
+    "name": "smitecondition",
+    "profession": "guardian"
+  },
+  {
+    "id": 9246,
+    "name": "mercifulintervention",
+    "profession": "guardian"
+  },
+  {
+    "id": 9247,
+    "name": "judgesintervention",
+    "profession": "guardian"
+  },
+  {
+    "id": 9248,
+    "name": "contemplationofpurity",
+    "profession": "guardian"
+  },
+  {
+    "id": 9250,
+    "name": "virtueofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 9251,
+    "name": "wallofreflection",
+    "profession": "guardian"
+  },
+  {
+    "id": 9253,
+    "name": "hallowedground",
+    "profession": "guardian"
+  },
+  {
+    "id": 9260,
+    "name": "zealotsembrace",
+    "profession": "guardian"
+  },
+  {
+    "id": 9265,
+    "name": "empower",
+    "profession": "guardian"
+  },
+  {
+    "id": 9268,
+    "name": "virtueofcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 10168,
+    "name": "confusingimages",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10169,
+    "name": "chaosstorm",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10170,
+    "name": "mindslash",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10171,
+    "name": "mindgash",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10172,
+    "name": "mindspike",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10173,
+    "name": "illusionaryleap",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10174,
+    "name": "phantasmalswordsman",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10175,
+    "name": "phantasmalduelist",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10176,
+    "name": "etherfeast",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10177,
+    "name": "mirror",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10180,
+    "name": "kick"
+  },
+  {
+    "id": 10181,
+    "name": "peck"
+  },
+  {
+    "id": 10182,
+    "name": "screech"
+  },
+  {
+    "id": 10183,
+    "name": "claw"
+  },
+  {
+    "id": 10185,
+    "name": "arcanethievery",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10186,
+    "name": "temporalcurtain",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10187,
+    "name": "veil",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10189,
+    "name": "phantasmalmage",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10190,
+    "name": "cryoffrustration",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10191,
+    "name": "mindwrack",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10192,
+    "name": "distortion",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10196,
+    "name": "mindblast",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10197,
+    "name": "portalentre",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10199,
+    "name": "portalexeunt",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10200,
+    "name": "blink",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10201,
+    "name": "decoy",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10202,
+    "name": "mirrorimages",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10203,
+    "name": "nullfield",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10204,
+    "name": "mantraofdistraction",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10207,
+    "name": "mantraofresolve",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10211,
+    "name": "mantraofpain",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10213,
+    "name": "mantraofrecovery",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10216,
+    "name": "phantasmalwarlock",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10218,
+    "name": "mindstab",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10219,
+    "name": "spatialsurge",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10220,
+    "name": "illusionarywave",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10221,
+    "name": "phantasmalberserker",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10224,
+    "name": "phantasmalrogue",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10229,
+    "name": "magicbullet",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10232,
+    "name": "signetofdomination",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10234,
+    "name": "signetofmidnight",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10236,
+    "name": "signetofinspiration",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10237,
+    "name": "mantraofconcentration",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10244,
+    "name": "illusionoflife",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10245,
+    "name": "massinvisibility",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10247,
+    "name": "signetofillusions",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10251,
+    "name": "phantasmalmariner",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10255,
+    "name": "vortex",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10258,
+    "name": "sirenscall",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10259,
+    "name": "blindingtide",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10260,
+    "name": "illusionofdrowning",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10267,
+    "name": "phantasmaldisenchanter",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10273,
+    "name": "windsofchaos",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10276,
+    "name": "illusionarycounter",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10280,
+    "name": "illusionaryriposte",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10282,
+    "name": "phantasmalwarden",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10285,
+    "name": "theprestige",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10287,
+    "name": "diversion",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10289,
+    "name": "etherbolt",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10290,
+    "name": "etherblast",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10291,
+    "name": "etherclone",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10302,
+    "name": "feedback",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10310,
+    "name": "phaseretreat",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10311,
+    "name": "timewarp",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10314,
+    "name": "counterspell",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10315,
+    "name": "stab",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10316,
+    "name": "jab",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10317,
+    "name": "evasivestrike",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10318,
+    "name": "feignedsurge",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10325,
+    "name": "slipstream",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10327,
+    "name": "imminentvoyage",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10328,
+    "name": "phantasmalwhaler",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10331,
+    "name": "chaosarmor",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10333,
+    "name": "mirrorblade",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10334,
+    "name": "blurredfrenzy",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10337,
+    "name": "swap",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10341,
+    "name": "phantasmaldefender",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10356,
+    "name": "feedback",
+    "profession": "bundle"
+  },
+  {
+    "id": 10358,
+    "name": "counterblade",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10363,
+    "name": "intothevoid",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10366,
+    "name": "deception",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10372,
+    "name": "bite"
+  },
+  {
+    "id": 10373,
+    "name": "chomp"
+  },
+  {
+    "id": 10374,
+    "name": "frenzy"
+  },
+  {
+    "id": 10375,
+    "name": "flee"
+  },
+  {
+    "id": 10376,
+    "name": "spit"
+  },
+  {
+    "id": 10377,
+    "name": "timewarp",
+    "profession": "mesmer"
+  },
+  {
+    "id": 10527,
+    "name": "wellofblood",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10528,
+    "name": "ghastlyclaws",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10529,
+    "name": "darkpact",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10532,
+    "name": "graspingdead",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10533,
+    "name": "summonbonefiend",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10540,
+    "name": "putridexplosion",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10541,
+    "name": "summonboneminions",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10543,
+    "name": "summonfleshwurm",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10544,
+    "name": "bloodispower",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10545,
+    "name": "wellofcorruption",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10546,
+    "name": "wellofsuffering",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10547,
+    "name": "summonbloodfiend",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10548,
+    "name": "consumeconditions",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10549,
+    "name": "plaguelands",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10550,
+    "name": "lichform",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10552,
+    "name": "putridcurse",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10554,
+    "name": "lifeblast",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10555,
+    "name": "spinalshivers",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10556,
+    "name": "wailofdoom",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10557,
+    "name": "locustswarm",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10559,
+    "name": "fetidground",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10560,
+    "name": "lifeleech",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10561,
+    "name": "rendingclaws",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10562,
+    "name": "plaguesignet",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10563,
+    "name": "lifesiphon",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10570,
+    "name": "rigormortis",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10574,
+    "name": "deathshroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10577,
+    "name": "tasteofdeath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10583,
+    "name": "spectralarmor",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10585,
+    "name": "enddeathshroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10586,
+    "name": "locked",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10588,
+    "name": "doom",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10589,
+    "name": "summonshadowfiend",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10590,
+    "name": "haunt",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10594,
+    "name": "lifetransfer",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10596,
+    "name": "necroticgrasp",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10600,
+    "name": "necrotictraversal",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10602,
+    "name": "corruptboon",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10604,
+    "name": "darkpath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10605,
+    "name": "chillblains",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10606,
+    "name": "epidemic",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10607,
+    "name": "wellofdarkness",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10608,
+    "name": "spectralring",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10609,
+    "name": "wellofpower",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10611,
+    "name": "signetofundeath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10612,
+    "name": "signetofthelocust",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10616,
+    "name": "darkspear",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10617,
+    "name": "reapersscythe",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10619,
+    "name": "deadlyfeast",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10620,
+    "name": "spectralgrasp",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10622,
+    "name": "signetofspite",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10623,
+    "name": "crimsontide",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10624,
+    "name": "feast",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10625,
+    "name": "foulcurrent",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10628,
+    "name": "sinkingtomb",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10629,
+    "name": "frozenabyss",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10632,
+    "name": "grimspecter"
+  },
+  {
+    "id": 10633,
+    "name": "rippleofhorror"
+  },
+  {
+    "id": 10634,
+    "name": "deathlyclaws",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10635,
+    "name": "lichsgaze"
+  },
+  {
+    "id": 10636,
+    "name": "summonmadness"
+  },
+  {
+    "id": 10640,
+    "name": "lifeleech",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10641,
+    "name": "deathcurse",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10642,
+    "name": "feedingfrenzy",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10643,
+    "name": "gatheringplague",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10644,
+    "name": "darkwater",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10645,
+    "name": "waveoffear",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10646,
+    "name": "summonfleshgolem",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10647,
+    "name": "charge",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10660,
+    "name": "fear",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10661,
+    "name": "witheringplague",
+    "profession": "thief"
+  },
+  {
+    "id": 10662,
+    "name": "plagueofdarkness",
+    "profession": "thief"
+  },
+  {
+    "id": 10663,
+    "name": "plagueofpestilence",
+    "profession": "thief"
+  },
+  {
+    "id": 10670,
+    "name": "wellofblood",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10671,
+    "name": "wellofcorruption",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10672,
+    "name": "wellofdarkness",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10673,
+    "name": "wellofpower",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10674,
+    "name": "wellofsuffering",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10685,
+    "name": "spectralwalk",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10687,
+    "name": "spectralrecall",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10689,
+    "name": "corrosivepoisoncloud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10690,
+    "name": "plagueblast",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10692,
+    "name": "cruelstrike",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10693,
+    "name": "wickedstrike",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10694,
+    "name": "wickedspiral",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10695,
+    "name": "deadlycatch",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10698,
+    "name": "bloodcurse",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10699,
+    "name": "rendingcurse",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10701,
+    "name": "unholyfeast",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10702,
+    "name": "necroticslash",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10703,
+    "name": "necroticstab",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10704,
+    "name": "necroticbite",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10705,
+    "name": "deathlyswarm",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10706,
+    "name": "enfeeblingblood",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10709,
+    "name": "feastofcorruption",
+    "profession": "necromancer"
+  },
+  {
+    "id": 10800,
+    "name": "mistfirewolf",
+    "profession": "guardian"
+  },
+  {
+    "id": 11164,
+    "name": "rendinglunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 12318,
+    "name": "technobabble",
+    "profession": "guardian"
+  },
+  {
+    "id": 12319,
+    "name": "radiationfield",
+    "profession": "guardian"
+  },
+  {
+    "id": 12320,
+    "name": "paininverter",
+    "profession": "guardian"
+  },
+  {
+    "id": 12323,
+    "name": "summonseriesgolem",
+    "profession": "guardian"
+  },
+  {
+    "id": 12324,
+    "name": "summondseriesgolem",
+    "profession": "guardian"
+  },
+  {
+    "id": 12325,
+    "name": "summonpowersuit",
+    "profession": "guardian"
+  },
+  {
+    "id": 12334,
+    "name": "confusingspeech",
+    "profession": "engineer"
+  },
+  {
+    "id": 12335,
+    "name": "paintransference",
+    "profession": "engineer"
+  },
+  {
+    "id": 12336,
+    "name": "ventradiation",
+    "profession": "engineer"
+  },
+  {
+    "id": 12337,
+    "name": "shrapnelmine",
+    "profession": "guardian"
+  },
+  {
+    "id": 12338,
+    "name": "battleroar",
+    "profession": "guardian"
+  },
+  {
+    "id": 12339,
+    "name": "hiddenpistol",
+    "profession": "guardian"
+  },
+  {
+    "id": 12340,
+    "name": "warbandsupport",
+    "profession": "guardian"
+  },
+  {
+    "id": 12343,
+    "name": "artillerybarrage",
+    "profession": "guardian"
+  },
+  {
+    "id": 12344,
+    "name": "charrzooka",
+    "profession": "guardian"
+  },
+  {
+    "id": 12345,
+    "name": "firerocket",
+    "profession": "thief"
+  },
+  {
+    "id": 12346,
+    "name": "firerocketbarrage",
+    "profession": "thief"
+  },
+  {
+    "id": 12347,
+    "name": "rocketjump",
+    "profession": "thief"
+  },
+  {
+    "id": 12348,
+    "name": "rocketspray",
+    "profession": "thief"
+  },
+  {
+    "id": 12349,
+    "name": "heatseeker",
+    "profession": "thief"
+  },
+  {
+    "id": 12354,
+    "name": "invigoratingroar",
+    "profession": "engineer"
+  },
+  {
+    "id": 12355,
+    "name": "boobytrap",
+    "profession": "engineer"
+  },
+  {
+    "id": 12357,
+    "name": "hiddenpistols",
+    "profession": "engineer"
+  },
+  {
+    "id": 12360,
+    "name": "prayertodwayna",
+    "profession": "guardian"
+  },
+  {
+    "id": 12361,
+    "name": "prayertokormir",
+    "profession": "guardian"
+  },
+  {
+    "id": 12362,
+    "name": "prayertolyssa",
+    "profession": "guardian"
+  },
+  {
+    "id": 12363,
+    "name": "houndsofbalthazar",
+    "profession": "guardian"
+  },
+  {
+    "id": 12367,
+    "name": "reaperofgrenth",
+    "profession": "guardian"
+  },
+  {
+    "id": 12370,
+    "name": "oakheartswipe"
+  },
+  {
+    "id": 12371,
+    "name": "bindingroots"
+  },
+  {
+    "id": 12372,
+    "name": "removeavatarofmelandru",
+    "profession": "guardian"
+  },
+  {
+    "id": 12373,
+    "name": "avatarofmelandru",
+    "profession": "guardian"
+  },
+  {
+    "id": 12374,
+    "name": "cleansingleaves"
+  },
+  {
+    "id": 12375,
+    "name": "summonhealingspring"
+  },
+  {
+    "id": 12376,
+    "name": "roaroftheforest"
+  },
+  {
+    "id": 12377,
+    "name": "blessingofdwayna",
+    "profession": "engineer"
+  },
+  {
+    "id": 12378,
+    "name": "blessingofkormir",
+    "profession": "engineer"
+  },
+  {
+    "id": 12379,
+    "name": "blessingoflyssa",
+    "profession": "engineer"
+  },
+  {
+    "id": 12380,
+    "name": "charge",
+    "profession": "thief"
+  },
+  {
+    "id": 12385,
+    "name": "becomethebear",
+    "profession": "guardian"
+  },
+  {
+    "id": 12386,
+    "name": "releasethebear",
+    "profession": "guardian"
+  },
+  {
+    "id": 12387,
+    "name": "callowl",
+    "profession": "guardian"
+  },
+  {
+    "id": 12389,
+    "name": "leap"
+  },
+  {
+    "id": 12390,
+    "name": "howl"
+  },
+  {
+    "id": 12391,
+    "name": "becomethewolf",
+    "profession": "guardian"
+  },
+  {
+    "id": 12392,
+    "name": "releasethewolf",
+    "profession": "guardian"
+  },
+  {
+    "id": 12399,
+    "name": "prowl"
+  },
+  {
+    "id": 12401,
+    "name": "becomethesnowleopard",
+    "profession": "guardian"
+  },
+  {
+    "id": 12402,
+    "name": "releasethesnowleopard",
+    "profession": "guardian"
+  },
+  {
+    "id": 12403,
+    "name": "becometheraven",
+    "profession": "guardian"
+  },
+  {
+    "id": 12404,
+    "name": "releasetheraven",
+    "profession": "guardian"
+  },
+  {
+    "id": 12406,
+    "name": "windblast"
+  },
+  {
+    "id": 12407,
+    "name": "rendingtalons"
+  },
+  {
+    "id": 12408,
+    "name": "shriek"
+  },
+  {
+    "id": 12409,
+    "name": "swoop"
+  },
+  {
+    "id": 12410,
+    "name": "swipe"
+  },
+  {
+    "id": 12417,
+    "name": "callwurm",
+    "profession": "guardian"
+  },
+  {
+    "id": 12421,
+    "name": "cripplingswipe"
+  },
+  {
+    "id": 12422,
+    "name": "rendingswipe"
+  },
+  {
+    "id": 12423,
+    "name": "rendingslash"
+  },
+  {
+    "id": 12424,
+    "name": "bloodfrenzy"
+  },
+  {
+    "id": 12425,
+    "name": "snarl"
+  },
+  {
+    "id": 12427,
+    "name": "dash"
+  },
+  {
+    "id": 12429,
+    "name": "frenzy"
+  },
+  {
+    "id": 12430,
+    "name": "growl"
+  },
+  {
+    "id": 12431,
+    "name": "pounce"
+  },
+  {
+    "id": 12432,
+    "name": "swipe",
+    "profession": "thief"
+  },
+  {
+    "id": 12433,
+    "name": "brutalswipe",
+    "profession": "thief"
+  },
+  {
+    "id": 12434,
+    "name": "heavyswipe",
+    "profession": "thief"
+  },
+  {
+    "id": 12435,
+    "name": "roar",
+    "profession": "thief"
+  },
+  {
+    "id": 12436,
+    "name": "maul",
+    "profession": "thief"
+  },
+  {
+    "id": 12438,
+    "name": "eatwurmegg",
+    "profession": "engineer"
+  },
+  {
+    "id": 12439,
+    "name": "eatowlegg",
+    "profession": "engineer"
+  },
+  {
+    "id": 12440,
+    "name": "healingseed",
+    "profession": "guardian"
+  },
+  {
+    "id": 12447,
+    "name": "summondruidspirit",
+    "profession": "guardian"
+  },
+  {
+    "id": 12450,
+    "name": "summonsylvanhound",
+    "profession": "guardian"
+  },
+  {
+    "id": 12453,
+    "name": "graspingvines",
+    "profession": "guardian"
+  },
+  {
+    "id": 12456,
+    "name": "seedturret",
+    "profession": "guardian"
+  },
+  {
+    "id": 12457,
+    "name": "takeroot",
+    "profession": "guardian"
+  },
+  {
+    "id": 12462,
+    "name": "throwvine",
+    "profession": "engineer"
+  },
+  {
+    "id": 12463,
+    "name": "vineshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 12465,
+    "name": "leafybandage",
+    "profession": "engineer"
+  },
+  {
+    "id": 12466,
+    "name": "ricochet",
+    "profession": "ranger"
+  },
+  {
+    "id": 12468,
+    "name": "poisonvolley",
+    "profession": "ranger"
+  },
+  {
+    "id": 12469,
+    "name": "barrage",
+    "profession": "ranger"
+  },
+  {
+    "id": 12470,
+    "name": "crossfire",
+    "profession": "ranger"
+  },
+  {
+    "id": 12471,
+    "name": "slash",
+    "profession": "ranger"
+  },
+  {
+    "id": 12472,
+    "name": "cripplingthrust",
+    "profession": "ranger"
+  },
+  {
+    "id": 12473,
+    "name": "precisionswipe",
+    "profession": "ranger"
+  },
+  {
+    "id": 12474,
+    "name": "slash",
+    "profession": "ranger"
+  },
+  {
+    "id": 12475,
+    "name": "hiltbash",
+    "profession": "ranger"
+  },
+  {
+    "id": 12476,
+    "name": "spiketrap",
+    "profession": "ranger"
+  },
+  {
+    "id": 12477,
+    "name": "cripplingtalon",
+    "profession": "ranger"
+  },
+  {
+    "id": 12478,
+    "name": "stalkersstrike",
+    "profession": "ranger"
+  },
+  {
+    "id": 12480,
+    "name": "splitblade",
+    "profession": "ranger"
+  },
+  {
+    "id": 12481,
+    "name": "hornetsting",
+    "profession": "ranger"
+  },
+  {
+    "id": 12482,
+    "name": "monarchsleap",
+    "profession": "ranger"
+  },
+  {
+    "id": 12483,
+    "name": "trollunguent",
+    "profession": "ranger"
+  },
+  {
+    "id": 12485,
+    "name": "thunderclap",
+    "profession": "ranger"
+  },
+  {
+    "id": 12486,
+    "name": "throwdirt",
+    "profession": "ranger"
+  },
+  {
+    "id": 12487,
+    "name": "slice",
+    "profession": "ranger"
+  },
+  {
+    "id": 12488,
+    "name": "enduringswing",
+    "profession": "ranger"
+  },
+  {
+    "id": 12489,
+    "name": "healingspring",
+    "profession": "ranger"
+  },
+  {
+    "id": 12490,
+    "name": "wintersbite",
+    "profession": "ranger"
+  },
+  {
+    "id": 12491,
+    "name": "signetofthewild",
+    "profession": "ranger"
+  },
+  {
+    "id": 12492,
+    "name": "frosttrap",
+    "profession": "ranger"
+  },
+  {
+    "id": 12493,
+    "name": "stormspirit",
+    "profession": "ranger"
+  },
+  {
+    "id": 12494,
+    "name": "lightningreflexes",
+    "profession": "ranger"
+  },
+  {
+    "id": 12495,
+    "name": "stonespirit",
+    "profession": "ranger"
+  },
+  {
+    "id": 12496,
+    "name": "vipersnest",
+    "profession": "ranger"
+  },
+  {
+    "id": 12497,
+    "name": "frostspirit",
+    "profession": "ranger"
+  },
+  {
+    "id": 12498,
+    "name": "sunspirit",
+    "profession": "ranger"
+  },
+  {
+    "id": 12499,
+    "name": "flametrap",
+    "profession": "ranger"
+  },
+  {
+    "id": 12500,
+    "name": "signetofstone",
+    "profession": "ranger"
+  },
+  {
+    "id": 12501,
+    "name": "muddyterrain",
+    "profession": "ranger"
+  },
+  {
+    "id": 12502,
+    "name": "signetofrenewal",
+    "profession": "ranger"
+  },
+  {
+    "id": 12504,
+    "name": "bonfire",
+    "profession": "ranger"
+  },
+  {
+    "id": 12507,
+    "name": "cripplingshot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12508,
+    "name": "concussionshot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12509,
+    "name": "rapidfire",
+    "profession": "ranger"
+  },
+  {
+    "id": 12510,
+    "name": "longrangeshot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12511,
+    "name": "pointblankshot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12515,
+    "name": "lickwounds",
+    "profession": "ranger"
+  },
+  {
+    "id": 12516,
+    "name": "strengthofthepack",
+    "profession": "ranger"
+  },
+  {
+    "id": 12517,
+    "name": "quickshot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12521,
+    "name": "swoop",
+    "profession": "ranger"
+  },
+  {
+    "id": 12522,
+    "name": "counterattack",
+    "profession": "ranger"
+  },
+  {
+    "id": 12523,
+    "name": "counterattackkick",
+    "profession": "ranger"
+  },
+  {
+    "id": 12525,
+    "name": "maul",
+    "profession": "ranger"
+  },
+  {
+    "id": 12526,
+    "name": "splintershot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12527,
+    "name": "mercyshot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12528,
+    "name": "feedingfrenzy",
+    "profession": "ranger"
+  },
+  {
+    "id": 12529,
+    "name": "coralshot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12530,
+    "name": "inkblast",
+    "profession": "ranger"
+  },
+  {
+    "id": 12533,
+    "name": "vipersnest",
+    "profession": "ranger"
+  },
+  {
+    "id": 12535,
+    "name": "frosttrap",
+    "profession": "ranger"
+  },
+  {
+    "id": 12537,
+    "name": "sharpeningstone",
+    "profession": "ranger"
+  },
+  {
+    "id": 12542,
+    "name": "signetofthehunt",
+    "profession": "ranger"
+  },
+  {
+    "id": 12550,
+    "name": "quickeningzephyr",
+    "profession": "ranger"
+  },
+  {
+    "id": 12552,
+    "name": "manowar",
+    "profession": "ranger"
+  },
+  {
+    "id": 12553,
+    "name": "stab",
+    "profession": "ranger"
+  },
+  {
+    "id": 12555,
+    "name": "jab",
+    "profession": "ranger"
+  },
+  {
+    "id": 12556,
+    "name": "toxicstrike",
+    "profession": "ranger"
+  },
+  {
+    "id": 12557,
+    "name": "surgingmaw",
+    "profession": "ranger"
+  },
+  {
+    "id": 12559,
+    "name": "swirlingstrike",
+    "profession": "ranger"
+  },
+  {
+    "id": 12561,
+    "name": "counterstrike",
+    "profession": "ranger"
+  },
+  {
+    "id": 12566,
+    "name": "throwknife",
+    "profession": "ranger"
+  },
+  {
+    "id": 12569,
+    "name": "spiritofnature",
+    "profession": "ranger"
+  },
+  {
+    "id": 12570,
+    "name": "flametrap",
+    "profession": "ranger"
+  },
+  {
+    "id": 12573,
+    "name": "huntersshot",
+    "profession": "ranger"
+  },
+  {
+    "id": 12580,
+    "name": "entangle",
+    "profession": "ranger"
+  },
+  {
+    "id": 12592,
+    "name": "solarflare",
+    "profession": "ranger"
+  },
+  {
+    "id": 12593,
+    "name": "coldsnap",
+    "profession": "ranger"
+  },
+  {
+    "id": 12594,
+    "name": "calllightning",
+    "profession": "ranger"
+  },
+  {
+    "id": 12595,
+    "name": "quicksand",
+    "profession": "ranger"
+  },
+  {
+    "id": 12596,
+    "name": "naturesrenewal",
+    "profession": "ranger"
+  },
+  {
+    "id": 12620,
+    "name": "hunterscall",
+    "profession": "ranger"
+  },
+  {
+    "id": 12621,
+    "name": "callofthewild",
+    "profession": "ranger"
+  },
+  {
+    "id": 12622,
+    "name": "serpentsstrike",
+    "profession": "ranger"
+  },
+  {
+    "id": 12630,
+    "name": "counterthrow",
+    "profession": "ranger"
+  },
+  {
+    "id": 12631,
+    "name": "protectme",
+    "profession": "ranger"
+  },
+  {
+    "id": 12632,
+    "name": "guard",
+    "profession": "ranger"
+  },
+  {
+    "id": 12633,
+    "name": "sicem",
+    "profession": "ranger"
+  },
+  {
+    "id": 12635,
+    "name": "throwtorch",
+    "profession": "ranger"
+  },
+  {
+    "id": 12638,
+    "name": "pathofscars",
+    "profession": "ranger"
+  },
+  {
+    "id": 12639,
+    "name": "whirlingdefense",
+    "profession": "ranger"
+  },
+  {
+    "id": 12656,
+    "name": "icybite"
+  },
+  {
+    "id": 12658,
+    "name": "mightyroar"
+  },
+  {
+    "id": 12664,
+    "name": "rendingmaul"
+  },
+  {
+    "id": 12666,
+    "name": "shakeitoff"
+  },
+  {
+    "id": 12667,
+    "name": "icyroar"
+  },
+  {
+    "id": 12670,
+    "name": "firebreath"
+  },
+  {
+    "id": 12674,
+    "name": "poisonbarbs"
+  },
+  {
+    "id": 12675,
+    "name": "poisonouscloud"
+  },
+  {
+    "id": 12679,
+    "name": "rendingbarbs"
+  },
+  {
+    "id": 12680,
+    "name": "rendingpounce"
+  },
+  {
+    "id": 12681,
+    "name": "stalk"
+  },
+  {
+    "id": 12685,
+    "name": "enfeeblingroar"
+  },
+  {
+    "id": 12687,
+    "name": "poisoncloud"
+  },
+  {
+    "id": 12688,
+    "name": "enfeeblingmaul"
+  },
+  {
+    "id": 12689,
+    "name": "icymaul"
+  },
+  {
+    "id": 12690,
+    "name": "poisonousmaul"
+  },
+  {
+    "id": 12691,
+    "name": "purgeconditions"
+  },
+  {
+    "id": 12693,
+    "name": "icypounce"
+  },
+  {
+    "id": 12695,
+    "name": "boil"
+  },
+  {
+    "id": 12696,
+    "name": "frostbreath"
+  },
+  {
+    "id": 12697,
+    "name": "frostnova"
+  },
+  {
+    "id": 12698,
+    "name": "lightningbreath"
+  },
+  {
+    "id": 12699,
+    "name": "electrocute"
+  },
+  {
+    "id": 12700,
+    "name": "poisoncloud"
+  },
+  {
+    "id": 12701,
+    "name": "insectswarm"
+  },
+  {
+    "id": 12702,
+    "name": "poisoncloud"
+  },
+  {
+    "id": 12703,
+    "name": "regenerate"
+  },
+  {
+    "id": 12704,
+    "name": "lashtailvenom"
+  },
+  {
+    "id": 12708,
+    "name": "dazingscreech"
+  },
+  {
+    "id": 12709,
+    "name": "dazingscreech"
+  },
+  {
+    "id": 12711,
+    "name": "icyscreech"
+  },
+  {
+    "id": 12712,
+    "name": "furiousscreech"
+  },
+  {
+    "id": 12713,
+    "name": "protectingscreech"
+  },
+  {
+    "id": 12714,
+    "name": "terrifyinghowl"
+  },
+  {
+    "id": 12715,
+    "name": "intimidatinghowl"
+  },
+  {
+    "id": 12716,
+    "name": "chillinghowl"
+  },
+  {
+    "id": 12717,
+    "name": "regenerate"
+  },
+  {
+    "id": 12718,
+    "name": "howlofthepack"
+  },
+  {
+    "id": 12721,
+    "name": "chillingslash"
+  },
+  {
+    "id": 12722,
+    "name": "laceratingslash"
+  },
+  {
+    "id": 12723,
+    "name": "blindingslash"
+  },
+  {
+    "id": 12729,
+    "name": "paralyzingvenom"
+  },
+  {
+    "id": 12730,
+    "name": "weakeningvenom"
+  },
+  {
+    "id": 12731,
+    "name": "deadlyvenom"
+  },
+  {
+    "id": 12732,
+    "name": "forage"
+  },
+  {
+    "id": 12744,
+    "name": "stunningrush"
+  },
+  {
+    "id": 12748,
+    "name": "chillingwhirl"
+  },
+  {
+    "id": 12749,
+    "name": "immobilizingwhirl"
+  },
+  {
+    "id": 12754,
+    "name": "forage"
+  },
+  {
+    "id": 12755,
+    "name": "forage"
+  },
+  {
+    "id": 12756,
+    "name": "forage"
+  },
+  {
+    "id": 12757,
+    "name": "feedingfrenzy"
+  },
+  {
+    "id": 13002,
+    "name": "shadowstep",
+    "profession": "thief"
+  },
+  {
+    "id": 13003,
+    "name": "trailofknives",
+    "profession": "thief"
+  },
+  {
+    "id": 13004,
+    "name": "doublestrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13005,
+    "name": "backstab",
+    "profession": "thief"
+  },
+  {
+    "id": 13006,
+    "name": "deathblossom",
+    "profession": "thief"
+  },
+  {
+    "id": 13007,
+    "name": "larcenousstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13008,
+    "name": "bolashot",
+    "profession": "thief"
+  },
+  {
+    "id": 13009,
+    "name": "slice",
+    "profession": "thief"
+  },
+  {
+    "id": 13010,
+    "name": "shadowstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13011,
+    "name": "unload",
+    "profession": "thief"
+  },
+  {
+    "id": 13012,
+    "name": "headshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13014,
+    "name": "steal",
+    "profession": "thief"
+  },
+  {
+    "id": 13015,
+    "name": "infiltratorsstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13016,
+    "name": "flankingstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13019,
+    "name": "dancingdagger",
+    "profession": "thief"
+  },
+  {
+    "id": 13020,
+    "name": "scorpionwire",
+    "profession": "thief"
+  },
+  {
+    "id": 13021,
+    "name": "withdraw",
+    "profession": "thief"
+  },
+  {
+    "id": 13022,
+    "name": "trickshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13024,
+    "name": "chokinggas",
+    "profession": "thief"
+  },
+  {
+    "id": 13025,
+    "name": "infiltratorsarrow",
+    "profession": "thief"
+  },
+  {
+    "id": 13026,
+    "name": "preparethousandneedles",
+    "profession": "thief"
+  },
+  {
+    "id": 13027,
+    "name": "hideinshadows",
+    "profession": "thief"
+  },
+  {
+    "id": 13028,
+    "name": "caltrops",
+    "profession": "thief"
+  },
+  {
+    "id": 13031,
+    "name": "pistolwhip",
+    "profession": "thief"
+  },
+  {
+    "id": 13033,
+    "name": "smokebomb",
+    "profession": "thief"
+  },
+  {
+    "id": 13035,
+    "name": "rollforinitiative",
+    "profession": "thief"
+  },
+  {
+    "id": 13037,
+    "name": "spidervenom",
+    "profession": "thief"
+  },
+  {
+    "id": 13038,
+    "name": "prepareshadowportal",
+    "profession": "thief"
+  },
+  {
+    "id": 13040,
+    "name": "shadowshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13041,
+    "name": "clusterbomb",
+    "profession": "thief"
+  },
+  {
+    "id": 13043,
+    "name": "detonatecluster",
+    "profession": "thief"
+  },
+  {
+    "id": 13044,
+    "name": "blindingpowder",
+    "profession": "thief"
+  },
+  {
+    "id": 13046,
+    "name": "assassinssignet",
+    "profession": "thief"
+  },
+  {
+    "id": 13050,
+    "name": "signetofmalice",
+    "profession": "thief"
+  },
+  {
+    "id": 13055,
+    "name": "skalevenom",
+    "profession": "thief"
+  },
+  {
+    "id": 13056,
+    "name": "preparesealarea",
+    "profession": "thief"
+  },
+  {
+    "id": 13057,
+    "name": "preparepitfall",
+    "profession": "thief"
+  },
+  {
+    "id": 13060,
+    "name": "signetofshadows",
+    "profession": "thief"
+  },
+  {
+    "id": 13062,
+    "name": "signetofagility",
+    "profession": "thief"
+  },
+  {
+    "id": 13064,
+    "name": "infiltratorssignet",
+    "profession": "thief"
+  },
+  {
+    "id": 13065,
+    "name": "smokescreen",
+    "profession": "thief"
+  },
+  {
+    "id": 13066,
+    "name": "haste",
+    "profession": "thief"
+  },
+  {
+    "id": 13068,
+    "name": "shadowassault",
+    "profession": "thief"
+  },
+  {
+    "id": 13069,
+    "name": "flankingdive",
+    "profession": "thief"
+  },
+  {
+    "id": 13070,
+    "name": "towline",
+    "profession": "thief"
+  },
+  {
+    "id": 13072,
+    "name": "piercingshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13073,
+    "name": "deluge",
+    "profession": "thief"
+  },
+  {
+    "id": 13074,
+    "name": "escape",
+    "profession": "thief"
+  },
+  {
+    "id": 13075,
+    "name": "cripplingshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13076,
+    "name": "inkshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13078,
+    "name": "smoketrail",
+    "profession": "thief"
+  },
+  {
+    "id": 13079,
+    "name": "divingknife",
+    "profession": "thief"
+  },
+  {
+    "id": 13080,
+    "name": "vanishinthedeep",
+    "profession": "thief"
+  },
+  {
+    "id": 13081,
+    "name": "cheapshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13082,
+    "name": "thievesguild",
+    "profession": "thief"
+  },
+  {
+    "id": 13083,
+    "name": "disablingshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13084,
+    "name": "vitalshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13085,
+    "name": "daggerstorm",
+    "profession": "thief"
+  },
+  {
+    "id": 13087,
+    "name": "wildstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13088,
+    "name": "slash",
+    "profession": "thief"
+  },
+  {
+    "id": 13093,
+    "name": "devourervenom",
+    "profession": "thief"
+  },
+  {
+    "id": 13096,
+    "name": "icedrakevenom",
+    "profession": "thief"
+  },
+  {
+    "id": 13097,
+    "name": "heartseeker",
+    "profession": "thief"
+  },
+  {
+    "id": 13099,
+    "name": "sealarea",
+    "profession": "thief"
+  },
+  {
+    "id": 13106,
+    "name": "shadowreturn",
+    "profession": "thief"
+  },
+  {
+    "id": 13108,
+    "name": "lotusstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13110,
+    "name": "twistingfangs",
+    "profession": "thief"
+  },
+  {
+    "id": 13111,
+    "name": "repeater",
+    "profession": "thief"
+  },
+  {
+    "id": 13112,
+    "name": "stab",
+    "profession": "thief"
+  },
+  {
+    "id": 13113,
+    "name": "blackpowder",
+    "profession": "thief"
+  },
+  {
+    "id": 13114,
+    "name": "tacticalstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13115,
+    "name": "sneakattack",
+    "profession": "thief"
+  },
+  {
+    "id": 13116,
+    "name": "cripplingstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13117,
+    "name": "shadowrefuge",
+    "profession": "thief"
+  },
+  {
+    "id": 13119,
+    "name": "stab",
+    "profession": "thief"
+  },
+  {
+    "id": 13120,
+    "name": "jab",
+    "profession": "thief"
+  },
+  {
+    "id": 13121,
+    "name": "poisontipstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13122,
+    "name": "ninetailedstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13125,
+    "name": "deadlystrike",
+    "profession": "thief"
+  },
+  {
+    "id": 13126,
+    "name": "theripper",
+    "profession": "thief"
+  },
+  {
+    "id": 13128,
+    "name": "infiltratorsreturn",
+    "profession": "thief"
+  },
+  {
+    "id": 13129,
+    "name": "surpriseshot",
+    "profession": "thief"
+  },
+  {
+    "id": 13130,
+    "name": "breakstance",
+    "profession": "thief"
+  },
+  {
+    "id": 13132,
+    "name": "basiliskvenom",
+    "profession": "thief"
+  },
+  {
+    "id": 13138,
+    "name": "venomousknife",
+    "profession": "thief"
+  },
+  {
+    "id": 13140,
+    "name": "shadowescape",
+    "profession": "thief"
+  },
+  {
+    "id": 13334,
+    "name": "flameexpulsion",
+    "profession": "bundle"
+  },
+  {
+    "id": 13465,
+    "name": "lesserelixirb",
+    "profession": "bundle"
+  },
+  {
+    "id": 13516,
+    "name": "allyward",
+    "profession": "bundle"
+  },
+  {
+    "id": 13551,
+    "name": "smokebomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 13552,
+    "name": "staticdischarge",
+    "profession": "bundle"
+  },
+  {
+    "id": 13677,
+    "name": "lessersymbolofresolution",
+    "profession": "bundle"
+  },
+  {
+    "id": 13684,
+    "name": "lessersymbolofprotection",
+    "profession": "bundle"
+  },
+  {
+    "id": 13688,
+    "name": "lessershieldofabsorption",
+    "profession": "bundle"
+  },
+  {
+    "id": 13733,
+    "name": "lesserchaosstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 13849,
+    "name": "lesserwellofblood",
+    "profession": "bundle"
+  },
+  {
+    "id": 13906,
+    "name": "lesserspinalshivers",
+    "profession": "bundle"
+  },
+  {
+    "id": 13907,
+    "name": "lesserenfeeble",
+    "profession": "bundle"
+  },
+  {
+    "id": 13918,
+    "name": "lessermarkofblood",
+    "profession": "bundle"
+  },
+  {
+    "id": 13938,
+    "name": "lessermuddyterrain",
+    "profession": "bundle"
+  },
+  {
+    "id": 14136,
+    "name": "lessercaltrops",
+    "profession": "bundle"
+  },
+  {
+    "id": 14268,
+    "name": "recklessimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 14330,
+    "name": "lesserbalancedstance",
+    "profession": "bundle"
+  },
+  {
+    "id": 14350,
+    "name": "return",
+    "profession": "necromancer"
+  },
+  {
+    "id": 14353,
+    "name": "eviscerate",
+    "profession": "warrior"
+  },
+  {
+    "id": 14354,
+    "name": "throwbolas",
+    "profession": "warrior"
+  },
+  {
+    "id": 14355,
+    "name": "signetofrage",
+    "profession": "warrior"
+  },
+  {
+    "id": 14356,
+    "name": "greatswordswing",
+    "profession": "warrior"
+  },
+  {
+    "id": 14358,
+    "name": "hammerswing",
+    "profession": "warrior"
+  },
+  {
+    "id": 14359,
+    "name": "staggeringblow",
+    "profession": "warrior"
+  },
+  {
+    "id": 14360,
+    "name": "riflebutt",
+    "profession": "warrior"
+  },
+  {
+    "id": 14361,
+    "name": "shieldbash",
+    "profession": "warrior"
+  },
+  {
+    "id": 14362,
+    "name": "shieldstance",
+    "profession": "warrior"
+  },
+  {
+    "id": 14363,
+    "name": "hamstring",
+    "profession": "warrior"
+  },
+  {
+    "id": 14364,
+    "name": "severartery",
+    "profession": "warrior"
+  },
+  {
+    "id": 14365,
+    "name": "gash",
+    "profession": "warrior"
+  },
+  {
+    "id": 14366,
+    "name": "savageleap",
+    "profession": "warrior"
+  },
+  {
+    "id": 14367,
+    "name": "flurry",
+    "profession": "warrior"
+  },
+  {
+    "id": 14368,
+    "name": "frenzy",
+    "profession": "warrior"
+  },
+  {
+    "id": 14369,
+    "name": "chop",
+    "profession": "warrior"
+  },
+  {
+    "id": 14370,
+    "name": "doublechop",
+    "profession": "warrior"
+  },
+  {
+    "id": 14371,
+    "name": "triplechop",
+    "profession": "warrior"
+  },
+  {
+    "id": 14372,
+    "name": "shakeitoff",
+    "profession": "warrior"
+  },
+  {
+    "id": 14373,
+    "name": "greatswordslice",
+    "profession": "warrior"
+  },
+  {
+    "id": 14374,
+    "name": "brutalstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 14375,
+    "name": "arcingslice",
+    "profession": "warrior"
+  },
+  {
+    "id": 14376,
+    "name": "macesmash",
+    "profession": "warrior"
+  },
+  {
+    "id": 14377,
+    "name": "macebash",
+    "profession": "warrior"
+  },
+  {
+    "id": 14378,
+    "name": "pulverize",
+    "profession": "warrior"
+  },
+  {
+    "id": 14381,
+    "name": "arcingarrow",
+    "profession": "warrior"
+  },
+  {
+    "id": 14384,
+    "name": "hammerbash",
+    "profession": "warrior"
+  },
+  {
+    "id": 14385,
+    "name": "hammersmash",
+    "profession": "warrior"
+  },
+  {
+    "id": 14386,
+    "name": "fierceblow",
+    "profession": "warrior"
+  },
+  {
+    "id": 14387,
+    "name": "earthshaker",
+    "profession": "warrior"
+  },
+  {
+    "id": 14388,
+    "name": "stomp",
+    "profession": "warrior"
+  },
+  {
+    "id": 14389,
+    "name": "healingsignet",
+    "profession": "warrior"
+  },
+  {
+    "id": 14390,
+    "name": "throwrock",
+    "profession": "warrior"
+  },
+  {
+    "id": 14391,
+    "name": "vengeance",
+    "profession": "warrior"
+  },
+  {
+    "id": 14392,
+    "name": "endurepain",
+    "profession": "warrior"
+  },
+  {
+    "id": 14393,
+    "name": "charge",
+    "profession": "warrior"
+  },
+  {
+    "id": 14394,
+    "name": "callofvalor",
+    "profession": "warrior"
+  },
+  {
+    "id": 14395,
+    "name": "brutalshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14396,
+    "name": "killshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14398,
+    "name": "throwaxe",
+    "profession": "warrior"
+  },
+  {
+    "id": 14399,
+    "name": "whirlingaxe",
+    "profession": "warrior"
+  },
+  {
+    "id": 14400,
+    "name": "riposte",
+    "profession": "warrior"
+  },
+  {
+    "id": 14401,
+    "name": "mending",
+    "profession": "warrior"
+  },
+  {
+    "id": 14402,
+    "name": "tothelimit",
+    "profession": "warrior"
+  },
+  {
+    "id": 14403,
+    "name": "forgreatjustice",
+    "profession": "warrior"
+  },
+  {
+    "id": 14404,
+    "name": "signetofmight",
+    "profession": "warrior"
+  },
+  {
+    "id": 14405,
+    "name": "bannerofstrength",
+    "profession": "warrior"
+  },
+  {
+    "id": 14406,
+    "name": "berserkerstance",
+    "profession": "warrior"
+  },
+  {
+    "id": 14407,
+    "name": "bannerofdiscipline",
+    "profession": "warrior"
+  },
+  {
+    "id": 14408,
+    "name": "banneroftactics",
+    "profession": "warrior"
+  },
+  {
+    "id": 14409,
+    "name": "fearme",
+    "profession": "warrior"
+  },
+  {
+    "id": 14410,
+    "name": "signetoffury",
+    "profession": "warrior"
+  },
+  {
+    "id": 14412,
+    "name": "balancedstance",
+    "profession": "warrior"
+  },
+  {
+    "id": 14413,
+    "name": "dolyaksignet",
+    "profession": "warrior"
+  },
+  {
+    "id": 14414,
+    "name": "skullcrack",
+    "profession": "warrior"
+  },
+  {
+    "id": 14415,
+    "name": "tremor",
+    "profession": "warrior"
+  },
+  {
+    "id": 14416,
+    "name": "volley",
+    "profession": "warrior"
+  },
+  {
+    "id": 14418,
+    "name": "dualstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 14419,
+    "name": "battlestandard",
+    "profession": "warrior"
+  },
+  {
+    "id": 14421,
+    "name": "cycloneaxe",
+    "profession": "warrior"
+  },
+  {
+    "id": 14422,
+    "name": "eviscerate",
+    "profession": "warrior"
+  },
+  {
+    "id": 14423,
+    "name": "eviscerate",
+    "profession": "warrior"
+  },
+  {
+    "id": 14424,
+    "name": "eviscerate",
+    "profession": "warrior"
+  },
+  {
+    "id": 14425,
+    "name": "skullcrack",
+    "profession": "warrior"
+  },
+  {
+    "id": 14426,
+    "name": "skullcrack",
+    "profession": "warrior"
+  },
+  {
+    "id": 14427,
+    "name": "skullcrack",
+    "profession": "warrior"
+  },
+  {
+    "id": 14428,
+    "name": "flurry",
+    "profession": "warrior"
+  },
+  {
+    "id": 14429,
+    "name": "flurry",
+    "profession": "warrior"
+  },
+  {
+    "id": 14430,
+    "name": "flurry",
+    "profession": "warrior"
+  },
+  {
+    "id": 14431,
+    "name": "dualshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14432,
+    "name": "fierceshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14437,
+    "name": "stab",
+    "profession": "warrior"
+  },
+  {
+    "id": 14438,
+    "name": "jab",
+    "profession": "warrior"
+  },
+  {
+    "id": 14439,
+    "name": "impale",
+    "profession": "warrior"
+  },
+  {
+    "id": 14440,
+    "name": "marinersfrenzy",
+    "profession": "warrior"
+  },
+  {
+    "id": 14441,
+    "name": "parry",
+    "profession": "warrior"
+  },
+  {
+    "id": 14443,
+    "name": "whirlingstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 14446,
+    "name": "rush",
+    "profession": "warrior"
+  },
+  {
+    "id": 14447,
+    "name": "whirlwindattack",
+    "profession": "warrior"
+  },
+  {
+    "id": 14448,
+    "name": "barbedpull",
+    "profession": "warrior"
+  },
+  {
+    "id": 14463,
+    "name": "punch",
+    "profession": "warrior"
+  },
+  {
+    "id": 14464,
+    "name": "kick",
+    "profession": "warrior"
+  },
+  {
+    "id": 14465,
+    "name": "repeatingshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14466,
+    "name": "punctureshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14467,
+    "name": "knotshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14469,
+    "name": "forcefulshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14470,
+    "name": "forcefulshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14471,
+    "name": "forcefulshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14472,
+    "name": "explosiveshell",
+    "profession": "warrior"
+  },
+  {
+    "id": 14473,
+    "name": "killshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14474,
+    "name": "killshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14475,
+    "name": "killshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14479,
+    "name": "signetofstamina",
+    "profession": "warrior"
+  },
+  {
+    "id": 14480,
+    "name": "tsunamislash",
+    "profession": "warrior"
+  },
+  {
+    "id": 14481,
+    "name": "splitshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14482,
+    "name": "hammershock",
+    "profession": "warrior"
+  },
+  {
+    "id": 14483,
+    "name": "rampage",
+    "profession": "warrior"
+  },
+  {
+    "id": 14485,
+    "name": "smash"
+  },
+  {
+    "id": 14486,
+    "name": "bash"
+  },
+  {
+    "id": 14487,
+    "name": "uppercut"
+  },
+  {
+    "id": 14488,
+    "name": "kick"
+  },
+  {
+    "id": 14489,
+    "name": "dash"
+  },
+  {
+    "id": 14490,
+    "name": "seismicleap"
+  },
+  {
+    "id": 14497,
+    "name": "finalthrust",
+    "profession": "warrior"
+  },
+  {
+    "id": 14498,
+    "name": "impale",
+    "profession": "warrior"
+  },
+  {
+    "id": 14501,
+    "name": "rip",
+    "profession": "warrior"
+  },
+  {
+    "id": 14502,
+    "name": "kick",
+    "profession": "warrior"
+  },
+  {
+    "id": 14503,
+    "name": "pommelbash",
+    "profession": "warrior"
+  },
+  {
+    "id": 14504,
+    "name": "pindown",
+    "profession": "warrior"
+  },
+  {
+    "id": 14505,
+    "name": "smolderingarrow",
+    "profession": "warrior"
+  },
+  {
+    "id": 14506,
+    "name": "combustiveshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14507,
+    "name": "counterblow",
+    "profession": "warrior"
+  },
+  {
+    "id": 14510,
+    "name": "bladetrail",
+    "profession": "warrior"
+  },
+  {
+    "id": 14511,
+    "name": "backbreaker",
+    "profession": "warrior"
+  },
+  {
+    "id": 14512,
+    "name": "earthshaker",
+    "profession": "warrior"
+  },
+  {
+    "id": 14513,
+    "name": "earthshaker",
+    "profession": "warrior"
+  },
+  {
+    "id": 14514,
+    "name": "earthshaker",
+    "profession": "warrior"
+  },
+  {
+    "id": 14515,
+    "name": "hammertoss",
+    "profession": "warrior"
+  },
+  {
+    "id": 14516,
+    "name": "bullscharge",
+    "profession": "warrior"
+  },
+  {
+    "id": 14518,
+    "name": "crushingblow",
+    "profession": "warrior"
+  },
+  {
+    "id": 14519,
+    "name": "fanoffire",
+    "profession": "warrior"
+  },
+  {
+    "id": 14520,
+    "name": "combustiveshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14521,
+    "name": "combustiveshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14522,
+    "name": "combustiveshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14528,
+    "name": "bannerofdefense",
+    "profession": "warrior"
+  },
+  {
+    "id": 14544,
+    "name": "forcefulshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14545,
+    "name": "arcingslice",
+    "profession": "warrior"
+  },
+  {
+    "id": 14546,
+    "name": "arcingslice",
+    "profession": "warrior"
+  },
+  {
+    "id": 14547,
+    "name": "arcingslice",
+    "profession": "warrior"
+  },
+  {
+    "id": 14548,
+    "name": "adrenalinerush",
+    "profession": "warrior"
+  },
+  {
+    "id": 14549,
+    "name": "whirlingstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 14550,
+    "name": "whirlingstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 14551,
+    "name": "whirlingstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 14552,
+    "name": "marinersshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 14554,
+    "name": "hundredblades",
+    "profession": "warrior"
+  },
+  {
+    "id": 14555,
+    "name": "adrenalinerush",
+    "profession": "warrior"
+  },
+  {
+    "id": 14556,
+    "name": "throwboulder"
+  },
+  {
+    "id": 14557,
+    "name": "adrenalinerush",
+    "profession": "warrior"
+  },
+  {
+    "id": 14568,
+    "name": "shakeitoff",
+    "profession": "bundle"
+  },
+  {
+    "id": 14569,
+    "name": "battlestandard",
+    "profession": "warrior"
+  },
+  {
+    "id": 14570,
+    "name": "bannerofdefense",
+    "profession": "warrior"
+  },
+  {
+    "id": 14571,
+    "name": "bannerofdiscipline",
+    "profession": "warrior"
+  },
+  {
+    "id": 14572,
+    "name": "bannerofstrength",
+    "profession": "warrior"
+  },
+  {
+    "id": 14573,
+    "name": "banneroftactics",
+    "profession": "warrior"
+  },
+  {
+    "id": 14575,
+    "name": "onmymark",
+    "profession": "warrior"
+  },
+  {
+    "id": 15072,
+    "name": "superelixir",
+    "profession": "engineer"
+  },
+  {
+    "id": 15716,
+    "name": "vaporblade",
+    "profession": "elementalist"
+  },
+  {
+    "id": 15717,
+    "name": "impale",
+    "profession": "elementalist"
+  },
+  {
+    "id": 15718,
+    "name": "dragonsclaw",
+    "profession": "elementalist"
+  },
+  {
+    "id": 15773,
+    "name": "agony",
+    "profession": "bundle"
+  },
+  {
+    "id": 15795,
+    "name": "mistform",
+    "profession": "elementalist"
+  },
+  {
+    "id": 15834,
+    "name": "shieldofjudgment",
+    "profession": "guardian"
+  },
+  {
+    "id": 15861,
+    "name": "return"
+  },
+  {
+    "id": 15862,
+    "name": "return"
+  },
+  {
+    "id": 15863,
+    "name": "flee"
+  },
+  {
+    "id": 16012,
+    "name": "stomp",
+    "profession": "bundle"
+  },
+  {
+    "id": 16013,
+    "name": "spit",
+    "profession": "bundle"
+  },
+  {
+    "id": 16014,
+    "name": "stickyspit",
+    "profession": "bundle"
+  },
+  {
+    "id": 16027,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 16040,
+    "name": "stomp",
+    "profession": "bundle"
+  },
+  {
+    "id": 16097,
+    "name": "stickyspit",
+    "profession": "bundle"
+  },
+  {
+    "id": 16098,
+    "name": "stickyspit",
+    "profession": "bundle"
+  },
+  {
+    "id": 16296,
+    "name": "spin",
+    "profession": "bundle"
+  },
+  {
+    "id": 16298,
+    "name": "eaten",
+    "profession": "bundle"
+  },
+  {
+    "id": 16301,
+    "name": "tidalshock",
+    "profession": "bundle"
+  },
+  {
+    "id": 16426,
+    "name": "sonicshriek"
+  },
+  {
+    "id": 16427,
+    "name": "sonicbarrier"
+  },
+  {
+    "id": 16432,
+    "name": "cloakanddagger",
+    "profession": "thief"
+  },
+  {
+    "id": 16435,
+    "name": "shadowportal",
+    "profession": "thief"
+  },
+  {
+    "id": 16918,
+    "name": "spin",
+    "profession": "bundle"
+  },
+  {
+    "id": 16919,
+    "name": "punch",
+    "profession": "bundle"
+  },
+  {
+    "id": 16920,
+    "name": "pound",
+    "profession": "bundle"
+  },
+  {
+    "id": 16921,
+    "name": "overload",
+    "profession": "bundle"
+  },
+  {
+    "id": 17008,
+    "name": "magneticleap",
+    "profession": "elementalist"
+  },
+  {
+    "id": 17260,
+    "name": "detonateflameblast",
+    "profession": "thief"
+  },
+  {
+    "id": 17810,
+    "name": "dropmine",
+    "profession": "bundle"
+  },
+  {
+    "id": 17811,
+    "name": "magneticbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 17812,
+    "name": "superspeed",
+    "profession": "bundle"
+  },
+  {
+    "id": 17813,
+    "name": "fireshield",
+    "profession": "bundle"
+  },
+  {
+    "id": 17814,
+    "name": "magneticaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 17815,
+    "name": "gluetrail",
+    "profession": "bundle"
+  },
+  {
+    "id": 18504,
+    "name": "dhuumfire",
+    "profession": "necromancer"
+  },
+  {
+    "id": 19115,
+    "name": "reapersmark",
+    "profession": "necromancer"
+  },
+  {
+    "id": 19116,
+    "name": "putridmark",
+    "profession": "necromancer"
+  },
+  {
+    "id": 19117,
+    "name": "markofblood",
+    "profession": "necromancer"
+  },
+  {
+    "id": 19504,
+    "name": "taintedshackles",
+    "profession": "necromancer"
+  },
+  {
+    "id": 20451,
+    "name": "elixirx",
+    "profession": "engineer"
+  },
+  {
+    "id": 20975,
+    "name": "laceratingslash"
+  },
+  {
+    "id": 21646,
+    "name": "shieldsmash"
+  },
+  {
+    "id": 21647,
+    "name": "stonesheath"
+  },
+  {
+    "id": 21656,
+    "name": "arcanebrilliance",
+    "profession": "elementalist"
+  },
+  {
+    "id": 21659,
+    "name": "aed",
+    "profession": "engineer"
+  },
+  {
+    "id": 21661,
+    "name": "staticshock",
+    "profession": "engineer"
+  },
+  {
+    "id": 21664,
+    "name": "litanyofwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 21750,
+    "name": "signetoftheether",
+    "profession": "mesmer"
+  },
+  {
+    "id": 21762,
+    "name": "signetofvampirism",
+    "profession": "necromancer"
+  },
+  {
+    "id": 21773,
+    "name": "waterspirit",
+    "profession": "ranger"
+  },
+  {
+    "id": 21775,
+    "name": "aquasurge",
+    "profession": "ranger"
+  },
+  {
+    "id": 21778,
+    "name": "skelkvenom",
+    "profession": "thief"
+  },
+  {
+    "id": 21795,
+    "name": "glacialheart",
+    "profession": "bundle"
+  },
+  {
+    "id": 21813,
+    "name": "lesserendurepain",
+    "profession": "bundle"
+  },
+  {
+    "id": 21815,
+    "name": "defiantstance",
+    "profession": "warrior"
+  },
+  {
+    "id": 22221,
+    "name": "mistlockinstabilityearthquake",
+    "profession": "bundle"
+  },
+  {
+    "id": 22499,
+    "name": "mysticrebuke",
+    "profession": "bundle"
+  },
+  {
+    "id": 22521,
+    "name": "lessercleansingfire",
+    "profession": "bundle"
+  },
+  {
+    "id": 22572,
+    "name": "arcanewave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 22573,
+    "name": "rocket",
+    "profession": "engineer"
+  },
+  {
+    "id": 22574,
+    "name": "rocketturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 24287,
+    "name": "dhuumfire",
+    "profession": "necromancer"
+  },
+  {
+    "id": 24305,
+    "name": "lightningrod",
+    "profession": "bundle"
+  },
+  {
+    "id": 24329,
+    "name": "bunkerdown",
+    "profession": "bundle"
+  },
+  {
+    "id": 24356,
+    "name": "poisonnova",
+    "profession": "bundle"
+  },
+  {
+    "id": 24407,
+    "name": "renewaloffire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 24409,
+    "name": "renewalofair",
+    "profession": "elementalist"
+  },
+  {
+    "id": 24410,
+    "name": "renewalofwater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 24411,
+    "name": "renewalofearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 24414,
+    "name": "signetofmercy",
+    "profession": "guardian"
+  },
+  {
+    "id": 24544,
+    "name": "signetofundeath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 24755,
+    "name": "thousandcuts",
+    "profession": "mesmer"
+  },
+  {
+    "id": 25480,
+    "name": "shockingbolt",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25486,
+    "name": "glyphoflesserelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25487,
+    "name": "glyphoflesserelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25488,
+    "name": "glyphofelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25489,
+    "name": "glyphofelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25490,
+    "name": "glyphofelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25491,
+    "name": "glyphofelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25492,
+    "name": "crashingwaves",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25495,
+    "name": "glyphoflesserelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25497,
+    "name": "glyphoflesserelementals",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25498,
+    "name": "stomp",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25499,
+    "name": "flamebarrage",
+    "profession": "elementalist"
+  },
+  {
+    "id": 25513,
+    "name": "phantasmalblade",
+    "profession": "bundle"
+  },
+  {
+    "id": 25541,
+    "name": "illusionoflife",
+    "profession": "mesmer"
+  },
+  {
+    "id": 25579,
+    "name": "lesserarcaneshield",
+    "profession": "bundle"
+  },
+  {
+    "id": 26557,
+    "name": "vengefulhammers",
+    "profession": "revenant"
+  },
+  {
+    "id": 26644,
+    "name": "facetofstrength",
+    "profession": "revenant"
+  },
+  {
+    "id": 26666,
+    "name": "manifesttoxin",
+    "profession": "revenant"
+  },
+  {
+    "id": 26679,
+    "name": "forcedengagement",
+    "profession": "revenant"
+  },
+  {
+    "id": 26693,
+    "name": "resistthedarkness",
+    "profession": "revenant"
+  },
+  {
+    "id": 26699,
+    "name": "unrelentingassault",
+    "profession": "revenant"
+  },
+  {
+    "id": 26730,
+    "name": "anguishswipe",
+    "profession": "revenant"
+  },
+  {
+    "id": 26821,
+    "name": "protectivesolace",
+    "profession": "revenant"
+  },
+  {
+    "id": 26937,
+    "name": "enchanteddaggers",
+    "profession": "revenant"
+  },
+  {
+    "id": 26956,
+    "name": "releasehammers",
+    "profession": "revenant"
+  },
+  {
+    "id": 27014,
+    "name": "facetofelements",
+    "profession": "revenant"
+  },
+  {
+    "id": 27025,
+    "name": "naturalharmony",
+    "profession": "revenant"
+  },
+  {
+    "id": 27063,
+    "name": "forcefuldisplacement",
+    "profession": "revenant"
+  },
+  {
+    "id": 27066,
+    "name": "miseryswipe",
+    "profession": "revenant"
+  },
+  {
+    "id": 27074,
+    "name": "deathstrike",
+    "profession": "revenant"
+  },
+  {
+    "id": 27080,
+    "name": "gazeofdarkness",
+    "profession": "revenant"
+  },
+  {
+    "id": 27107,
+    "name": "impossibleodds",
+    "profession": "revenant"
+  },
+  {
+    "id": 27162,
+    "name": "elementalblast",
+    "profession": "revenant"
+  },
+  {
+    "id": 27198,
+    "name": "domeofthemists",
+    "profession": "bundle"
+  },
+  {
+    "id": 27220,
+    "name": "facetoflight",
+    "profession": "revenant"
+  },
+  {
+    "id": 27228,
+    "name": "infuselight",
+    "profession": "revenant"
+  },
+  {
+    "id": 27280,
+    "name": "leapingslice",
+    "profession": "bundle"
+  },
+  {
+    "id": 27322,
+    "name": "painabsorption",
+    "profession": "revenant"
+  },
+  {
+    "id": 27356,
+    "name": "energyexpulsion",
+    "profession": "revenant"
+  },
+  {
+    "id": 27372,
+    "name": "soothingstone",
+    "profession": "revenant"
+  },
+  {
+    "id": 27505,
+    "name": "banishenchantment",
+    "profession": "revenant"
+  },
+  {
+    "id": 27510,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 27628,
+    "name": "diminishsolace",
+    "profession": "revenant"
+  },
+  {
+    "id": 27665,
+    "name": "fieldofthemists",
+    "profession": "revenant"
+  },
+  {
+    "id": 27715,
+    "name": "purifyingessence",
+    "profession": "revenant"
+  },
+  {
+    "id": 27760,
+    "name": "facetofchaos",
+    "profession": "revenant"
+  },
+  {
+    "id": 27792,
+    "name": "vengefulblast",
+    "profession": "revenant"
+  },
+  {
+    "id": 27917,
+    "name": "calltoanguish",
+    "profession": "revenant"
+  },
+  {
+    "id": 27964,
+    "name": "echoingeruption",
+    "profession": "revenant"
+  },
+  {
+    "id": 27975,
+    "name": "riteofthegreatdwarf",
+    "profession": "revenant"
+  },
+  {
+    "id": 27976,
+    "name": "phasesmash",
+    "profession": "revenant"
+  },
+  {
+    "id": 28029,
+    "name": "frigidblitz",
+    "profession": "revenant"
+  },
+  {
+    "id": 28075,
+    "name": "chaoticrelease",
+    "profession": "revenant"
+  },
+  {
+    "id": 28085,
+    "name": "legendarydragonstance",
+    "profession": "revenant"
+  },
+  {
+    "id": 28110,
+    "name": "dropthehammer",
+    "profession": "revenant"
+  },
+  {
+    "id": 28113,
+    "name": "burstofstrength",
+    "profession": "revenant"
+  },
+  {
+    "id": 28134,
+    "name": "legendaryassassinstance",
+    "profession": "revenant"
+  },
+  {
+    "id": 28180,
+    "name": "essencesap",
+    "profession": "revenant"
+  },
+  {
+    "id": 28195,
+    "name": "legendarycentaurstance",
+    "profession": "revenant"
+  },
+  {
+    "id": 28219,
+    "name": "empoweringmisery",
+    "profession": "revenant"
+  },
+  {
+    "id": 28231,
+    "name": "phasetraversal",
+    "profession": "revenant"
+  },
+  {
+    "id": 28253,
+    "name": "coalescenceofruin",
+    "profession": "revenant"
+  },
+  {
+    "id": 28262,
+    "name": "crystalhibernation",
+    "profession": "revenant"
+  },
+  {
+    "id": 28287,
+    "name": "embracethedarkness",
+    "profession": "revenant"
+  },
+  {
+    "id": 28357,
+    "name": "searingfissure",
+    "profession": "revenant"
+  },
+  {
+    "id": 28379,
+    "name": "facetofdarkness",
+    "profession": "revenant"
+  },
+  {
+    "id": 28382,
+    "name": "relinquishpower",
+    "profession": "revenant"
+  },
+  {
+    "id": 28405,
+    "name": "maul",
+    "profession": "bundle"
+  },
+  {
+    "id": 28406,
+    "name": "jadewinds",
+    "profession": "revenant"
+  },
+  {
+    "id": 28409,
+    "name": "temporalrift",
+    "profession": "revenant"
+  },
+  {
+    "id": 28419,
+    "name": "legendarydwarfstance",
+    "profession": "revenant"
+  },
+  {
+    "id": 28427,
+    "name": "ventariswill",
+    "profession": "revenant"
+  },
+  {
+    "id": 28472,
+    "name": "shacklingwave",
+    "profession": "revenant"
+  },
+  {
+    "id": 28494,
+    "name": "legendarydemonstance",
+    "profession": "revenant"
+  },
+  {
+    "id": 28516,
+    "name": "inspiringreinforcement",
+    "profession": "revenant"
+  },
+  {
+    "id": 28549,
+    "name": "hammerbolt",
+    "profession": "revenant"
+  },
+  {
+    "id": 28571,
+    "name": "duelistspreparation",
+    "profession": "revenant"
+  },
+  {
+    "id": 28625,
+    "name": "deathstrike",
+    "profession": "revenant"
+  },
+  {
+    "id": 28692,
+    "name": "ignitingbrand",
+    "profession": "revenant"
+  },
+  {
+    "id": 28714,
+    "name": "spearofanguish",
+    "profession": "revenant"
+  },
+  {
+    "id": 28797,
+    "name": "frigiddischarge",
+    "profession": "revenant"
+  },
+  {
+    "id": 28815,
+    "name": "devourbrand",
+    "profession": "revenant"
+  },
+  {
+    "id": 28827,
+    "name": "venomoussphere",
+    "profession": "revenant"
+  },
+  {
+    "id": 28915,
+    "name": "rapidassault",
+    "profession": "revenant"
+  },
+  {
+    "id": 28930,
+    "name": "riftcontainment",
+    "profession": "revenant"
+  },
+  {
+    "id": 28964,
+    "name": "riftslash",
+    "profession": "revenant"
+  },
+  {
+    "id": 28978,
+    "name": "surgeofthemists",
+    "profession": "revenant"
+  },
+  {
+    "id": 29002,
+    "name": "rejuvenatingassault",
+    "profession": "revenant"
+  },
+  {
+    "id": 29057,
+    "name": "preparationthrust",
+    "profession": "revenant"
+  },
+  {
+    "id": 29082,
+    "name": "naturalharmony",
+    "profession": "revenant"
+  },
+  {
+    "id": 29114,
+    "name": "energyexpulsion",
+    "profession": "revenant"
+  },
+  {
+    "id": 29145,
+    "name": "mendersrebuke",
+    "profession": "revenant"
+  },
+  {
+    "id": 29148,
+    "name": "projecttranquility",
+    "profession": "revenant"
+  },
+  {
+    "id": 29180,
+    "name": "rapidswipe",
+    "profession": "revenant"
+  },
+  {
+    "id": 29197,
+    "name": "purifyingessence",
+    "profession": "revenant"
+  },
+  {
+    "id": 29209,
+    "name": "ripostingshadows",
+    "profession": "revenant"
+  },
+  {
+    "id": 29233,
+    "name": "chillingisolation",
+    "profession": "revenant"
+  },
+  {
+    "id": 29248,
+    "name": "tailstab",
+    "profession": "bundle"
+  },
+  {
+    "id": 29256,
+    "name": "brutalblade",
+    "profession": "revenant"
+  },
+  {
+    "id": 29288,
+    "name": "wardingrift",
+    "profession": "revenant"
+  },
+  {
+    "id": 29310,
+    "name": "protectivesolace",
+    "profession": "revenant"
+  },
+  {
+    "id": 29321,
+    "name": "renewingwave",
+    "profession": "revenant"
+  },
+  {
+    "id": 29331,
+    "name": "forcefulbash",
+    "profession": "revenant"
+  },
+  {
+    "id": 29371,
+    "name": "facetofnature",
+    "profession": "revenant"
+  },
+  {
+    "id": 29373,
+    "name": "healingorb",
+    "profession": "bundle"
+  },
+  {
+    "id": 29386,
+    "name": "envoyofexuberance",
+    "profession": "revenant"
+  },
+  {
+    "id": 29393,
+    "name": "truenature",
+    "profession": "bundle"
+  },
+  {
+    "id": 29414,
+    "name": "youareallweaklings",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29415,
+    "name": "overloadwater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29442,
+    "name": "liferend",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29449,
+    "name": "lessercallofthewild",
+    "profession": "bundle"
+  },
+  {
+    "id": 29453,
+    "name": "sandsquall",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29458,
+    "name": "lifeslash",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29473,
+    "name": "detonate",
+    "profession": "engineer"
+  },
+  {
+    "id": 29477,
+    "name": "decoy",
+    "profession": "bundle"
+  },
+  {
+    "id": 29505,
+    "name": "reconstructionfield",
+    "profession": "engineer"
+  },
+  {
+    "id": 29515,
+    "name": "tosselixirx",
+    "profession": "engineer"
+  },
+  {
+    "id": 29516,
+    "name": "impactstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 29518,
+    "name": "detonatesupplycrateturrets",
+    "profession": "engineer"
+  },
+  {
+    "id": 29519,
+    "name": "signetofhumility",
+    "profession": "mesmer"
+  },
+  {
+    "id": 29522,
+    "name": "rocketboots",
+    "profession": "engineer"
+  },
+  {
+    "id": 29526,
+    "name": "wellofprecognition",
+    "profession": "mesmer"
+  },
+  {
+    "id": 29533,
+    "name": "wildfire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29535,
+    "name": "washthepainaway",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29547,
+    "name": "bandageblast",
+    "profession": "engineer"
+  },
+  {
+    "id": 29548,
+    "name": "heatsync",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29558,
+    "name": "glyphofthetides",
+    "profession": "ranger"
+  },
+  {
+    "id": 29560,
+    "name": "spitefulspirit",
+    "profession": "bundle"
+  },
+  {
+    "id": 29578,
+    "name": "mimic",
+    "profession": "mesmer"
+  },
+  {
+    "id": 29591,
+    "name": "utilitygoggles",
+    "profession": "engineer"
+  },
+  {
+    "id": 29604,
+    "name": "chillingnova",
+    "profession": "bundle"
+  },
+  {
+    "id": 29606,
+    "name": "invisibleanalysis",
+    "profession": "bundle"
+  },
+  {
+    "id": 29613,
+    "name": "sunderingleap",
+    "profession": "warrior"
+  },
+  {
+    "id": 29618,
+    "name": "overloadearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29630,
+    "name": "deflectingshot",
+    "profession": "guardian"
+  },
+  {
+    "id": 29639,
+    "name": "finishingblow",
+    "profession": "thief"
+  },
+  {
+    "id": 29644,
+    "name": "gunflame",
+    "profession": "warrior"
+  },
+  {
+    "id": 29649,
+    "name": "dejavu",
+    "profession": "mesmer"
+  },
+  {
+    "id": 29665,
+    "name": "bypasscoating",
+    "profession": "engineer"
+  },
+  {
+    "id": 29666,
+    "name": "nothingcansaveyou",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29679,
+    "name": "skullgrinder",
+    "profession": "warrior"
+  },
+  {
+    "id": 29705,
+    "name": "duskstrike",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29706,
+    "name": "overloadfire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29709,
+    "name": "terrify",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29712,
+    "name": "cleansingpulse",
+    "profession": "bundle"
+  },
+  {
+    "id": 29716,
+    "name": "medpackdrop",
+    "profession": "engineer"
+  },
+  {
+    "id": 29719,
+    "name": "overloadair",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29722,
+    "name": "detonateelixirx",
+    "profession": "engineer"
+  },
+  {
+    "id": 29739,
+    "name": "purgegyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 29740,
+    "name": "graspingdarkness",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29772,
+    "name": "bandageself",
+    "profession": "engineer"
+  },
+  {
+    "id": 29785,
+    "name": "negativebash",
+    "profession": "engineer"
+  },
+  {
+    "id": 29786,
+    "name": "testoffaith",
+    "profession": "guardian"
+  },
+  {
+    "id": 29789,
+    "name": "symbolofenergy",
+    "profession": "guardian"
+  },
+  {
+    "id": 29812,
+    "name": "lesserutilitygoggles",
+    "profession": "bundle"
+  },
+  {
+    "id": 29830,
+    "name": "continuumsplit",
+    "profession": "mesmer"
+  },
+  {
+    "id": 29840,
+    "name": "shockshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 29845,
+    "name": "blazebreaker",
+    "profession": "warrior"
+  },
+  {
+    "id": 29852,
+    "name": "arcdivider",
+    "profession": "warrior"
+  },
+  {
+    "id": 29855,
+    "name": "nightfall",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29856,
+    "name": "wellofrecall",
+    "profession": "mesmer"
+  },
+  {
+    "id": 29867,
+    "name": "chillingscythe",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29887,
+    "name": "spearofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 29889,
+    "name": "aimassistedrocket",
+    "profession": "bundle"
+  },
+  {
+    "id": 29894,
+    "name": "lessersignetofvampirism",
+    "profession": "bundle"
+  },
+  {
+    "id": 29902,
+    "name": "dropgunk",
+    "profession": "bundle"
+  },
+  {
+    "id": 29905,
+    "name": "stowmortarkit",
+    "profession": "engineer"
+  },
+  {
+    "id": 29911,
+    "name": "weakeningcharge",
+    "profession": "thief"
+  },
+  {
+    "id": 29921,
+    "name": "shreddergyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 29923,
+    "name": "scorchedearth",
+    "profession": "warrior"
+  },
+  {
+    "id": 29940,
+    "name": "flamesofwar",
+    "profession": "warrior"
+  },
+  {
+    "id": 29941,
+    "name": "wildblow",
+    "profession": "warrior"
+  },
+  {
+    "id": 29948,
+    "name": "flashfreeze",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29958,
+    "name": "infusingterror",
+    "profession": "necromancer"
+  },
+  {
+    "id": 29965,
+    "name": "feelmywrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 29968,
+    "name": "rebound",
+    "profession": "elementalist"
+  },
+  {
+    "id": 29977,
+    "name": "lessersignetofmight",
+    "profession": "bundle"
+  },
+  {
+    "id": 29991,
+    "name": "personalbatteringram",
+    "profession": "engineer"
+  },
+  {
+    "id": 30008,
+    "name": "cyclone",
+    "profession": "elementalist"
+  },
+  {
+    "id": 30025,
+    "name": "purification",
+    "profession": "guardian"
+  },
+  {
+    "id": 30027,
+    "name": "defensefield",
+    "profession": "engineer"
+  },
+  {
+    "id": 30029,
+    "name": "shieldofcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 30032,
+    "name": "elixirshell",
+    "profession": "thief"
+  },
+  {
+    "id": 30039,
+    "name": "shieldofcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 30047,
+    "name": "eyeofthestorm",
+    "profession": "elementalist"
+  },
+  {
+    "id": 30074,
+    "name": "shatteringblow",
+    "profession": "warrior"
+  },
+  {
+    "id": 30077,
+    "name": "uppercut",
+    "profession": "thief"
+  },
+  {
+    "id": 30083,
+    "name": "wingsofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 30088,
+    "name": "electrowhirl",
+    "profession": "engineer"
+  },
+  {
+    "id": 30101,
+    "name": "bulwarkgyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 30105,
+    "name": "chilledtothebone",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30121,
+    "name": "flashshell",
+    "profession": "thief"
+  },
+  {
+    "id": 30123,
+    "name": "searchandrescue",
+    "profession": "bundle"
+  },
+  {
+    "id": 30135,
+    "name": "staffbash",
+    "profession": "thief"
+  },
+  {
+    "id": 30142,
+    "name": "bandage",
+    "profession": "bundle"
+  },
+  {
+    "id": 30163,
+    "name": "gravedigger",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30166,
+    "name": "lesserpowercleanse",
+    "profession": "bundle"
+  },
+  {
+    "id": 30185,
+    "name": "berserk",
+    "profession": "warrior"
+  },
+  {
+    "id": 30189,
+    "name": "bloodreckoning",
+    "profession": "warrior"
+  },
+  {
+    "id": 30192,
+    "name": "lesserphantasmaldefender",
+    "profession": "bundle"
+  },
+  {
+    "id": 30210,
+    "name": "hookstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 30225,
+    "name": "wingsofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 30229,
+    "name": "trueshot",
+    "profession": "guardian"
+  },
+  {
+    "id": 30230,
+    "name": "overchargesupplycrate",
+    "profession": "engineer"
+  },
+  {
+    "id": 30238,
+    "name": "glyphofthetides",
+    "profession": "ranger"
+  },
+  {
+    "id": 30239,
+    "name": "lesserhaste",
+    "profession": "bundle"
+  },
+  {
+    "id": 30255,
+    "name": "lessersignetofwrath",
+    "profession": "bundle"
+  },
+  {
+    "id": 30258,
+    "name": "outrage",
+    "profession": "warrior"
+  },
+  {
+    "id": 30262,
+    "name": "detectionpulse",
+    "profession": "engineer"
+  },
+  {
+    "id": 30264,
+    "name": "overchargesupplycrate",
+    "profession": "engineer"
+  },
+  {
+    "id": 30273,
+    "name": "dragonsmaw",
+    "profession": "guardian"
+  },
+  {
+    "id": 30278,
+    "name": "lifereap",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30279,
+    "name": "chemicalfield",
+    "profession": "engineer"
+  },
+  {
+    "id": 30286,
+    "name": "wingsofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 30305,
+    "name": "wellofeternity",
+    "profession": "mesmer"
+  },
+  {
+    "id": 30307,
+    "name": "endothermicshell",
+    "profession": "thief"
+  },
+  {
+    "id": 30336,
+    "name": "duststorm",
+    "profession": "elementalist"
+  },
+  {
+    "id": 30337,
+    "name": "throwmine",
+    "profession": "engineer"
+  },
+  {
+    "id": 30343,
+    "name": "headbutt",
+    "profession": "warrior"
+  },
+  {
+    "id": 30357,
+    "name": "medicgyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 30359,
+    "name": "gravitywell",
+    "profession": "mesmer"
+  },
+  {
+    "id": 30364,
+    "name": "processionofblades",
+    "profession": "guardian"
+  },
+  {
+    "id": 30369,
+    "name": "impairingdaggers",
+    "profession": "thief"
+  },
+  {
+    "id": 30371,
+    "name": "mortarshot",
+    "profession": "thief"
+  },
+  {
+    "id": 30400,
+    "name": "channeledvigor",
+    "profession": "thief"
+  },
+  {
+    "id": 30432,
+    "name": "aftershock",
+    "profession": "elementalist"
+  },
+  {
+    "id": 30434,
+    "name": "punishingstrikes",
+    "profession": "thief"
+  },
+  {
+    "id": 30435,
+    "name": "berserk",
+    "profession": "warrior"
+  },
+  {
+    "id": 30446,
+    "name": "waterglobe",
+    "profession": "elementalist"
+  },
+  {
+    "id": 30448,
+    "name": "glyphofthetides",
+    "profession": "ranger"
+  },
+  {
+    "id": 30461,
+    "name": "signetofcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 30471,
+    "name": "punctureshot",
+    "profession": "guardian"
+  },
+  {
+    "id": 30488,
+    "name": "yoursoulismine",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30489,
+    "name": "equalizingblow",
+    "profession": "engineer"
+  },
+  {
+    "id": 30501,
+    "name": "positivestrike",
+    "profession": "engineer"
+  },
+  {
+    "id": 30504,
+    "name": "soulspiral",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30519,
+    "name": "reflexivestrike",
+    "profession": "thief"
+  },
+  {
+    "id": 30520,
+    "name": "debilitatingarc",
+    "profession": "thief"
+  },
+  {
+    "id": 30521,
+    "name": "medblaster",
+    "profession": "engineer"
+  },
+  {
+    "id": 30525,
+    "name": "wellofcalamity",
+    "profession": "mesmer"
+  },
+  {
+    "id": 30553,
+    "name": "fragmentsoffaith",
+    "profession": "guardian"
+  },
+  {
+    "id": 30557,
+    "name": "executionersscythe",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30568,
+    "name": "distractingdaggers",
+    "profession": "thief"
+  },
+  {
+    "id": 30588,
+    "name": "medpackdrop",
+    "profession": "engineer"
+  },
+  {
+    "id": 30597,
+    "name": "vault",
+    "profession": "thief"
+  },
+  {
+    "id": 30599,
+    "name": "orbitalstrike",
+    "profession": "engineer"
+  },
+  {
+    "id": 30614,
+    "name": "staffstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 30628,
+    "name": "huntersward",
+    "profession": "guardian"
+  },
+  {
+    "id": 30643,
+    "name": "tidesoftime",
+    "profession": "mesmer"
+  },
+  {
+    "id": 30661,
+    "name": "banditsdefense",
+    "profession": "thief"
+  },
+  {
+    "id": 30662,
+    "name": "feeltheburn",
+    "profession": "elementalist"
+  },
+  {
+    "id": 30665,
+    "name": "rocketcharge",
+    "profession": "engineer"
+  },
+  {
+    "id": 30670,
+    "name": "suffer",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30682,
+    "name": "flamingflurry",
+    "profession": "warrior"
+  },
+  {
+    "id": 30686,
+    "name": "longfusedpowderpack",
+    "profession": "bundle"
+  },
+  {
+    "id": 30693,
+    "name": "palmstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 30713,
+    "name": "thunderclap",
+    "profession": "engineer"
+  },
+  {
+    "id": 30725,
+    "name": "tosselixirx",
+    "profession": "engineer"
+  },
+  {
+    "id": 30745,
+    "name": "eyeofthestorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 30747,
+    "name": "continuumshift",
+    "profession": "mesmer"
+  },
+  {
+    "id": 30769,
+    "name": "echoofmemory",
+    "profession": "mesmer"
+  },
+  {
+    "id": 30770,
+    "name": "pulmonaryimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 30772,
+    "name": "rise",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30775,
+    "name": "duststrike",
+    "profession": "thief"
+  },
+  {
+    "id": 30783,
+    "name": "wingsofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 30792,
+    "name": "reapersshroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30795,
+    "name": "lightningorb",
+    "profession": "elementalist"
+  },
+  {
+    "id": 30799,
+    "name": "fadingtwilight",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30800,
+    "name": "elitemortarkit",
+    "profession": "engineer"
+  },
+  {
+    "id": 30814,
+    "name": "wellofaction",
+    "profession": "mesmer"
+  },
+  {
+    "id": 30815,
+    "name": "sneakgyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 30825,
+    "name": "deathscharge",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30828,
+    "name": "slickshoes",
+    "profession": "engineer"
+  },
+  {
+    "id": 30851,
+    "name": "decapitate",
+    "profession": "warrior"
+  },
+  {
+    "id": 30860,
+    "name": "deathspiral",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30864,
+    "name": "tidalsurge",
+    "profession": "elementalist"
+  },
+  {
+    "id": 30868,
+    "name": "fistflurry",
+    "profession": "thief"
+  },
+  {
+    "id": 30871,
+    "name": "lightsjudgment",
+    "profession": "guardian"
+  },
+  {
+    "id": 30879,
+    "name": "rupturingsmash",
+    "profession": "warrior"
+  },
+  {
+    "id": 30881,
+    "name": "aed",
+    "profession": "engineer"
+  },
+  {
+    "id": 30885,
+    "name": "poisongasshell",
+    "profession": "thief"
+  },
+  {
+    "id": 30893,
+    "name": "deploymine",
+    "profession": "engineer"
+  },
+  {
+    "id": 30961,
+    "name": "exitreapersshroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 30989,
+    "name": "burningshackles",
+    "profession": "warrior"
+  },
+  {
+    "id": 31048,
+    "name": "wildwhirl",
+    "profession": "warrior"
+  },
+  {
+    "id": 31100,
+    "name": "calltoanguish",
+    "profession": "revenant"
+  },
+  {
+    "id": 31129,
+    "name": "bound",
+    "profession": "bundle"
+  },
+  {
+    "id": 31159,
+    "name": "purgingflames",
+    "profession": "guardian"
+  },
+  {
+    "id": 31167,
+    "name": "sparecapacitor",
+    "profession": "engineer"
+  },
+  {
+    "id": 31187,
+    "name": "dash",
+    "profession": "bundle"
+  },
+  {
+    "id": 31248,
+    "name": "blastgyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 31267,
+    "name": "impalinglotus",
+    "profession": "bundle"
+  },
+  {
+    "id": 31294,
+    "name": "jadewinds",
+    "profession": "revenant"
+  },
+  {
+    "id": 31295,
+    "name": "sanctuary",
+    "profession": "guardian"
+  },
+  {
+    "id": 31318,
+    "name": "lunarimpact",
+    "profession": "ranger"
+  },
+  {
+    "id": 31322,
+    "name": "glyphofalignment",
+    "profession": "ranger"
+  },
+  {
+    "id": 31324,
+    "name": "timebomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 31340,
+    "name": "distributedmagic",
+    "profession": "bundle"
+  },
+  {
+    "id": 31344,
+    "name": "ghastlyrampage",
+    "profession": "bundle"
+  },
+  {
+    "id": 31348,
+    "name": "glyphofalignment",
+    "profession": "ranger"
+  },
+  {
+    "id": 31367,
+    "name": "spikebarrage"
+  },
+  {
+    "id": 31375,
+    "name": "magicaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 31390,
+    "name": "heat",
+    "profession": "bundle"
+  },
+  {
+    "id": 31391,
+    "name": "distributedmagic",
+    "profession": "bundle"
+  },
+  {
+    "id": 31392,
+    "name": "unstablemagicspike",
+    "profession": "bundle"
+  },
+  {
+    "id": 31396,
+    "name": "wickedswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 31401,
+    "name": "glyphofequality",
+    "profession": "ranger"
+  },
+  {
+    "id": 31403,
+    "name": "smash",
+    "profession": "bundle"
+  },
+  {
+    "id": 31406,
+    "name": "seedoflife",
+    "profession": "ranger"
+  },
+  {
+    "id": 31407,
+    "name": "glyphofrejuvenation",
+    "profession": "ranger"
+  },
+  {
+    "id": 31410,
+    "name": "ghastlyrampage",
+    "profession": "bundle"
+  },
+  {
+    "id": 31411,
+    "name": "releasecelestialavatar",
+    "profession": "ranger"
+  },
+  {
+    "id": 31419,
+    "name": "magicstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 31438,
+    "name": "essencesap"
+  },
+  {
+    "id": 31442,
+    "name": "punch",
+    "profession": "bundle"
+  },
+  {
+    "id": 31451,
+    "name": "furiouspounce"
+  },
+  {
+    "id": 31459,
+    "name": "consumingflame"
+  },
+  {
+    "id": 31462,
+    "name": "magicaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 31483,
+    "name": "hauntingaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 31491,
+    "name": "quickshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 31496,
+    "name": "sublimeconversion",
+    "profession": "ranger"
+  },
+  {
+    "id": 31503,
+    "name": "naturalconvergence",
+    "profession": "ranger"
+  },
+  {
+    "id": 31529,
+    "name": "distributedmagic",
+    "profession": "bundle"
+  },
+  {
+    "id": 31535,
+    "name": "ancestralgrace",
+    "profession": "ranger"
+  },
+  {
+    "id": 31539,
+    "name": "unstablepylon",
+    "profession": "bundle"
+  },
+  {
+    "id": 31544,
+    "name": "flakshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 31557,
+    "name": "magicaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 31565,
+    "name": "ghastlyrampage",
+    "profession": "bundle"
+  },
+  {
+    "id": 31568,
+    "name": "smokecloud"
+  },
+  {
+    "id": 31582,
+    "name": "glyphofunity",
+    "profession": "ranger"
+  },
+  {
+    "id": 31607,
+    "name": "glyphofalignment",
+    "profession": "ranger"
+  },
+  {
+    "id": 31622,
+    "name": "ghastlyrampage",
+    "profession": "bundle"
+  },
+  {
+    "id": 31623,
+    "name": "ghastlyprison",
+    "profession": "bundle"
+  },
+  {
+    "id": 31624,
+    "name": "youwilljoinus",
+    "profession": "bundle"
+  },
+  {
+    "id": 31636,
+    "name": "punch",
+    "profession": "bundle"
+  },
+  {
+    "id": 31639,
+    "name": "lightningassault"
+  },
+  {
+    "id": 31643,
+    "name": "cannonbarrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 31658,
+    "name": "glyphofequality",
+    "profession": "ranger"
+  },
+  {
+    "id": 31677,
+    "name": "glyphofthestars",
+    "profession": "ranger"
+  },
+  {
+    "id": 31700,
+    "name": "vinesurge",
+    "profession": "ranger"
+  },
+  {
+    "id": 31710,
+    "name": "solarbeam",
+    "profession": "ranger"
+  },
+  {
+    "id": 31720,
+    "name": "kick",
+    "profession": "bundle"
+  },
+  {
+    "id": 31721,
+    "name": "hailofbullets",
+    "profession": "bundle"
+  },
+  {
+    "id": 31723,
+    "name": "essencesap",
+    "profession": "revenant"
+  },
+  {
+    "id": 31727,
+    "name": "forcefuldisplacement",
+    "profession": "revenant"
+  },
+  {
+    "id": 31740,
+    "name": "glyphofunity",
+    "profession": "ranger"
+  },
+  {
+    "id": 31746,
+    "name": "glyphofequality",
+    "profession": "ranger"
+  },
+  {
+    "id": 31747,
+    "name": "ghastlyrampage",
+    "profession": "bundle"
+  },
+  {
+    "id": 31750,
+    "name": "distributedmagic",
+    "profession": "bundle"
+  },
+  {
+    "id": 31760,
+    "name": "linkedignition",
+    "profession": "bundle"
+  },
+  {
+    "id": 31761,
+    "name": "flameblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 31763,
+    "name": "platformquake",
+    "profession": "bundle"
+  },
+  {
+    "id": 31765,
+    "name": "shardsoffaith",
+    "profession": "bundle"
+  },
+  {
+    "id": 31769,
+    "name": "distributedmagic",
+    "profession": "bundle"
+  },
+  {
+    "id": 31776,
+    "name": "lesserseedoflife",
+    "profession": "bundle"
+  },
+  {
+    "id": 31788,
+    "name": "explosion",
+    "profession": "bundle"
+  },
+  {
+    "id": 31792,
+    "name": "ectoplasm",
+    "profession": "bundle"
+  },
+  {
+    "id": 31793,
+    "name": "bulletstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 31796,
+    "name": "cosmicray",
+    "profession": "ranger"
+  },
+  {
+    "id": 31819,
+    "name": "glyphofrejuvenation",
+    "profession": "ranger"
+  },
+  {
+    "id": 31820,
+    "name": "heat",
+    "profession": "bundle"
+  },
+  {
+    "id": 31828,
+    "name": "unstablepylon",
+    "profession": "bundle"
+  },
+  {
+    "id": 31860,
+    "name": "unstablemagicspike",
+    "profession": "bundle"
+  },
+  {
+    "id": 31861,
+    "name": "spiritfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 31867,
+    "name": "glyphofrejuvenation",
+    "profession": "ranger"
+  },
+  {
+    "id": 31869,
+    "name": "celestialavatar",
+    "profession": "ranger"
+  },
+  {
+    "id": 31875,
+    "name": "spectralimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 31884,
+    "name": "unstablepylon",
+    "profession": "bundle"
+  },
+  {
+    "id": 31885,
+    "name": "magicaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 31886,
+    "name": "magicpulse",
+    "profession": "bundle"
+  },
+  {
+    "id": 31888,
+    "name": "glyphofunity",
+    "profession": "ranger"
+  },
+  {
+    "id": 31889,
+    "name": "astralwisp",
+    "profession": "ranger"
+  },
+  {
+    "id": 31894,
+    "name": "rejuvenatingtides",
+    "profession": "ranger"
+  },
+  {
+    "id": 31914,
+    "name": "wehealasone",
+    "profession": "ranger"
+  },
+  {
+    "id": 32242,
+    "name": "seedoflife",
+    "profession": "ranger"
+  },
+  {
+    "id": 32253,
+    "name": "rejuvenatingtides",
+    "profession": "ranger"
+  },
+  {
+    "id": 32364,
+    "name": "lunarimpact",
+    "profession": "ranger"
+  },
+  {
+    "id": 32588,
+    "name": "riteofthegreatdwarf",
+    "profession": "bundle"
+  },
+  {
+    "id": 33134,
+    "name": "huntersverdict",
+    "profession": "guardian"
+  },
+  {
+    "id": 33387,
+    "name": "cosmicray",
+    "profession": "ranger"
+  },
+  {
+    "id": 34070,
+    "name": "naturalconvergence",
+    "profession": "ranger"
+  },
+  {
+    "id": 34112,
+    "name": "platformcrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 34152,
+    "name": "timebomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 34174,
+    "name": "platformcrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 34309,
+    "name": "searchandrescue",
+    "profession": "ranger"
+  },
+  {
+    "id": 34326,
+    "name": "feedback",
+    "profession": "mesmer"
+  },
+  {
+    "id": 34335,
+    "name": "sweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 34336,
+    "name": "welloftheprofane",
+    "profession": "bundle"
+  },
+  {
+    "id": 34343,
+    "name": "swing",
+    "profession": "bundle"
+  },
+  {
+    "id": 34344,
+    "name": "fieryvortex",
+    "profession": "bundle"
+  },
+  {
+    "id": 34345,
+    "name": "unrelentingassault",
+    "profession": "bundle"
+  },
+  {
+    "id": 34353,
+    "name": "swing",
+    "profession": "bundle"
+  },
+  {
+    "id": 34354,
+    "name": "tormentingbite",
+    "profession": "bundle"
+  },
+  {
+    "id": 34356,
+    "name": "snowstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 34359,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 34363,
+    "name": "spontaneouscombustion",
+    "profession": "bundle"
+  },
+  {
+    "id": 34368,
+    "name": "bleedingbite",
+    "profession": "bundle"
+  },
+  {
+    "id": 34371,
+    "name": "oppressivegaze",
+    "profession": "bundle"
+  },
+  {
+    "id": 34375,
+    "name": "flamespray",
+    "profession": "bundle"
+  },
+  {
+    "id": 34380,
+    "name": "oppressivegaze",
+    "profession": "bundle"
+  },
+  {
+    "id": 34383,
+    "name": "hailofbullets",
+    "profession": "bundle"
+  },
+  {
+    "id": 34387,
+    "name": "volatilepoison",
+    "profession": "bundle"
+  },
+  {
+    "id": 34388,
+    "name": "swing",
+    "profession": "bundle"
+  },
+  {
+    "id": 34396,
+    "name": "unrelentingassault",
+    "profession": "bundle"
+  },
+  {
+    "id": 34398,
+    "name": "snipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 34404,
+    "name": "shardsofrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 34411,
+    "name": "shardsofrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 34413,
+    "name": "surrender",
+    "profession": "bundle"
+  },
+  {
+    "id": 34417,
+    "name": "flakshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 34431,
+    "name": "vulnerablespit",
+    "profession": "bundle"
+  },
+  {
+    "id": 34438,
+    "name": "fieryspit",
+    "profession": "bundle"
+  },
+  {
+    "id": 34440,
+    "name": "bloodshards",
+    "profession": "bundle"
+  },
+  {
+    "id": 34448,
+    "name": "overheadsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 34450,
+    "name": "unstablebloodmagic",
+    "profession": "bundle"
+  },
+  {
+    "id": 34455,
+    "name": "sweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 34460,
+    "name": "poisonousspit",
+    "profession": "bundle"
+  },
+  {
+    "id": 34462,
+    "name": "slowingthump",
+    "profession": "bundle"
+  },
+  {
+    "id": 34464,
+    "name": "slowburn",
+    "profession": "bundle"
+  },
+  {
+    "id": 34466,
+    "name": "fieryvortex",
+    "profession": "bundle"
+  },
+  {
+    "id": 34473,
+    "name": "corruption",
+    "profession": "bundle"
+  },
+  {
+    "id": 34479,
+    "name": "tantrum",
+    "profession": "bundle"
+  },
+  {
+    "id": 34480,
+    "name": "bloodshards",
+    "profession": "bundle"
+  },
+  {
+    "id": 34481,
+    "name": "volatilepoison",
+    "profession": "bundle"
+  },
+  {
+    "id": 34482,
+    "name": "sporerelease",
+    "profession": "bundle"
+  },
+  {
+    "id": 34488,
+    "name": "poisonspatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 34503,
+    "name": "cripplingthump",
+    "profession": "bundle"
+  },
+  {
+    "id": 34505,
+    "name": "volatileaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 34516,
+    "name": "halitosis",
+    "profession": "bundle"
+  },
+  {
+    "id": 34526,
+    "name": "heatwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 34528,
+    "name": "zealousbenediction",
+    "profession": "bundle"
+  },
+  {
+    "id": 34537,
+    "name": "toxiccloud",
+    "profession": "bundle"
+  },
+  {
+    "id": 34543,
+    "name": "thunder",
+    "profession": "bundle"
+  },
+  {
+    "id": 34554,
+    "name": "downpour",
+    "profession": "bundle"
+  },
+  {
+    "id": 34565,
+    "name": "toxiccloud",
+    "profession": "bundle"
+  },
+  {
+    "id": 34569,
+    "name": "corrosiveresidue",
+    "profession": "bundle"
+  },
+  {
+    "id": 34609,
+    "name": "glyphofelementalharmony",
+    "profession": "elementalist"
+  },
+  {
+    "id": 34637,
+    "name": "glyphofelementalpower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 34651,
+    "name": "glyphofelementalharmony",
+    "profession": "elementalist"
+  },
+  {
+    "id": 34714,
+    "name": "glyphofelementalpower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 34724,
+    "name": "glyphofelementalharmony",
+    "profession": "elementalist"
+  },
+  {
+    "id": 34736,
+    "name": "glyphofelementalpower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 34743,
+    "name": "glyphofelementalharmony",
+    "profession": "elementalist"
+  },
+  {
+    "id": 34772,
+    "name": "glyphofelementalpower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 34894,
+    "name": "magicblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 34910,
+    "name": "unravelingtorrent",
+    "profession": "bundle"
+  },
+  {
+    "id": 34913,
+    "name": "temporalvortex",
+    "profession": "bundle"
+  },
+  {
+    "id": 34916,
+    "name": "confoundingflurry",
+    "profession": "bundle"
+  },
+  {
+    "id": 34922,
+    "name": "cerebralslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 34946,
+    "name": "constructaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 34953,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 34963,
+    "name": "chaotichaze",
+    "profession": "bundle"
+  },
+  {
+    "id": 34971,
+    "name": "phantasmalblades",
+    "profession": "bundle"
+  },
+  {
+    "id": 35009,
+    "name": "confoundingfrenzy",
+    "profession": "bundle"
+  },
+  {
+    "id": 35031,
+    "name": "xerasfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 35047,
+    "name": "swipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 35064,
+    "name": "phantasmalblades",
+    "profession": "bundle"
+  },
+  {
+    "id": 35077,
+    "name": "hailoffury",
+    "profession": "bundle"
+  },
+  {
+    "id": 35082,
+    "name": "phantasmalblades",
+    "profession": "bundle"
+  },
+  {
+    "id": 35086,
+    "name": "towerdrop",
+    "profession": "bundle"
+  },
+  {
+    "id": 35116,
+    "name": "teleportdisplacementfield",
+    "profession": "bundle"
+  },
+  {
+    "id": 35128,
+    "name": "temporalshred",
+    "profession": "bundle"
+  },
+  {
+    "id": 35137,
+    "name": "phantasmalblades",
+    "profession": "bundle"
+  },
+  {
+    "id": 35139,
+    "name": "tormentingdredge",
+    "profession": "bundle"
+  },
+  {
+    "id": 35142,
+    "name": "backhand",
+    "profession": "bundle"
+  },
+  {
+    "id": 35154,
+    "name": "facesmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 35164,
+    "name": "illusionaryshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 35167,
+    "name": "overheadsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 35224,
+    "name": "elementalrequiem",
+    "profession": "thief"
+  },
+  {
+    "id": 35304,
+    "name": "dustcharge",
+    "profession": "thief"
+  },
+  {
+    "id": 35637,
+    "name": "swordofdecimation",
+    "profession": "mesmer"
+  },
+  {
+    "id": 35822,
+    "name": "rockthrow",
+    "profession": "bundle"
+  },
+  {
+    "id": 36281,
+    "name": "summoncrablings",
+    "profession": "bundle"
+  },
+  {
+    "id": 36488,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 36995,
+    "name": "flurry",
+    "profession": "bundle"
+  },
+  {
+    "id": 37060,
+    "name": "cyclone",
+    "profession": "bundle"
+  },
+  {
+    "id": 37197,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 37607,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 37611,
+    "name": "spatialmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 37613,
+    "name": "mindcrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 37629,
+    "name": "spatialmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 37631,
+    "name": "orbitalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 37642,
+    "name": "spatialmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 37660,
+    "name": "macesmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 37673,
+    "name": "spatialmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 37677,
+    "name": "soldiersaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 37703,
+    "name": "regret",
+    "profession": "bundle"
+  },
+  {
+    "id": 37716,
+    "name": "rapiddecay",
+    "profession": "bundle"
+  },
+  {
+    "id": 37775,
+    "name": "sharedagony",
+    "profession": "bundle"
+  },
+  {
+    "id": 37784,
+    "name": "impact",
+    "profession": "bundle"
+  },
+  {
+    "id": 37788,
+    "name": "jadeexplosion",
+    "profession": "bundle"
+  },
+  {
+    "id": 37797,
+    "name": "tramplingrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 37805,
+    "name": "soulfeast",
+    "profession": "bundle"
+  },
+  {
+    "id": 37816,
+    "name": "spearimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 37843,
+    "name": "claw",
+    "profession": "bundle"
+  },
+  {
+    "id": 37851,
+    "name": "inevitablebetrayal",
+    "profession": "bundle"
+  },
+  {
+    "id": 37872,
+    "name": "demonicaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 37873,
+    "name": "channeledagony",
+    "profession": "guardian"
+  },
+  {
+    "id": 37881,
+    "name": "demonicprojection",
+    "profession": "bundle"
+  },
+  {
+    "id": 37892,
+    "name": "soulswarm",
+    "profession": "bundle"
+  },
+  {
+    "id": 37901,
+    "name": "effigypulse",
+    "profession": "bundle"
+  },
+  {
+    "id": 37910,
+    "name": "gravitywave",
+    "profession": "bundle"
+  },
+  {
+    "id": 37927,
+    "name": "spearimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 37929,
+    "name": "annihilate",
+    "profession": "bundle"
+  },
+  {
+    "id": 37940,
+    "name": "anguishedwail",
+    "profession": "bundle"
+  },
+  {
+    "id": 37952,
+    "name": "punishmentaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 37974,
+    "name": "tramplingrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 37980,
+    "name": "demonicshockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 37982,
+    "name": "demonicshockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 37989,
+    "name": "cosmicaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 37996,
+    "name": "shockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 38006,
+    "name": "corporalpunishment",
+    "profession": "bundle"
+  },
+  {
+    "id": 38007,
+    "name": "saulsgrace",
+    "profession": "bundle"
+  },
+  {
+    "id": 38013,
+    "name": "brutalize",
+    "profession": "bundle"
+  },
+  {
+    "id": 38040,
+    "name": "prisonshank",
+    "profession": "bundle"
+  },
+  {
+    "id": 38046,
+    "name": "demonicshockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 38055,
+    "name": "regret",
+    "profession": "bundle"
+  },
+  {
+    "id": 38060,
+    "name": "energysurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 38074,
+    "name": "spatialmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 38094,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 38102,
+    "name": "impact",
+    "profession": "bundle"
+  },
+  {
+    "id": 38113,
+    "name": "displacement",
+    "profession": "bundle"
+  },
+  {
+    "id": 38116,
+    "name": "regret",
+    "profession": "bundle"
+  },
+  {
+    "id": 38168,
+    "name": "prisonersweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 38180,
+    "name": "spearreturn",
+    "profession": "bundle"
+  },
+  {
+    "id": 38184,
+    "name": "enemytile",
+    "profession": "bundle"
+  },
+  {
+    "id": 38187,
+    "name": "weakminded",
+    "profession": "bundle"
+  },
+  {
+    "id": 38208,
+    "name": "annihilate",
+    "profession": "bundle"
+  },
+  {
+    "id": 38210,
+    "name": "sharedagony",
+    "profession": "bundle"
+  },
+  {
+    "id": 38231,
+    "name": "impalingstab",
+    "profession": "bundle"
+  },
+  {
+    "id": 38236,
+    "name": "inevitablebetrayal",
+    "profession": "bundle"
+  },
+  {
+    "id": 38258,
+    "name": "brutalaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 38260,
+    "name": "inevitablebetrayal",
+    "profession": "bundle"
+  },
+  {
+    "id": 38266,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 38268,
+    "name": "inevitablebetrayal",
+    "profession": "bundle"
+  },
+  {
+    "id": 38273,
+    "name": "cleave",
+    "profession": "bundle"
+  },
+  {
+    "id": 38302,
+    "name": "spatialmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 38304,
+    "name": "wrath",
+    "profession": "bundle"
+  },
+  {
+    "id": 38305,
+    "name": "bludgeon",
+    "profession": "bundle"
+  },
+  {
+    "id": 38313,
+    "name": "meteorswarm",
+    "profession": "bundle"
+  },
+  {
+    "id": 38314,
+    "name": "anguishedbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 38451,
+    "name": "judgmentofwar",
+    "profession": "bundle"
+  },
+  {
+    "id": 38748,
+    "name": "detonaterocketturret",
+    "profession": "engineer"
+  },
+  {
+    "id": 38750,
+    "name": "detonatesupplycrateturrets",
+    "profession": "engineer"
+  },
+  {
+    "id": 38767,
+    "name": "unholyburst",
+    "profession": "necromancer"
+  },
+  {
+    "id": 38844,
+    "name": "overheadsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 38846,
+    "name": "mistchargedchop",
+    "profession": "bundle"
+  },
+  {
+    "id": 38847,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 38849,
+    "name": "spiralstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 38858,
+    "name": "temporalrealignment",
+    "profession": "bundle"
+  },
+  {
+    "id": 38863,
+    "name": "bigshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 38865,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 38867,
+    "name": "astralsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 38874,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 38878,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 38881,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 38889,
+    "name": "radiantfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 38894,
+    "name": "headkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 38896,
+    "name": "punishingkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 38897,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 38920,
+    "name": "solarbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 38924,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 38926,
+    "name": "radiantfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 38927,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 38941,
+    "name": "solarbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 38942,
+    "name": "whirligig",
+    "profession": "bundle"
+  },
+  {
+    "id": 38954,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 38966,
+    "name": "starburstcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 38977,
+    "name": "vault",
+    "profession": "bundle"
+  },
+  {
+    "id": 38982,
+    "name": "starburstcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 38986,
+    "name": "pulsarblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 38987,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 38991,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39001,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39005,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 39007,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39011,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 39013,
+    "name": "warp",
+    "profession": "bundle"
+  },
+  {
+    "id": 39018,
+    "name": "starburstcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39019,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39021,
+    "name": "cosmicstreaks",
+    "profession": "bundle"
+  },
+  {
+    "id": 39025,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39029,
+    "name": "redmarble",
+    "profession": "bundle"
+  },
+  {
+    "id": 39031,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39033,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39035,
+    "name": "astralsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39037,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 39039,
+    "name": "solarbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 39053,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39054,
+    "name": "bigshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39063,
+    "name": "cranialcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39064,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39078,
+    "name": "plunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39082,
+    "name": "lightningbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 39093,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39099,
+    "name": "firebreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 39103,
+    "name": "electrocute",
+    "profession": "bundle"
+  },
+  {
+    "id": 39107,
+    "name": "mistbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 39110,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39116,
+    "name": "jabcombo",
+    "profession": "bundle"
+  },
+  {
+    "id": 39122,
+    "name": "explode",
+    "profession": "bundle"
+  },
+  {
+    "id": 39133,
+    "name": "waveofmutilation",
+    "profession": "bundle"
+  },
+  {
+    "id": 39135,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39136,
+    "name": "solarbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 39138,
+    "name": "solarblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 39139,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39146,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39152,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39160,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39163,
+    "name": "curvedshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39171,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39185,
+    "name": "astralsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39186,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39195,
+    "profession": "bundle"
+  },
+  {
+    "id": 39198,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39200,
+    "name": "discharge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39204,
+    "name": "focusedrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 39212,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39213,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39215,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39216,
+    "name": "explode",
+    "profession": "bundle"
+  },
+  {
+    "id": 39217,
+    "name": "curvedshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39220,
+    "name": "cranialcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39222,
+    "name": "bigshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39225,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 39228,
+    "name": "solarcyclone",
+    "profession": "bundle"
+  },
+  {
+    "id": 39232,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39235,
+    "name": "searingheat",
+    "profession": "bundle"
+  },
+  {
+    "id": 39238,
+    "name": "beamingsmile",
+    "profession": "bundle"
+  },
+  {
+    "id": 39242,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39247,
+    "name": "obliterate",
+    "profession": "bundle"
+  },
+  {
+    "id": 39251,
+    "name": "focusedrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 39253,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39254,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39257,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39261,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39263,
+    "profession": "bundle"
+  },
+  {
+    "id": 39267,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39274,
+    "name": "starburstcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39275,
+    "name": "corporealreassignment",
+    "profession": "bundle"
+  },
+  {
+    "id": 39276,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39278,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39284,
+    "name": "forceofthenightmare",
+    "profession": "bundle"
+  },
+  {
+    "id": 39291,
+    "name": "rollingchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 39297,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39298,
+    "name": "solarstomp",
+    "profession": "bundle"
+  },
+  {
+    "id": 39299,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 39300,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39303,
+    "name": "solarfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 39306,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39308,
+    "name": "focusedrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 39313,
+    "name": "solarbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 39319,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39321,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 39322,
+    "name": "curvedshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39323,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39332,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39335,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39345,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39346,
+    "name": "rollingchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 39350,
+    "name": "mistbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 39357,
+    "name": "globollamarble",
+    "profession": "bundle"
+  },
+  {
+    "id": 39363,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39375,
+    "name": "uppercut",
+    "profession": "bundle"
+  },
+  {
+    "id": 39377,
+    "name": "combustionrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 39383,
+    "name": "starburstcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39388,
+    "name": "jabcombo",
+    "profession": "bundle"
+  },
+  {
+    "id": 39392,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39394,
+    "name": "cranialcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39395,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39398,
+    "name": "mibring",
+    "profession": "bundle"
+  },
+  {
+    "id": 39401,
+    "name": "overheadsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 39416,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 39417,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39419,
+    "name": "astralsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39422,
+    "name": "smallshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39423,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39426,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39427,
+    "name": "combustionrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 39433,
+    "name": "flyingknee",
+    "profession": "bundle"
+  },
+  {
+    "id": 39434,
+    "name": "radiantfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 39442,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 39450,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39454,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39458,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39466,
+    "name": "uppercut",
+    "profession": "bundle"
+  },
+  {
+    "id": 39469,
+    "name": "teleportlunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39470,
+    "name": "obliterate",
+    "profession": "bundle"
+  },
+  {
+    "id": 39478,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39479,
+    "name": "mistchargedchop",
+    "profession": "bundle"
+  },
+  {
+    "id": 39482,
+    "name": "punishingkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 39483,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39485,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39491,
+    "name": "explode",
+    "profession": "bundle"
+  },
+  {
+    "id": 39495,
+    "name": "globollamarble",
+    "profession": "bundle"
+  },
+  {
+    "id": 39504,
+    "name": "flyingknee",
+    "profession": "bundle"
+  },
+  {
+    "id": 39507,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39514,
+    "name": "warp",
+    "profession": "bundle"
+  },
+  {
+    "id": 39520,
+    "name": "punishingkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 39521,
+    "name": "mistchargedchop",
+    "profession": "bundle"
+  },
+  {
+    "id": 39523,
+    "name": "starburstcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39526,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39534,
+    "name": "cranialcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39539,
+    "name": "sharedshock",
+    "profession": "bundle"
+  },
+  {
+    "id": 39540,
+    "name": "thwack",
+    "profession": "bundle"
+  },
+  {
+    "id": 39541,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39551,
+    "name": "explode",
+    "profession": "bundle"
+  },
+  {
+    "id": 39557,
+    "name": "mibring",
+    "profession": "bundle"
+  },
+  {
+    "id": 39564,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39572,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39575,
+    "name": "mistsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 39579,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39581,
+    "name": "combustionrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 39582,
+    "name": "headkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 39583,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39590,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39602,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39607,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 39609,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39615,
+    "name": "combustionrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 39619,
+    "name": "punishingkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 39628,
+    "name": "globollamarble",
+    "profession": "bundle"
+  },
+  {
+    "id": 39638,
+    "name": "mistbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 39646,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39648,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 39653,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39664,
+    "name": "solarbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 39667,
+    "name": "solarfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 39668,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39673,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39674,
+    "name": "rollingchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 39684,
+    "name": "solarfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 39685,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39686,
+    "name": "cranialcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 39691,
+    "name": "solardischarge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39694,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39701,
+    "name": "teleportlunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39708,
+    "name": "astralsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39711,
+    "name": "focusedrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 39713,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39714,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39728,
+    "name": "solarfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 39734,
+    "name": "rollingchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 39745,
+    "name": "globollamarble",
+    "profession": "bundle"
+  },
+  {
+    "id": 39746,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39748,
+    "name": "tawshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39755,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39760,
+    "name": "solarbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 39765,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39770,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39775,
+    "name": "focusedrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 39782,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 39787,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39788,
+    "name": "discharge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39790,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39795,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39801,
+    "name": "corruptedground",
+    "profession": "bundle"
+  },
+  {
+    "id": 39816,
+    "name": "curvedshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 39823,
+    "name": "solarblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 39829,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39830,
+    "name": "diffractiveedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 39839,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39845,
+    "name": "radiantfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 39847,
+    "name": "pulsarblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 39848,
+    "name": "solarbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 39849,
+    "name": "explode",
+    "profession": "bundle"
+  },
+  {
+    "id": 39853,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39854,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39857,
+    "name": "solarblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 39863,
+    "name": "redmarble",
+    "profession": "bundle"
+  },
+  {
+    "id": 39867,
+    "name": "bowlermarble",
+    "profession": "bundle"
+  },
+  {
+    "id": 39874,
+    "name": "solarfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 39875,
+    "name": "focusedanger",
+    "profession": "bundle"
+  },
+  {
+    "id": 39879,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39884,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39886,
+    "name": "radiantfury",
+    "profession": "bundle"
+  },
+  {
+    "id": 39889,
+    "name": "horizonstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39894,
+    "name": "rollingchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 39895,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39910,
+    "name": "punishingkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 39911,
+    "name": "spiralstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 39915,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 39916,
+    "name": "combustionrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 39920,
+    "name": "overheadsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 39924,
+    "name": "crimsondawn",
+    "profession": "bundle"
+  },
+  {
+    "id": 39959,
+    "name": "waveofpanic",
+    "profession": "mesmer"
+  },
+  {
+    "id": 39960,
+    "name": "stealwarmth",
+    "profession": "thief"
+  },
+  {
+    "id": 39964,
+    "name": "firestrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 39972,
+    "name": "silencer",
+    "profession": "warrior"
+  },
+  {
+    "id": 39977,
+    "name": "awakenedsoldierswing",
+    "profession": "bundle"
+  },
+  {
+    "id": 39981,
+    "name": "soddenswath",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40078,
+    "name": "firebolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 40084,
+    "name": "crushingblow",
+    "profession": "bundle"
+  },
+  {
+    "id": 40111,
+    "name": "narcoticspores",
+    "profession": "ranger"
+  },
+  {
+    "id": 40133,
+    "name": "stealresistance",
+    "profession": "thief"
+  },
+  {
+    "id": 40139,
+    "name": "rustfrenzy",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40160,
+    "name": "radiantarc",
+    "profession": "engineer"
+  },
+  {
+    "id": 40170,
+    "name": "naturalfrenzy",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40175,
+    "name": "bloodbanepath",
+    "profession": "revenant"
+  },
+  {
+    "id": 40183,
+    "name": "primordialstance",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40184,
+    "name": "chaosvortex",
+    "profession": "mesmer"
+  },
+  {
+    "id": 40200,
+    "name": "falseoasis",
+    "profession": "mesmer"
+  },
+  {
+    "id": 40229,
+    "name": "doublelavaaxe",
+    "profession": "thief"
+  },
+  {
+    "id": 40255,
+    "name": "smokeassault",
+    "profession": "ranger"
+  },
+  {
+    "id": 40274,
+    "name": "trailofanguish",
+    "profession": "necromancer"
+  },
+  {
+    "id": 40275,
+    "name": "keenstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 40301,
+    "name": "leadingswipe",
+    "profession": "ranger"
+  },
+  {
+    "id": 40326,
+    "name": "fireswipe",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40332,
+    "name": "pressureblast",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40378,
+    "name": "hydrothermalvent",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40436,
+    "name": "sniperscover",
+    "profession": "thief"
+  },
+  {
+    "id": 40485,
+    "name": "icerazorsire",
+    "profession": "revenant"
+  },
+  {
+    "id": 40497,
+    "name": "shattershot",
+    "profession": "revenant"
+  },
+  {
+    "id": 40498,
+    "name": "vulturestance",
+    "profession": "ranger"
+  },
+  {
+    "id": 40507,
+    "name": "coolantblast",
+    "profession": "engineer"
+  },
+  {
+    "id": 40533,
+    "name": "launchwall",
+    "profession": "engineer"
+  },
+  {
+    "id": 40560,
+    "name": "focusedslash",
+    "profession": "warrior"
+  },
+  {
+    "id": 40588,
+    "name": "primalcry",
+    "profession": "ranger"
+  },
+  {
+    "id": 40600,
+    "name": "kneel",
+    "profession": "thief"
+  },
+  {
+    "id": 40601,
+    "name": "earthshaker",
+    "profession": "warrior"
+  },
+  {
+    "id": 40614,
+    "name": "phantasmalspinningaxe",
+    "profession": "bundle"
+  },
+  {
+    "id": 40624,
+    "name": "symbolofvengeance",
+    "profession": "guardian"
+  },
+  {
+    "id": 40625,
+    "name": "bite",
+    "profession": "ranger"
+  },
+  {
+    "id": 40643,
+    "name": "intimidatingshout",
+    "profession": "bundle"
+  },
+  {
+    "id": 40709,
+    "name": "earthenvortex",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40710,
+    "name": "deadlyaim",
+    "profession": "thief"
+  },
+  {
+    "id": 40729,
+    "name": "worldlyimpact",
+    "profession": "ranger"
+  },
+  {
+    "id": 40791,
+    "name": "giantflurry",
+    "profession": "bundle"
+  },
+  {
+    "id": 40794,
+    "name": "earthensynergy",
+    "profession": "elementalist"
+  },
+  {
+    "id": 40813,
+    "name": "nefariousfavor",
+    "profession": "necromancer"
+  },
+  {
+    "id": 40857,
+    "name": "deadlykick",
+    "profession": "bundle"
+  },
+  {
+    "id": 40888,
+    "name": "stealprecision",
+    "profession": "thief"
+  },
+  {
+    "id": 40903,
+    "name": "stealhealth",
+    "profession": "thief"
+  },
+  {
+    "id": 40904,
+    "name": "stealstrength",
+    "profession": "thief"
+  },
+  {
+    "id": 40915,
+    "name": "mantraofpotence",
+    "profession": "guardian"
+  },
+  {
+    "id": 40963,
+    "name": "grindingstones",
+    "profession": "elementalist"
+  },
+  {
+    "id": 41001,
+    "name": "elementalcompression",
+    "profession": "elementalist"
+  },
+  {
+    "id": 41052,
+    "name": "seiche",
+    "profession": "elementalist"
+  },
+  {
+    "id": 41065,
+    "name": "crystalsands",
+    "profession": "mesmer"
+  },
+  {
+    "id": 41068,
+    "name": "freeaction",
+    "profession": "thief"
+  },
+  {
+    "id": 41100,
+    "name": "naturalhealing",
+    "profession": "warrior"
+  },
+  {
+    "id": 41110,
+    "name": "skullcrack",
+    "profession": "warrior"
+  },
+  {
+    "id": 41119,
+    "name": "reverberantshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 41123,
+    "name": "deactivatephotonforge",
+    "profession": "engineer"
+  },
+  {
+    "id": 41125,
+    "name": "plasmablast",
+    "profession": "elementalist"
+  },
+  {
+    "id": 41156,
+    "name": "fanggrapple"
+  },
+  {
+    "id": 41158,
+    "name": "shadowflare",
+    "profession": "thief"
+  },
+  {
+    "id": 41164,
+    "name": "mirrorstrikes",
+    "profession": "mesmer"
+  },
+  {
+    "id": 41167,
+    "name": "aquasiphon",
+    "profession": "elementalist"
+  },
+  {
+    "id": 41184,
+    "name": "monsoon",
+    "profession": "elementalist"
+  },
+  {
+    "id": 41205,
+    "name": "bindingshadow",
+    "profession": "thief"
+  },
+  {
+    "id": 41206,
+    "name": "rainofspikes",
+    "profession": "ranger"
+  },
+  {
+    "id": 41218,
+    "name": "spectrumshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 41220,
+    "name": "darkrazorsdaring",
+    "profession": "revenant"
+  },
+  {
+    "id": 41247,
+    "name": "giantstomp",
+    "profession": "bundle"
+  },
+  {
+    "id": 41283,
+    "name": "booncrusher",
+    "profession": "warrior"
+  },
+  {
+    "id": 41294,
+    "name": "citadelbombardment",
+    "profession": "revenant"
+  },
+  {
+    "id": 41324,
+    "name": "phantasmalseekingaxe",
+    "profession": "bundle"
+  },
+  {
+    "id": 41330,
+    "name": "forcefulshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 41372,
+    "name": "mercy",
+    "profession": "thief"
+  },
+  {
+    "id": 41380,
+    "name": "stowtome",
+    "profession": "guardian"
+  },
+  {
+    "id": 41406,
+    "name": "maul",
+    "profession": "ranger"
+  },
+  {
+    "id": 41422,
+    "name": "brutalaim",
+    "profession": "thief"
+  },
+  {
+    "id": 41461,
+    "name": "devourerretreat",
+    "profession": "ranger"
+  },
+  {
+    "id": 41494,
+    "name": "skirmishersshot",
+    "profession": "thief"
+  },
+  {
+    "id": 41513,
+    "name": "citadelbombardment",
+    "profession": "bundle"
+  },
+  {
+    "id": 41524,
+    "name": "kick",
+    "profession": "ranger"
+  },
+  {
+    "id": 41537,
+    "name": "chomp",
+    "profession": "ranger"
+  },
+  {
+    "id": 41543,
+    "name": "woundingstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 41571,
+    "name": "shieldoftheavenger",
+    "profession": "guardian"
+  },
+  {
+    "id": 41575,
+    "name": "tailswipe",
+    "profession": "ranger"
+  },
+  {
+    "id": 41612,
+    "name": "orbitalcommandstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 41615,
+    "name": "serpentsiphon",
+    "profession": "necromancer"
+  },
+  {
+    "id": 41684,
+    "name": "flashcutterstorm",
+    "profession": "engineer"
+  },
+  {
+    "id": 41712,
+    "name": "plasmicstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 41714,
+    "name": "mantraofsolace",
+    "profession": "guardian"
+  },
+  {
+    "id": 41721,
+    "name": "screech",
+    "profession": "bundle"
+  },
+  {
+    "id": 41746,
+    "name": "whirlingstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 41780,
+    "name": "tomeofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 41800,
+    "name": "serpentstab",
+    "profession": "ranger"
+  },
+  {
+    "id": 41820,
+    "name": "scorchrazor",
+    "profession": "revenant"
+  },
+  {
+    "id": 41829,
+    "name": "sevenshot",
+    "profession": "revenant"
+  },
+  {
+    "id": 41837,
+    "name": "darkwater",
+    "profession": "ranger"
+  },
+  {
+    "id": 41843,
+    "name": "prismaticsingularity",
+    "profession": "engineer"
+  },
+  {
+    "id": 41858,
+    "name": "legendaryrenegadestance",
+    "profession": "revenant"
+  },
+  {
+    "id": 41860,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 41887,
+    "name": "peck",
+    "profession": "bundle"
+  },
+  {
+    "id": 41908,
+    "name": "wingbuffet",
+    "profession": "ranger"
+  },
+  {
+    "id": 41919,
+    "name": "imminentthreat",
+    "profession": "warrior"
+  },
+  {
+    "id": 41937,
+    "name": "deathsretreat",
+    "profession": "thief"
+  },
+  {
+    "id": 42009,
+    "name": "primelightbeam",
+    "profession": "engineer"
+  },
+  {
+    "id": 42041,
+    "name": "killshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 42042,
+    "name": "quickeningscreech",
+    "profession": "ranger"
+  },
+  {
+    "id": 42163,
+    "name": "bladeburst",
+    "profession": "engineer"
+  },
+  {
+    "id": 42180,
+    "name": "blindingroar"
+  },
+  {
+    "id": 42181,
+    "name": "fieryfrost",
+    "profession": "elementalist"
+  },
+  {
+    "id": 42183,
+    "name": "reformedmiragemirror",
+    "profession": "bundle"
+  },
+  {
+    "id": 42235,
+    "name": "crystallineimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 42259,
+    "name": "tomeofcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 42271,
+    "name": "twinstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 42297,
+    "name": "manifestsandshade",
+    "profession": "necromancer"
+  },
+  {
+    "id": 42304,
+    "name": "etherbarrage",
+    "profession": "mesmer"
+  },
+  {
+    "id": 42321,
+    "name": "piledriver",
+    "profession": "elementalist"
+  },
+  {
+    "id": 42330,
+    "name": "steamsurge",
+    "profession": "elementalist"
+  },
+  {
+    "id": 42355,
+    "name": "ghastlybreach",
+    "profession": "necromancer"
+  },
+  {
+    "id": 42371,
+    "name": "tomeofcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 42379,
+    "name": "ashenblast",
+    "profession": "elementalist"
+  },
+  {
+    "id": 42470,
+    "name": "lessersignetofstone",
+    "profession": "bundle"
+  },
+  {
+    "id": 42475,
+    "name": "brightslashstorm",
+    "profession": "engineer"
+  },
+  {
+    "id": 42494,
+    "name": "flurry",
+    "profession": "warrior"
+  },
+  {
+    "id": 42521,
+    "name": "holographicshockwave",
+    "profession": "engineer"
+  },
+  {
+    "id": 42575,
+    "name": "batteringslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 42577,
+    "name": "lunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 42707,
+    "name": "arcingslice",
+    "profession": "warrior"
+  },
+  {
+    "id": 42717,
+    "name": "protection",
+    "profession": "ranger"
+  },
+  {
+    "id": 42745,
+    "name": "precisecut",
+    "profession": "warrior"
+  },
+  {
+    "id": 42752,
+    "name": "dismisslieutenantsoulcleave",
+    "profession": "revenant"
+  },
+  {
+    "id": 42797,
+    "name": "chargingbite",
+    "profession": "ranger"
+  },
+  {
+    "id": 42803,
+    "name": "combustiveshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 42809,
+    "name": "worldlyimpact",
+    "profession": "ranger"
+  },
+  {
+    "id": 42836,
+    "name": "citadelbombardment",
+    "profession": "revenant"
+  },
+  {
+    "id": 42842,
+    "name": "laserdisk",
+    "profession": "engineer"
+  },
+  {
+    "id": 42851,
+    "name": "mirageadvance",
+    "profession": "mesmer"
+  },
+  {
+    "id": 42863,
+    "name": "stealtime",
+    "profession": "thief"
+  },
+  {
+    "id": 42867,
+    "name": "shearingedge",
+    "profession": "elementalist"
+  },
+  {
+    "id": 42894,
+    "name": "brutalcharge",
+    "profession": "ranger"
+  },
+  {
+    "id": 42907,
+    "name": "takedown",
+    "profession": "ranger"
+  },
+  {
+    "id": 42913,
+    "name": "lesserstoneresonance",
+    "profession": "bundle"
+  },
+  {
+    "id": 42917,
+    "name": "sandswell",
+    "profession": "necromancer"
+  },
+  {
+    "id": 42935,
+    "name": "desiccate",
+    "profession": "necromancer"
+  },
+  {
+    "id": 42938,
+    "name": "engagephotonforge",
+    "profession": "engineer"
+  },
+  {
+    "id": 42944,
+    "name": "beastmode",
+    "profession": "ranger"
+  },
+  {
+    "id": 42949,
+    "name": "razorclawsrage",
+    "profession": "revenant"
+  },
+  {
+    "id": 42954,
+    "name": "fracturingstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 42963,
+    "name": "savannahstrike"
+  },
+  {
+    "id": 42965,
+    "name": "hololeap",
+    "profession": "engineer"
+  },
+  {
+    "id": 43014,
+    "name": "leavebeastmode",
+    "profession": "ranger"
+  },
+  {
+    "id": 43060,
+    "name": "defypain",
+    "profession": "ranger"
+  },
+  {
+    "id": 43064,
+    "name": "sandthroughglass",
+    "profession": "mesmer"
+  },
+  {
+    "id": 43068,
+    "name": "taillash",
+    "profession": "ranger"
+  },
+  {
+    "id": 43074,
+    "name": "pyrovortex",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43080,
+    "name": "crystallinestrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43123,
+    "name": "breakenchantments",
+    "profession": "warrior"
+  },
+  {
+    "id": 43136,
+    "name": "bite",
+    "profession": "ranger"
+  },
+  {
+    "id": 43148,
+    "name": "sandflare",
+    "profession": "necromancer"
+  },
+  {
+    "id": 43176,
+    "name": "flashspark",
+    "profession": "engineer"
+  },
+  {
+    "id": 43186,
+    "name": "healingcloud",
+    "profession": "ranger"
+  },
+  {
+    "id": 43199,
+    "name": "breakingwave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43343,
+    "name": "bladerenewal",
+    "profession": "mesmer"
+  },
+  {
+    "id": 43357,
+    "name": "mantraofliberation",
+    "profession": "guardian"
+  },
+  {
+    "id": 43373,
+    "name": "stealdurability",
+    "profession": "thief"
+  },
+  {
+    "id": 43375,
+    "name": "preludelash",
+    "profession": "ranger"
+  },
+  {
+    "id": 43390,
+    "name": "deadeyesmark",
+    "profession": "thief"
+  },
+  {
+    "id": 43434,
+    "name": "crystalfling",
+    "profession": "bundle"
+  },
+  {
+    "id": 43448,
+    "name": "sandcascade",
+    "profession": "necromancer"
+  },
+  {
+    "id": 43459,
+    "name": "tarfont",
+    "profession": "bundle"
+  },
+  {
+    "id": 43476,
+    "name": "sunedge",
+    "profession": "engineer"
+  },
+  {
+    "id": 43488,
+    "name": "fleetingstability",
+    "profession": "warrior"
+  },
+  {
+    "id": 43532,
+    "name": "magebanetether",
+    "profession": "bundle"
+  },
+  {
+    "id": 43536,
+    "name": "doublearc",
+    "profession": "ranger"
+  },
+  {
+    "id": 43548,
+    "name": "frenziedattack",
+    "profession": "ranger"
+  },
+  {
+    "id": 43565,
+    "name": "bowoftruth",
+    "profession": "guardian"
+  },
+  {
+    "id": 43566,
+    "name": "eviscerate",
+    "profession": "warrior"
+  },
+  {
+    "id": 43576,
+    "name": "plasmabeam",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43616,
+    "name": "crystalslash",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43630,
+    "name": "ventexhaust",
+    "profession": "bundle"
+  },
+  {
+    "id": 43636,
+    "name": "headtoss"
+  },
+  {
+    "id": 43638,
+    "name": "weaveself",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43657,
+    "name": "searingslash",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43671,
+    "name": "poisongas",
+    "profession": "ranger"
+  },
+  {
+    "id": 43701,
+    "name": "photosynthesize",
+    "profession": "ranger"
+  },
+  {
+    "id": 43726,
+    "name": "cripplingleap",
+    "profession": "ranger"
+  },
+  {
+    "id": 43739,
+    "name": "photonwall",
+    "profession": "engineer"
+  },
+  {
+    "id": 43745,
+    "name": "sightbeyondsight",
+    "profession": "warrior"
+  },
+  {
+    "id": 43761,
+    "name": "axesofsymmetry",
+    "profession": "mesmer"
+  },
+  {
+    "id": 43762,
+    "name": "pyroclasticblast",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43766,
+    "name": "reverberantshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 43768,
+    "name": "stealdefenses",
+    "profession": "thief"
+  },
+  {
+    "id": 43788,
+    "name": "calllightning",
+    "profession": "ranger"
+  },
+  {
+    "id": 43803,
+    "name": "quantumstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 43815,
+    "name": "frenziedpeck",
+    "profession": "bundle"
+  },
+  {
+    "id": 43826,
+    "name": "searingslash",
+    "profession": "guardian"
+  },
+  {
+    "id": 43845,
+    "name": "cauterize",
+    "profession": "engineer"
+  },
+  {
+    "id": 43916,
+    "name": "doubletap",
+    "profession": "thief"
+  },
+  {
+    "id": 43937,
+    "name": "overheat",
+    "profession": "bundle"
+  },
+  {
+    "id": 43993,
+    "name": "spiritcrush",
+    "profession": "revenant"
+  },
+  {
+    "id": 44004,
+    "name": "wastrelsruin",
+    "profession": "warrior"
+  },
+  {
+    "id": 44076,
+    "name": "heroiccommand",
+    "profession": "revenant"
+  },
+  {
+    "id": 44080,
+    "name": "mantraoftruth",
+    "profession": "guardian"
+  },
+  {
+    "id": 44087,
+    "name": "deathsjudgment",
+    "profession": "thief"
+  },
+  {
+    "id": 44097,
+    "name": "entanglingweb",
+    "profession": "ranger"
+  },
+  {
+    "id": 44110,
+    "name": "refractioncutter",
+    "profession": "engineer"
+  },
+  {
+    "id": 44165,
+    "name": "fullcounter",
+    "profession": "warrior"
+  },
+  {
+    "id": 44239,
+    "name": "aquaticstance",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44240,
+    "name": "lesserquickeningzephyr",
+    "profession": "bundle"
+  },
+  {
+    "id": 44241,
+    "name": "splitsurge",
+    "profession": "mesmer"
+  },
+  {
+    "id": 44260,
+    "name": "lightstrikestorm",
+    "profession": "engineer"
+  },
+  {
+    "id": 44278,
+    "name": "deadlydelivery",
+    "profession": "ranger"
+  },
+  {
+    "id": 44296,
+    "name": "oppressivecollapse",
+    "profession": "necromancer"
+  },
+  {
+    "id": 44305,
+    "name": "needleshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 44321,
+    "name": "imaginaryaxes",
+    "profession": "mesmer"
+  },
+  {
+    "id": 44360,
+    "name": "fear",
+    "profession": "ranger"
+  },
+  {
+    "id": 44364,
+    "name": "tomeofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 44384,
+    "name": "cripplinganguish",
+    "profession": "ranger"
+  },
+  {
+    "id": 44386,
+    "name": "holoforgeoverheated",
+    "profession": "engineer"
+  },
+  {
+    "id": 44397,
+    "name": "dissonance",
+    "profession": "warrior"
+  },
+  {
+    "id": 44405,
+    "name": "riptide",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44428,
+    "name": "garishpillar",
+    "profession": "necromancer"
+  },
+  {
+    "id": 44451,
+    "name": "cauterizingstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44467,
+    "name": "throwboulder",
+    "profession": "bundle"
+  },
+  {
+    "id": 44514,
+    "name": "maul",
+    "profession": "ranger"
+  },
+  {
+    "id": 44526,
+    "name": "stealmobility",
+    "profession": "thief"
+  },
+  {
+    "id": 44530,
+    "name": "coronaburst",
+    "profession": "engineer"
+  },
+  {
+    "id": 44550,
+    "name": "lahar",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44588,
+    "name": "lightstrike",
+    "profession": "engineer"
+  },
+  {
+    "id": 44591,
+    "name": "spottersshot",
+    "profession": "thief"
+  },
+  {
+    "id": 44602,
+    "name": "bleedingedge",
+    "profession": "guardian"
+  },
+  {
+    "id": 44612,
+    "name": "unravel",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44617,
+    "name": "harmoniccry",
+    "profession": "ranger"
+  },
+  {
+    "id": 44626,
+    "name": "spiritualreprieve",
+    "profession": "ranger"
+  },
+  {
+    "id": 44637,
+    "name": "tailoredvictory",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44646,
+    "name": "hardlightarena",
+    "profession": "engineer"
+  },
+  {
+    "id": 44652,
+    "name": "plasmaburst",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44663,
+    "name": "desertshroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 44677,
+    "name": "miragemirror",
+    "profession": "mesmer"
+  },
+  {
+    "id": 44681,
+    "name": "chargedstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44695,
+    "name": "threeroundburst",
+    "profession": "thief"
+  },
+  {
+    "id": 44791,
+    "name": "laceratingchop",
+    "profession": "mesmer"
+  },
+  {
+    "id": 44840,
+    "name": "etherealchop",
+    "profession": "mesmer"
+  },
+  {
+    "id": 44846,
+    "name": "swordofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 44864,
+    "name": "ambushassault",
+    "profession": "mesmer"
+  },
+  {
+    "id": 44876,
+    "name": "fireblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 44885,
+    "name": "chomp",
+    "profession": "ranger"
+  },
+  {
+    "id": 44918,
+    "name": "lesserfieryeruption",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44926,
+    "name": "stoneresonance",
+    "profession": "elementalist"
+  },
+  {
+    "id": 44937,
+    "name": "disruptingstab",
+    "profession": "warrior"
+  },
+  {
+    "id": 44946,
+    "name": "manifestsandshade",
+    "profession": "necromancer"
+  },
+  {
+    "id": 44948,
+    "name": "bearstance",
+    "profession": "ranger"
+  },
+  {
+    "id": 44980,
+    "name": "jacarandasembrace"
+  },
+  {
+    "id": 44991,
+    "name": "swoop",
+    "profession": "ranger"
+  },
+  {
+    "id": 44998,
+    "name": "polaricleap",
+    "profession": "elementalist"
+  },
+  {
+    "id": 45010,
+    "name": "giantkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 45023,
+    "name": "tomeofresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 45046,
+    "name": "illusionaryambush",
+    "profession": "mesmer"
+  },
+  {
+    "id": 45047,
+    "name": "corecleave",
+    "profession": "guardian"
+  },
+  {
+    "id": 45088,
+    "name": "maliciousrestoration",
+    "profession": "thief"
+  },
+  {
+    "id": 45094,
+    "name": "throwgunk"
+  },
+  {
+    "id": 45142,
+    "name": "griffonstance",
+    "profession": "ranger"
+  },
+  {
+    "id": 45160,
+    "name": "bladestorm",
+    "profession": "warrior"
+  },
+  {
+    "id": 45216,
+    "name": "calllightning",
+    "profession": "elementalist"
+  },
+  {
+    "id": 45219,
+    "name": "deactivatephotonforge",
+    "profession": "engineer"
+  },
+  {
+    "id": 45230,
+    "name": "miragethrust",
+    "profession": "mesmer"
+  },
+  {
+    "id": 45243,
+    "name": "lingeringthoughts",
+    "profession": "mesmer"
+  },
+  {
+    "id": 45252,
+    "name": "breachingstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 45259,
+    "name": "polaricslash",
+    "profession": "elementalist"
+  },
+  {
+    "id": 45313,
+    "name": "flameuprising",
+    "profession": "elementalist"
+  },
+  {
+    "id": 45333,
+    "name": "windsofdisenchantment",
+    "profession": "warrior"
+  },
+  {
+    "id": 45353,
+    "name": "bite",
+    "profession": "bundle"
+  },
+  {
+    "id": 45380,
+    "name": "featherfootgrace",
+    "profession": "warrior"
+  },
+  {
+    "id": 45402,
+    "name": "blazingedge",
+    "profession": "guardian"
+  },
+  {
+    "id": 45425,
+    "name": "rainofswords",
+    "profession": "mesmer"
+  },
+  {
+    "id": 45426,
+    "name": "groundworkgouge",
+    "profession": "ranger"
+  },
+  {
+    "id": 45449,
+    "name": "jaunt",
+    "profession": "mesmer"
+  },
+  {
+    "id": 45460,
+    "name": "mantraoflore",
+    "profession": "guardian"
+  },
+  {
+    "id": 45479,
+    "name": "sharpenspines",
+    "profession": "ranger"
+  },
+  {
+    "id": 45508,
+    "name": "shadowmeld",
+    "profession": "thief"
+  },
+  {
+    "id": 45537,
+    "name": "ordersfromabove",
+    "profession": "revenant"
+  },
+  {
+    "id": 45581,
+    "name": "sunripper",
+    "profession": "engineer"
+  },
+  {
+    "id": 45666,
+    "name": "mirageretreat",
+    "profession": "mesmer"
+  },
+  {
+    "id": 45672,
+    "name": "shadowswap",
+    "profession": "thief"
+  },
+  {
+    "id": 45686,
+    "name": "breakrazorsbastion",
+    "profession": "revenant"
+  },
+  {
+    "id": 45709,
+    "name": "controlledanalysis",
+    "profession": "bundle"
+  },
+  {
+    "id": 45711,
+    "name": "sandshards",
+    "profession": "bundle"
+  },
+  {
+    "id": 45717,
+    "name": "onewolfpack",
+    "profession": "ranger"
+  },
+  {
+    "id": 45732,
+    "name": "particleaccelerator",
+    "profession": "engineer"
+  },
+  {
+    "id": 45742,
+    "name": "glacialdrift",
+    "profession": "elementalist"
+  },
+  {
+    "id": 45743,
+    "name": "charge",
+    "profession": "ranger"
+  },
+  {
+    "id": 45746,
+    "name": "twistoffate",
+    "profession": "elementalist"
+  },
+  {
+    "id": 45756,
+    "name": "brightslash",
+    "profession": "engineer"
+  },
+  {
+    "id": 45773,
+    "name": "soulcleavessummit",
+    "profession": "revenant"
+  },
+  {
+    "id": 45780,
+    "name": "marchofundeath"
+  },
+  {
+    "id": 45783,
+    "name": "photonblitz",
+    "profession": "engineer"
+  },
+  {
+    "id": 45789,
+    "name": "dolyakstance",
+    "profession": "ranger"
+  },
+  {
+    "id": 45797,
+    "name": "unflinchingfortitude",
+    "profession": "ranger"
+  },
+  {
+    "id": 45846,
+    "name": "harrowingwave",
+    "profession": "necromancer"
+  },
+  {
+    "id": 45890,
+    "name": "flashcutter",
+    "profession": "engineer"
+  },
+  {
+    "id": 45962,
+    "name": "intimidatingslam",
+    "profession": "bundle"
+  },
+  {
+    "id": 45970,
+    "name": "moastance",
+    "profession": "ranger"
+  },
+  {
+    "id": 45979,
+    "name": "gleamsaber",
+    "profession": "engineer"
+  },
+  {
+    "id": 45983,
+    "name": "clapotis",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46014,
+    "name": "stonetide",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46018,
+    "name": "mudslide",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46024,
+    "name": "crystallinesunder",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46044,
+    "name": "magehunterstrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 46123,
+    "name": "instinctiveengage",
+    "profession": "ranger"
+  },
+  {
+    "id": 46140,
+    "name": "katabaticwind",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46148,
+    "name": "mantraofflame",
+    "profession": "guardian"
+  },
+  {
+    "id": 46170,
+    "name": "hammerofwisdom",
+    "profession": "guardian"
+  },
+  {
+    "id": 46183,
+    "name": "empoweringroar",
+    "profession": "bundle"
+  },
+  {
+    "id": 46185,
+    "name": "moltenburst",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46233,
+    "name": "auraslicer",
+    "profession": "warrior"
+  },
+  {
+    "id": 46271,
+    "name": "needleexplosion",
+    "profession": "bundle"
+  },
+  {
+    "id": 46295,
+    "name": "galestrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46335,
+    "name": "shadowgust",
+    "profession": "thief"
+  },
+  {
+    "id": 46360,
+    "name": "absolutezero",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46386,
+    "name": "taillash",
+    "profession": "ranger"
+  },
+  {
+    "id": 46409,
+    "name": "legendaryrenegadestance",
+    "profession": "revenant"
+  },
+  {
+    "id": 46432,
+    "name": "brutalcharge",
+    "profession": "ranger"
+  },
+  {
+    "id": 46447,
+    "name": "lavaskin",
+    "profession": "elementalist"
+  },
+  {
+    "id": 46473,
+    "name": "manifestsandshade",
+    "profession": "necromancer"
+  },
+  {
+    "id": 46474,
+    "name": "manifestsandshade",
+    "profession": "necromancer"
+  },
+  {
+    "id": 46487,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 46547,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 46600,
+    "name": "bowoftruth",
+    "profession": "guardian"
+  },
+  {
+    "id": 46627,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 46629,
+    "name": "maul",
+    "profession": "ranger"
+  },
+  {
+    "id": 46732,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 46737,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 46750,
+    "name": "bowoftruth",
+    "profession": "guardian"
+  },
+  {
+    "id": 46843,
+    "name": "callofthedwarf",
+    "profession": "bundle"
+  },
+  {
+    "id": 46847,
+    "name": "callofthecentaur",
+    "profession": "bundle"
+  },
+  {
+    "id": 46849,
+    "name": "calloftherenegade",
+    "profession": "bundle"
+  },
+  {
+    "id": 46854,
+    "name": "calloftheassassin",
+    "profession": "bundle"
+  },
+  {
+    "id": 46856,
+    "name": "callofthedemon",
+    "profession": "bundle"
+  },
+  {
+    "id": 46857,
+    "name": "callofthedragon",
+    "profession": "bundle"
+  },
+  {
+    "id": 46862,
+    "name": "flameshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 46901,
+    "name": "sunderingsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 46916,
+    "name": "shieldbash",
+    "profession": "bundle"
+  },
+  {
+    "id": 46923,
+    "name": "hundredblades",
+    "profession": "bundle"
+  },
+  {
+    "id": 46930,
+    "name": "scytheassault",
+    "profession": "bundle"
+  },
+  {
+    "id": 46934,
+    "name": "dwaynastempest",
+    "profession": "bundle"
+  },
+  {
+    "id": 46941,
+    "name": "smite",
+    "profession": "bundle"
+  },
+  {
+    "id": 46980,
+    "name": "portaltrap",
+    "profession": "bundle"
+  },
+  {
+    "id": 46999,
+    "name": "scytheslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 47005,
+    "name": "kingswrath",
+    "profession": "bundle"
+  },
+  {
+    "id": 47013,
+    "name": "hailstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 47022,
+    "name": "glaciate",
+    "profession": "bundle"
+  },
+  {
+    "id": 47053,
+    "profession": "bundle"
+  },
+  {
+    "id": 47080,
+    "name": "scytheslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 47115,
+    "name": "bayonetthrust",
+    "profession": "bundle"
+  },
+  {
+    "id": 47120,
+    "name": "darkaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 47123,
+    "name": "scytheswing",
+    "profession": "bundle"
+  },
+  {
+    "id": 47164,
+    "name": "soulshackle",
+    "profession": "bundle"
+  },
+  {
+    "id": 47186,
+    "profession": "bundle"
+  },
+  {
+    "id": 47191,
+    "name": "soulscourge",
+    "profession": "bundle"
+  },
+  {
+    "id": 47205,
+    "name": "charge",
+    "profession": "bundle"
+  },
+  {
+    "id": 47224,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 47245,
+    "name": "pounce",
+    "profession": "bundle"
+  },
+  {
+    "id": 47258,
+    "name": "soullesstorrent",
+    "profession": "bundle"
+  },
+  {
+    "id": 47260,
+    "profession": "bundle"
+  },
+  {
+    "id": 47303,
+    "name": "hungeringmiasma",
+    "profession": "bundle"
+  },
+  {
+    "id": 47327,
+    "name": "vortexslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 47331,
+    "name": "fingersofthedead",
+    "profession": "bundle"
+  },
+  {
+    "id": 47356,
+    "name": "corpsedetonation",
+    "profession": "bundle"
+  },
+  {
+    "id": 47360,
+    "name": "breathofdeath",
+    "profession": "bundle"
+  },
+  {
+    "id": 47363,
+    "name": "spinningslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 47365,
+    "name": "shatterearth",
+    "profession": "bundle"
+  },
+  {
+    "id": 47371,
+    "name": "righteousflames",
+    "profession": "bundle"
+  },
+  {
+    "id": 47387,
+    "name": "putridbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 47430,
+    "name": "soulrift",
+    "profession": "bundle"
+  },
+  {
+    "id": 47453,
+    "name": "wallofearth",
+    "profession": "bundle"
+  },
+  {
+    "id": 47468,
+    "name": "dwaynaslightning",
+    "profession": "bundle"
+  },
+  {
+    "id": 47470,
+    "name": "soulsiphon",
+    "profession": "bundle"
+  },
+  {
+    "id": 47518,
+    "name": "piercingshadow",
+    "profession": "bundle"
+  },
+  {
+    "id": 47531,
+    "name": "numbingbreach",
+    "profession": "bundle"
+  },
+  {
+    "id": 47533,
+    "name": "portaltrap",
+    "profession": "bundle"
+  },
+  {
+    "id": 47536,
+    "name": "portaltrap",
+    "profession": "bundle"
+  },
+  {
+    "id": 47561,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 47572,
+    "name": "fingersofthedead",
+    "profession": "bundle"
+  },
+  {
+    "id": 47590,
+    "name": "soulspiral",
+    "profession": "bundle"
+  },
+  {
+    "id": 47607,
+    "name": "slice",
+    "profession": "bundle"
+  },
+  {
+    "id": 47626,
+    "name": "slice",
+    "profession": "bundle"
+  },
+  {
+    "id": 47632,
+    "name": "chargedshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 47662,
+    "name": "mysticwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 47666,
+    "name": "pummel",
+    "profession": "bundle"
+  },
+  {
+    "id": 47671,
+    "name": "electricbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 47679,
+    "name": "icebreaker",
+    "profession": "bundle"
+  },
+  {
+    "id": 47686,
+    "name": "executionersscythe",
+    "profession": "bundle"
+  },
+  {
+    "id": 47694,
+    "name": "triumphofwar",
+    "profession": "bundle"
+  },
+  {
+    "id": 47697,
+    "name": "pummel",
+    "profession": "bundle"
+  },
+  {
+    "id": 47714,
+    "name": "polymorphmoa",
+    "profession": "bundle"
+  },
+  {
+    "id": 47723,
+    "name": "frozendemise",
+    "profession": "bundle"
+  },
+  {
+    "id": 47725,
+    "name": "fist",
+    "profession": "bundle"
+  },
+  {
+    "id": 47726,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 47736,
+    "name": "hailstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 47747,
+    "name": "scytheshock",
+    "profession": "bundle"
+  },
+  {
+    "id": 47756,
+    "name": "wurmspit",
+    "profession": "bundle"
+  },
+  {
+    "id": 47769,
+    "name": "cull",
+    "profession": "bundle"
+  },
+  {
+    "id": 47771,
+    "profession": "bundle"
+  },
+  {
+    "id": 47784,
+    "name": "chargedshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 47815,
+    "name": "executionersscythe",
+    "profession": "bundle"
+  },
+  {
+    "id": 47824,
+    "name": "sonicblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 47830,
+    "name": "razordust",
+    "profession": "bundle"
+  },
+  {
+    "id": 47837,
+    "name": "chillingaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 47842,
+    "name": "slice",
+    "profession": "bundle"
+  },
+  {
+    "id": 47846,
+    "name": "eruption",
+    "profession": "bundle"
+  },
+  {
+    "id": 47847,
+    "name": "wingsofdwayna",
+    "profession": "bundle"
+  },
+  {
+    "id": 47867,
+    "name": "cascadingearth",
+    "profession": "bundle"
+  },
+  {
+    "id": 47907,
+    "name": "twistedlight",
+    "profession": "bundle"
+  },
+  {
+    "id": 47908,
+    "name": "fingersofthedead",
+    "profession": "bundle"
+  },
+  {
+    "id": 47915,
+    "name": "quadslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 47933,
+    "name": "rendearth",
+    "profession": "bundle"
+  },
+  {
+    "id": 47939,
+    "name": "soulsiphon",
+    "profession": "bundle"
+  },
+  {
+    "id": 47941,
+    "name": "balthazarsflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 47988,
+    "name": "avataroflyssa",
+    "profession": "bundle"
+  },
+  {
+    "id": 48007,
+    "name": "imbibe",
+    "profession": "bundle"
+  },
+  {
+    "id": 48009,
+    "name": "corpsedetonation",
+    "profession": "bundle"
+  },
+  {
+    "id": 48010,
+    "name": "unbridledfear",
+    "profession": "bundle"
+  },
+  {
+    "id": 48020,
+    "profession": "bundle"
+  },
+  {
+    "id": 48023,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 48038,
+    "name": "mysticdetonation",
+    "profession": "bundle"
+  },
+  {
+    "id": 48066,
+    "name": "kingswrath",
+    "profession": "bundle"
+  },
+  {
+    "id": 48093,
+    "name": "razordust",
+    "profession": "bundle"
+  },
+  {
+    "id": 48106,
+    "name": "shieldbash",
+    "profession": "bundle"
+  },
+  {
+    "id": 48108,
+    "name": "kingswrath",
+    "profession": "bundle"
+  },
+  {
+    "id": 48116,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 48121,
+    "name": "arcingaffliction",
+    "profession": "bundle"
+  },
+  {
+    "id": 48126,
+    "name": "firebreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 48128,
+    "name": "scytheslam",
+    "profession": "bundle"
+  },
+  {
+    "id": 48138,
+    "profession": "bundle"
+  },
+  {
+    "id": 48147,
+    "name": "earthquake",
+    "profession": "bundle"
+  },
+  {
+    "id": 48150,
+    "name": "deepabyss",
+    "profession": "bundle"
+  },
+  {
+    "id": 48167,
+    "name": "scytheslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 48172,
+    "name": "hatefulephemera",
+    "profession": "bundle"
+  },
+  {
+    "id": 48176,
+    "name": "deathmark",
+    "profession": "bundle"
+  },
+  {
+    "id": 48188,
+    "profession": "bundle"
+  },
+  {
+    "id": 48210,
+    "name": "greaterdeathmark",
+    "profession": "bundle"
+  },
+  {
+    "id": 48218,
+    "name": "bitingaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 48222,
+    "name": "wingsofrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 48235,
+    "profession": "bundle"
+  },
+  {
+    "id": 48238,
+    "name": "deathlyaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 48260,
+    "name": "scytheslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 48269,
+    "name": "ragebomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 48272,
+    "name": "bombshell",
+    "profession": "bundle"
+  },
+  {
+    "id": 48284,
+    "name": "rendearth",
+    "profession": "bundle"
+  },
+  {
+    "id": 48285,
+    "name": "shockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 48289,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 48305,
+    "name": "deathsreprise",
+    "profession": "bundle"
+  },
+  {
+    "id": 48309,
+    "name": "cull",
+    "profession": "bundle"
+  },
+  {
+    "id": 48318,
+    "name": "windsofchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 48327,
+    "name": "corrupttheliving",
+    "profession": "bundle"
+  },
+  {
+    "id": 48339,
+    "name": "righteouslightning",
+    "profession": "bundle"
+  },
+  {
+    "id": 48363,
+    "name": "quadslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 48377,
+    "name": "deepfreeze",
+    "profession": "bundle"
+  },
+  {
+    "id": 48386,
+    "name": "scytheswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 48387,
+    "name": "shoot",
+    "profession": "bundle"
+  },
+  {
+    "id": 48389,
+    "name": "twistedshadow",
+    "profession": "bundle"
+  },
+  {
+    "id": 48398,
+    "name": "cataclysmiccycle",
+    "profession": "bundle"
+  },
+  {
+    "id": 48417,
+    "name": "despairingdarkness",
+    "profession": "bundle"
+  },
+  {
+    "id": 48419,
+    "profession": "bundle"
+  },
+  {
+    "id": 48423,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 48432,
+    "name": "vortexslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 48437,
+    "name": "jaggederuption",
+    "profession": "bundle"
+  },
+  {
+    "id": 48448,
+    "name": "scytheslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 48489,
+    "name": "dwaynaslightning",
+    "profession": "bundle"
+  },
+  {
+    "id": 48500,
+    "name": "deathbloom",
+    "profession": "bundle"
+  },
+  {
+    "id": 48531,
+    "name": "rendingswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 48563,
+    "profession": "bundle"
+  },
+  {
+    "id": 48584,
+    "name": "conjureflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 48601,
+    "name": "bite",
+    "profession": "bundle"
+  },
+  {
+    "id": 48641,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 48642,
+    "name": "slice",
+    "profession": "bundle"
+  },
+  {
+    "id": 48662,
+    "name": "howlingdeath",
+    "profession": "bundle"
+  },
+  {
+    "id": 48664,
+    "name": "scythespin",
+    "profession": "bundle"
+  },
+  {
+    "id": 48666,
+    "name": "scytheslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 48673,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 48682,
+    "name": "chargedshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 48690,
+    "name": "throwboulder",
+    "profession": "bundle"
+  },
+  {
+    "id": 48692,
+    "name": "pathetic",
+    "profession": "bundle"
+  },
+  {
+    "id": 48752,
+    "name": "cull",
+    "profession": "bundle"
+  },
+  {
+    "id": 48758,
+    "name": "cull",
+    "profession": "bundle"
+  },
+  {
+    "id": 48760,
+    "name": "putridbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 48770,
+    "name": "avataroflyssa",
+    "profession": "bundle"
+  },
+  {
+    "id": 48794,
+    "name": "hungeringaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 48841,
+    "name": "wurmspit",
+    "profession": "bundle"
+  },
+  {
+    "id": 48851,
+    "name": "windsofchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 48865,
+    "name": "razordust",
+    "profession": "bundle"
+  },
+  {
+    "id": 48875,
+    "name": "fissure",
+    "profession": "bundle"
+  },
+  {
+    "id": 49045,
+    "name": "cleansingfield",
+    "profession": "engineer"
+  },
+  {
+    "id": 49056,
+    "name": "signetofwater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 49068,
+    "name": "mindwrack",
+    "profession": "mesmer"
+  },
+  {
+    "id": 49082,
+    "name": "vitalburst",
+    "profession": "engineer"
+  },
+  {
+    "id": 49097,
+    "name": "lesserelixirc",
+    "profession": "bundle"
+  },
+  {
+    "id": 49142,
+    "name": "uppercut",
+    "profession": "bundle"
+  },
+  {
+    "id": 49154,
+    "name": "arclightning",
+    "profession": "bundle"
+  },
+  {
+    "id": 49176,
+    "name": "noxiousreek",
+    "profession": "bundle"
+  },
+  {
+    "id": 49237,
+    "name": "uppercut",
+    "profession": "bundle"
+  },
+  {
+    "id": 49245,
+    "name": "brandedbreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 49722,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 49740,
+    "name": "voidtail",
+    "profession": "bundle"
+  },
+  {
+    "id": 49765,
+    "name": "leylinesurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 49786,
+    "name": "uppercut",
+    "profession": "bundle"
+  },
+  {
+    "id": 49794,
+    "name": "executionersscythe",
+    "profession": "bundle"
+  },
+  {
+    "id": 50043,
+    "name": "headkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 50197,
+    "name": "frontalblock",
+    "profession": "bundle"
+  },
+  {
+    "id": 50200,
+    "name": "flyingslam",
+    "profession": "bundle"
+  },
+  {
+    "id": 50212,
+    "name": "ringofcrags",
+    "profession": "bundle"
+  },
+  {
+    "id": 50245,
+    "name": "jabcombo",
+    "profession": "bundle"
+  },
+  {
+    "id": 50255,
+    "name": "furiousretaliation",
+    "profession": "bundle"
+  },
+  {
+    "id": 50373,
+    "name": "agony",
+    "profession": "bundle"
+  },
+  {
+    "id": 50379,
+    "name": "hookedspear",
+    "profession": "thief"
+  },
+  {
+    "id": 50380,
+    "name": "captureline",
+    "profession": "engineer"
+  },
+  {
+    "id": 50383,
+    "name": "inspiringreinforcement",
+    "profession": "revenant"
+  },
+  {
+    "id": 50390,
+    "name": "riftofpain",
+    "profession": "revenant"
+  },
+  {
+    "id": 50392,
+    "name": "judgmentoflight",
+    "profession": "guardian"
+  },
+  {
+    "id": 50395,
+    "name": "mistsfire",
+    "profession": "revenant"
+  },
+  {
+    "id": 50399,
+    "name": "detonatelight",
+    "profession": "guardian"
+  },
+  {
+    "id": 50408,
+    "name": "burstofshadows",
+    "profession": "bundle"
+  },
+  {
+    "id": 50410,
+    "name": "reckoningblast",
+    "profession": "revenant"
+  },
+  {
+    "id": 50414,
+    "name": "veil",
+    "profession": "mesmer"
+  },
+  {
+    "id": 50417,
+    "name": "maliciousdeadlystrike",
+    "profession": "thief"
+  },
+  {
+    "id": 50419,
+    "name": "mirageadvance",
+    "profession": "mesmer"
+  },
+  {
+    "id": 50438,
+    "name": "rocketboots",
+    "profession": "engineer"
+  },
+  {
+    "id": 50440,
+    "name": "nullfield",
+    "profession": "mesmer"
+  },
+  {
+    "id": 50441,
+    "name": "rocketboots",
+    "profession": "engineer"
+  },
+  {
+    "id": 50444,
+    "name": "infusionbomb",
+    "profession": "engineer"
+  },
+  {
+    "id": 50447,
+    "name": "lightningflash",
+    "profession": "elementalist"
+  },
+  {
+    "id": 50449,
+    "name": "maliciousripper",
+    "profession": "thief"
+  },
+  {
+    "id": 50451,
+    "name": "malicioussurpriseshot",
+    "profession": "thief"
+  },
+  {
+    "id": 50456,
+    "name": "portalfire",
+    "profession": "revenant"
+  },
+  {
+    "id": 50466,
+    "name": "malicioussneakattack",
+    "profession": "thief"
+  },
+  {
+    "id": 50472,
+    "name": "slickshoes",
+    "profession": "engineer"
+  },
+  {
+    "id": 50481,
+    "name": "maliciousbackstab",
+    "profession": "thief"
+  },
+  {
+    "id": 50483,
+    "name": "torrentialmists",
+    "profession": "revenant"
+  },
+  {
+    "id": 50484,
+    "name": "malicioustacticalstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 50491,
+    "name": "slickshoes",
+    "profession": "engineer"
+  },
+  {
+    "id": 50520,
+    "name": "drain",
+    "profession": "bundle"
+  },
+  {
+    "id": 50523,
+    "name": "pulverizingleap",
+    "profession": "bundle"
+  },
+  {
+    "id": 50594,
+    "name": "lightningstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 50601,
+    "name": "lightningbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 50630,
+    "name": "shadowsiphon",
+    "profession": "bundle"
+  },
+  {
+    "id": 50637,
+    "name": "webspray",
+    "profession": "bundle"
+  },
+  {
+    "id": 50660,
+    "name": "clingingshadows",
+    "profession": "bundle"
+  },
+  {
+    "id": 50661,
+    "name": "charge",
+    "profession": "bundle"
+  },
+  {
+    "id": 50668,
+    "name": "pulverizingleap",
+    "profession": "bundle"
+  },
+  {
+    "id": 50685,
+    "name": "lifeslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 50752,
+    "name": "slashingwinds",
+    "profession": "bundle"
+  },
+  {
+    "id": 50771,
+    "name": "stormsummoning",
+    "profession": "bundle"
+  },
+  {
+    "id": 50787,
+    "name": "savagestrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 50801,
+    "name": "shadowbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 50817,
+    "name": "corruptedclaws",
+    "profession": "bundle"
+  },
+  {
+    "id": 50823,
+    "name": "agonizingswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 50828,
+    "name": "disintegrationblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 50833,
+    "name": "venomousfangs",
+    "profession": "bundle"
+  },
+  {
+    "id": 50858,
+    "name": "lifereap",
+    "profession": "bundle"
+  },
+  {
+    "id": 50859,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 50861,
+    "name": "shadowbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 50926,
+    "name": "webnet",
+    "profession": "bundle"
+  },
+  {
+    "id": 50928,
+    "name": "venomousfangs",
+    "profession": "bundle"
+  },
+  {
+    "id": 50930,
+    "name": "webpull",
+    "profession": "bundle"
+  },
+  {
+    "id": 50960,
+    "name": "bloodyspin",
+    "profession": "bundle"
+  },
+  {
+    "id": 50970,
+    "name": "bloodyfeed",
+    "profession": "bundle"
+  },
+  {
+    "id": 50978,
+    "name": "spectralflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 50984,
+    "name": "pulverizingleap",
+    "profession": "bundle"
+  },
+  {
+    "id": 50999,
+    "name": "stormblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 51004,
+    "name": "shadeclaw",
+    "profession": "bundle"
+  },
+  {
+    "id": 51039,
+    "name": "disintegrationblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 51074,
+    "name": "shadedart",
+    "profession": "bundle"
+  },
+  {
+    "id": 51086,
+    "name": "stormsummoning",
+    "profession": "bundle"
+  },
+  {
+    "id": 51093,
+    "name": "agonizingrune",
+    "profession": "bundle"
+  },
+  {
+    "id": 51105,
+    "name": "bloodyleap",
+    "profession": "bundle"
+  },
+  {
+    "id": 51120,
+    "name": "agonizingrune",
+    "profession": "bundle"
+  },
+  {
+    "id": 51138,
+    "name": "wakeofdisintegration",
+    "profession": "bundle"
+  },
+  {
+    "id": 51155,
+    "name": "lightningstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 51169,
+    "name": "bloodyslice",
+    "profession": "bundle"
+  },
+  {
+    "id": 51202,
+    "name": "shadowrift",
+    "profession": "bundle"
+  },
+  {
+    "id": 51273,
+    "name": "liferend",
+    "profession": "bundle"
+  },
+  {
+    "id": 51321,
+    "name": "soulleach",
+    "profession": "bundle"
+  },
+  {
+    "id": 51349,
+    "name": "shadowblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 51364,
+    "name": "agonizingswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 51380,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 51385,
+    "name": "pounce",
+    "profession": "bundle"
+  },
+  {
+    "id": 51395,
+    "name": "spiketrap",
+    "profession": "ranger"
+  },
+  {
+    "id": 51635,
+    "profession": "bundle"
+  },
+  {
+    "id": 51638,
+    "profession": "bundle"
+  },
+  {
+    "id": 51639,
+    "profession": "bundle"
+  },
+  {
+    "id": 51641,
+    "profession": "bundle"
+  },
+  {
+    "id": 51645,
+    "name": "seekingjudgment",
+    "profession": "guardian"
+  },
+  {
+    "id": 51646,
+    "name": "transmutefrost",
+    "profession": "elementalist"
+  },
+  {
+    "id": 51647,
+    "name": "devouringdarkness",
+    "profession": "necromancer"
+  },
+  {
+    "id": 51660,
+    "name": "searinglight",
+    "profession": "guardian"
+  },
+  {
+    "id": 51662,
+    "name": "transmutelightning",
+    "profession": "elementalist"
+  },
+  {
+    "id": 51667,
+    "name": "truenature",
+    "profession": "revenant"
+  },
+  {
+    "id": 51675,
+    "name": "truenature",
+    "profession": "revenant"
+  },
+  {
+    "id": 51684,
+    "name": "transmuteearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 51696,
+    "name": "truenature",
+    "profession": "revenant"
+  },
+  {
+    "id": 51698,
+    "name": "elementalblast",
+    "profession": "revenant"
+  },
+  {
+    "id": 51711,
+    "name": "transmutefire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 51713,
+    "name": "truenature",
+    "profession": "revenant"
+  },
+  {
+    "id": 51714,
+    "name": "truenature",
+    "profession": "revenant"
+  },
+  {
+    "id": 51718,
+    "name": "flameslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 51721,
+    "name": "lavarift",
+    "profession": "bundle"
+  },
+  {
+    "id": 51727,
+    "name": "aquaticassassin",
+    "profession": "bundle"
+  },
+  {
+    "id": 51735,
+    "name": "junkfall",
+    "profession": "bundle"
+  },
+  {
+    "id": 51738,
+    "name": "wingbuffet",
+    "profession": "bundle"
+  },
+  {
+    "id": 51759,
+    "name": "waveofforce",
+    "profession": "bundle"
+  },
+  {
+    "id": 51761,
+    "name": "mistmeteorite",
+    "profession": "bundle"
+  },
+  {
+    "id": 51771,
+    "name": "aidofthewaterdjinn",
+    "profession": "bundle"
+  },
+  {
+    "id": 51776,
+    "name": "aquaticslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 51802,
+    "name": "incinerationorb",
+    "profession": "bundle"
+  },
+  {
+    "id": 51823,
+    "name": "teleport",
+    "profession": "bundle"
+  },
+  {
+    "id": 51825,
+    "name": "tidalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 51828,
+    "name": "thornypredicament",
+    "profession": "bundle"
+  },
+  {
+    "id": 51843,
+    "name": "buoyancy",
+    "profession": "bundle"
+  },
+  {
+    "id": 51849,
+    "name": "aidofthewaterdjinn",
+    "profession": "bundle"
+  },
+  {
+    "id": 51879,
+    "name": "bodyofflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 51909,
+    "profession": "bundle"
+  },
+  {
+    "id": 51918,
+    "name": "flamingcascade",
+    "profession": "bundle"
+  },
+  {
+    "id": 51923,
+    "name": "shatteredearth",
+    "profession": "bundle"
+  },
+  {
+    "id": 51937,
+    "name": "scepterbeam",
+    "profession": "bundle"
+  },
+  {
+    "id": 51952,
+    "name": "candyburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 51956,
+    "name": "ripper",
+    "profession": "bundle"
+  },
+  {
+    "id": 51958,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 51961,
+    "name": "meteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 51963,
+    "name": "sunderedplatform",
+    "profession": "bundle"
+  },
+  {
+    "id": 51965,
+    "name": "vaporjet",
+    "profession": "bundle"
+  },
+  {
+    "id": 51969,
+    "name": "fireball",
+    "profession": "bundle"
+  },
+  {
+    "id": 51975,
+    "name": "djinnsgaze",
+    "profession": "bundle"
+  },
+  {
+    "id": 51977,
+    "name": "aquaticbarrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 51979,
+    "name": "dualbite",
+    "profession": "bundle"
+  },
+  {
+    "id": 51989,
+    "name": "dregdetritus",
+    "profession": "bundle"
+  },
+  {
+    "id": 51999,
+    "name": "cycloneburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 52005,
+    "name": "aquaticaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 52013,
+    "name": "brandedvortex",
+    "profession": "bundle"
+  },
+  {
+    "id": 52030,
+    "name": "incinerationorb",
+    "profession": "bundle"
+  },
+  {
+    "id": 52054,
+    "name": "summon",
+    "profession": "bundle"
+  },
+  {
+    "id": 52057,
+    "name": "fireball",
+    "profession": "bundle"
+  },
+  {
+    "id": 52063,
+    "name": "mythwrightdischarge",
+    "profession": "bundle"
+  },
+  {
+    "id": 52082,
+    "profession": "bundle"
+  },
+  {
+    "id": 52086,
+    "name": "junkabsorption",
+    "profession": "bundle"
+  },
+  {
+    "id": 52116,
+    "name": "largosdomain",
+    "profession": "bundle"
+  },
+  {
+    "id": 52120,
+    "name": "junkfall",
+    "profession": "bundle"
+  },
+  {
+    "id": 52123,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52125,
+    "name": "brandstoneimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 52130,
+    "name": "aquaticvortex",
+    "profession": "bundle"
+  },
+  {
+    "id": 52131,
+    "name": "wintersdayaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 52135,
+    "name": "sharksplash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52150,
+    "name": "junktorrent",
+    "profession": "bundle"
+  },
+  {
+    "id": 52159,
+    "name": "fireball",
+    "profession": "bundle"
+  },
+  {
+    "id": 52161,
+    "name": "rupturedground",
+    "profession": "bundle"
+  },
+  {
+    "id": 52167,
+    "name": "plop",
+    "profession": "bundle"
+  },
+  {
+    "id": 52173,
+    "name": "pulverize",
+    "profession": "bundle"
+  },
+  {
+    "id": 52191,
+    "name": "ectoplasmicflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 52200,
+    "name": "teleport",
+    "profession": "bundle"
+  },
+  {
+    "id": 52202,
+    "name": "belch",
+    "profession": "bundle"
+  },
+  {
+    "id": 52221,
+    "name": "claw",
+    "profession": "bundle"
+  },
+  {
+    "id": 52224,
+    "name": "firewave",
+    "profession": "bundle"
+  },
+  {
+    "id": 52242,
+    "name": "shatteringimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 52248,
+    "name": "whiplash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52254,
+    "name": "brandstoneslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52265,
+    "name": "riposte",
+    "profession": "bundle"
+  },
+  {
+    "id": 52281,
+    "name": "swap",
+    "profession": "bundle"
+  },
+  {
+    "id": 52294,
+    "name": "presentsforall",
+    "profession": "bundle"
+  },
+  {
+    "id": 52310,
+    "name": "bighit",
+    "profession": "bundle"
+  },
+  {
+    "id": 52320,
+    "name": "aidofthewaterdjinn",
+    "profession": "bundle"
+  },
+  {
+    "id": 52321,
+    "name": "fracturedbrand",
+    "profession": "bundle"
+  },
+  {
+    "id": 52323,
+    "name": "volcanicgeyser",
+    "profession": "bundle"
+  },
+  {
+    "id": 52330,
+    "name": "seismicstomp",
+    "profession": "bundle"
+  },
+  {
+    "id": 52333,
+    "name": "flameslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52334,
+    "name": "flameslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52361,
+    "name": "sharksplash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52365,
+    "name": "foostivooflail",
+    "profession": "bundle"
+  },
+  {
+    "id": 52370,
+    "name": "conjuredslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52374,
+    "name": "aquaticdomain",
+    "profession": "bundle"
+  },
+  {
+    "id": 52383,
+    "name": "firedance",
+    "profession": "bundle"
+  },
+  {
+    "id": 52389,
+    "name": "blaze",
+    "profession": "bundle"
+  },
+  {
+    "id": 52406,
+    "name": "heavyimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 52415,
+    "name": "icybreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 52416,
+    "name": "noxiousperfume",
+    "profession": "bundle"
+  },
+  {
+    "id": 52422,
+    "name": "shatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 52428,
+    "name": "heavylanding",
+    "profession": "bundle"
+  },
+  {
+    "id": 52444,
+    "name": "spiritscream",
+    "profession": "bundle"
+  },
+  {
+    "id": 52446,
+    "name": "fallingdebris",
+    "profession": "bundle"
+  },
+  {
+    "id": 52452,
+    "name": "firetrail",
+    "profession": "bundle"
+  },
+  {
+    "id": 52461,
+    "name": "seaofflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 52462,
+    "name": "bighit",
+    "profession": "bundle"
+  },
+  {
+    "id": 52471,
+    "name": "swap",
+    "profession": "bundle"
+  },
+  {
+    "id": 52477,
+    "name": "aquaticdetainment",
+    "profession": "bundle"
+  },
+  {
+    "id": 52479,
+    "name": "pulverize",
+    "profession": "bundle"
+  },
+  {
+    "id": 52489,
+    "name": "aquaticassassin",
+    "profession": "bundle"
+  },
+  {
+    "id": 52493,
+    "name": "whirlingslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52507,
+    "name": "sharksplash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52512,
+    "name": "incinerationorb",
+    "profession": "bundle"
+  },
+  {
+    "id": 52520,
+    "name": "elementalbreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 52522,
+    "name": "burningcrucible",
+    "profession": "bundle"
+  },
+  {
+    "id": 52525,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 52528,
+    "name": "flameslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52583,
+    "name": "throwminion",
+    "profession": "bundle"
+  },
+  {
+    "id": 52587,
+    "name": "inferno",
+    "profession": "bundle"
+  },
+  {
+    "id": 52612,
+    "name": "fireball",
+    "profession": "bundle"
+  },
+  {
+    "id": 52613,
+    "name": "seismicstomp",
+    "profession": "bundle"
+  },
+  {
+    "id": 52614,
+    "name": "firedance",
+    "profession": "bundle"
+  },
+  {
+    "id": 52636,
+    "profession": "bundle"
+  },
+  {
+    "id": 52637,
+    "profession": "bundle"
+  },
+  {
+    "id": 52646,
+    "name": "aquaticslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52654,
+    "name": "crystallineimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 52656,
+    "name": "tremor",
+    "profession": "bundle"
+  },
+  {
+    "id": 52665,
+    "name": "brandstoneslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 52669,
+    "name": "bouquettoss",
+    "profession": "bundle"
+  },
+  {
+    "id": 52672,
+    "profession": "bundle"
+  },
+  {
+    "id": 52673,
+    "name": "incinerationorb",
+    "profession": "bundle"
+  },
+  {
+    "id": 52692,
+    "name": "wingbuffet",
+    "profession": "bundle"
+  },
+  {
+    "id": 52695,
+    "name": "aidofthewaterdjinn",
+    "profession": "bundle"
+  },
+  {
+    "id": 52700,
+    "name": "plop",
+    "profession": "bundle"
+  },
+  {
+    "id": 52705,
+    "name": "tailswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 52716,
+    "name": "vaporousstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 52726,
+    "name": "firebreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 52734,
+    "name": "wingbuffet",
+    "profession": "bundle"
+  },
+  {
+    "id": 52748,
+    "name": "firebreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 52775,
+    "name": "seaofflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 52779,
+    "name": "aquaticaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 52791,
+    "name": "meteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 52793,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 52811,
+    "name": "aidofthewaterdjinn",
+    "profession": "bundle"
+  },
+  {
+    "id": 52812,
+    "name": "tidalpool",
+    "profession": "bundle"
+  },
+  {
+    "id": 52814,
+    "name": "flamewave",
+    "profession": "bundle"
+  },
+  {
+    "id": 52820,
+    "name": "firewave",
+    "profession": "bundle"
+  },
+  {
+    "id": 52843,
+    "name": "thunderclap",
+    "profession": "bundle"
+  },
+  {
+    "id": 52862,
+    "name": "teleport",
+    "profession": "bundle"
+  },
+  {
+    "id": 52864,
+    "name": "firedance",
+    "profession": "bundle"
+  },
+  {
+    "id": 52876,
+    "name": "vaporrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 52878,
+    "name": "junkfall",
+    "profession": "bundle"
+  },
+  {
+    "id": 52884,
+    "profession": "bundle"
+  },
+  {
+    "id": 52892,
+    "name": "pull",
+    "profession": "bundle"
+  },
+  {
+    "id": 52906,
+    "name": "incinerationorb",
+    "profession": "bundle"
+  },
+  {
+    "id": 52931,
+    "name": "aquaticdetainment",
+    "profession": "bundle"
+  },
+  {
+    "id": 52933,
+    "name": "swordspin",
+    "profession": "bundle"
+  },
+  {
+    "id": 52934,
+    "name": "geyserslam",
+    "profession": "bundle"
+  },
+  {
+    "id": 52941,
+    "name": "fierymeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 52956,
+    "name": "dregflop",
+    "profession": "bundle"
+  },
+  {
+    "id": 52969,
+    "name": "firestreak",
+    "profession": "bundle"
+  },
+  {
+    "id": 53011,
+    "name": "claw",
+    "profession": "bundle"
+  },
+  {
+    "id": 53013,
+    "name": "fireball",
+    "profession": "bundle"
+  },
+  {
+    "id": 53018,
+    "name": "seaswell",
+    "profession": "bundle"
+  },
+  {
+    "id": 53038,
+    "name": "sear",
+    "profession": "bundle"
+  },
+  {
+    "id": 53047,
+    "name": "fireball",
+    "profession": "bundle"
+  },
+  {
+    "id": 53051,
+    "name": "teleport",
+    "profession": "bundle"
+  },
+  {
+    "id": 53064,
+    "name": "meteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 53065,
+    "name": "risingheat",
+    "profession": "bundle"
+  },
+  {
+    "id": 53072,
+    "name": "detonate",
+    "profession": "bundle"
+  },
+  {
+    "id": 53089,
+    "name": "aidofthewaterdjinn",
+    "profession": "bundle"
+  },
+  {
+    "id": 53093,
+    "name": "incinerationorb",
+    "profession": "bundle"
+  },
+  {
+    "id": 53100,
+    "name": "vaporousstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 53101,
+    "profession": "bundle"
+  },
+  {
+    "id": 53102,
+    "name": "firedance",
+    "profession": "bundle"
+  },
+  {
+    "id": 53105,
+    "name": "tailswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 53130,
+    "name": "geyser",
+    "profession": "bundle"
+  },
+  {
+    "id": 53134,
+    "name": "frigidaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 53146,
+    "name": "fireball",
+    "profession": "bundle"
+  },
+  {
+    "id": 53153,
+    "name": "firedance",
+    "profession": "bundle"
+  },
+  {
+    "id": 53446,
+    "name": "frostpatch",
+    "profession": "bundle"
+  },
+  {
+    "id": 53452,
+    "name": "frosttomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 53463,
+    "name": "icecone",
+    "profession": "bundle"
+  },
+  {
+    "id": 53464,
+    "name": "blizzard",
+    "profession": "bundle"
+  },
+  {
+    "id": 53475,
+    "name": "juttingicespikes",
+    "profession": "bundle"
+  },
+  {
+    "id": 53478,
+    "name": "coldheartedaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 53482,
+    "name": "glacialblow",
+    "profession": "guardian"
+  },
+  {
+    "id": 53496,
+    "name": "numbingbreach",
+    "profession": "bundle"
+  },
+  {
+    "id": 53511,
+    "name": "giantsnowball",
+    "profession": "bundle"
+  },
+  {
+    "id": 53514,
+    "name": "giantsnowball",
+    "profession": "bundle"
+  },
+  {
+    "id": 53520,
+    "name": "snowball",
+    "profession": "bundle"
+  },
+  {
+    "id": 53531,
+    "name": "juttingicespikes",
+    "profession": "bundle"
+  },
+  {
+    "id": 53537,
+    "name": "slam",
+    "profession": "bundle"
+  },
+  {
+    "id": 53540,
+    "name": "frostpatch",
+    "profession": "bundle"
+  },
+  {
+    "id": 53544,
+    "name": "juttingicespikes",
+    "profession": "bundle"
+  },
+  {
+    "id": 53548,
+    "name": "elixire",
+    "profession": "bundle"
+  },
+  {
+    "id": 53549,
+    "name": "aurorabeam",
+    "profession": "bundle"
+  },
+  {
+    "id": 53567,
+    "name": "fetidfog",
+    "profession": "bundle"
+  },
+  {
+    "id": 53585,
+    "name": "mineexplosion",
+    "profession": "bundle"
+  },
+  {
+    "id": 53586,
+    "name": "explosivelongshot",
+    "profession": "bundle"
+  },
+  {
+    "id": 53591,
+    "name": "deathlychill",
+    "profession": "bundle"
+  },
+  {
+    "id": 53598,
+    "name": "scattergrenade",
+    "profession": "bundle"
+  },
+  {
+    "id": 53601,
+    "name": "brandgust",
+    "profession": "bundle"
+  },
+  {
+    "id": 53649,
+    "name": "staticgrenade",
+    "profession": "bundle"
+  },
+  {
+    "id": 53663,
+    "name": "frostshard",
+    "profession": "bundle"
+  },
+  {
+    "id": 53675,
+    "name": "brandgust",
+    "profession": "bundle"
+  },
+  {
+    "id": 53678,
+    "name": "brandstoneimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 53707,
+    "name": "comet",
+    "profession": "bundle"
+  },
+  {
+    "id": 53727,
+    "name": "cindercyclone",
+    "profession": "bundle"
+  },
+  {
+    "id": 53749,
+    "name": "throwaxe",
+    "profession": "bundle"
+  },
+  {
+    "id": 53758,
+    "name": "phantomblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 53762,
+    "name": "brandsquall",
+    "profession": "bundle"
+  },
+  {
+    "id": 53784,
+    "name": "piranhasofthedeep",
+    "profession": "bundle"
+  },
+  {
+    "id": 53797,
+    "name": "brandgust",
+    "profession": "bundle"
+  },
+  {
+    "id": 53828,
+    "name": "deathlychill",
+    "profession": "bundle"
+  },
+  {
+    "id": 53847,
+    "name": "smash",
+    "profession": "bundle"
+  },
+  {
+    "id": 53867,
+    "name": "roaringbrand",
+    "profession": "bundle"
+  },
+  {
+    "id": 53926,
+    "name": "lifesiphon",
+    "profession": "bundle"
+  },
+  {
+    "id": 53934,
+    "name": "cadaversconfetti",
+    "profession": "bundle"
+  },
+  {
+    "id": 53968,
+    "name": "sharedshock",
+    "profession": "bundle"
+  },
+  {
+    "id": 53983,
+    "name": "cripplingdagger",
+    "profession": "bundle"
+  },
+  {
+    "id": 54011,
+    "name": "doublestrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 54029,
+    "name": "brandsquall",
+    "profession": "bundle"
+  },
+  {
+    "id": 54050,
+    "name": "grimlagoon",
+    "profession": "bundle"
+  },
+  {
+    "id": 54053,
+    "name": "webleedfire",
+    "profession": "bundle"
+  },
+  {
+    "id": 54070,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 54083,
+    "name": "piercingpeck",
+    "profession": "bundle"
+  },
+  {
+    "id": 54109,
+    "name": "piranhasofthedeep",
+    "profession": "bundle"
+  },
+  {
+    "id": 54120,
+    "name": "heartseeker",
+    "profession": "bundle"
+  },
+  {
+    "id": 54123,
+    "name": "brandstoneslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 54125,
+    "name": "piranhasofthedeep",
+    "profession": "bundle"
+  },
+  {
+    "id": 54133,
+    "name": "bloodybludgeon",
+    "profession": "bundle"
+  },
+  {
+    "id": 54139,
+    "profession": "bundle"
+  },
+  {
+    "id": 54164,
+    "name": "phantomdamnation",
+    "profession": "bundle"
+  },
+  {
+    "id": 54201,
+    "name": "charge",
+    "profession": "bundle"
+  },
+  {
+    "id": 54243,
+    "name": "stormfall",
+    "profession": "bundle"
+  },
+  {
+    "id": 54261,
+    "name": "throwbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 54284,
+    "name": "buccaneersboot",
+    "profession": "bundle"
+  },
+  {
+    "id": 54293,
+    "name": "lotusstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 54295,
+    "name": "cindercyclone",
+    "profession": "bundle"
+  },
+  {
+    "id": 54300,
+    "name": "piranhasofthedeep",
+    "profession": "bundle"
+  },
+  {
+    "id": 54324,
+    "name": "freezegrenade",
+    "profession": "bundle"
+  },
+  {
+    "id": 54348,
+    "name": "webleedfire",
+    "profession": "bundle"
+  },
+  {
+    "id": 54394,
+    "name": "cindercyclone",
+    "profession": "bundle"
+  },
+  {
+    "id": 54410,
+    "name": "tailswipe",
+    "profession": "bundle"
+  },
+  {
+    "id": 54413,
+    "name": "disruptingdagger",
+    "profession": "bundle"
+  },
+  {
+    "id": 54428,
+    "name": "chop",
+    "profession": "bundle"
+  },
+  {
+    "id": 54445,
+    "name": "cutlasscarve",
+    "profession": "bundle"
+  },
+  {
+    "id": 54463,
+    "name": "scurvyprick",
+    "profession": "bundle"
+  },
+  {
+    "id": 54496,
+    "profession": "bundle"
+  },
+  {
+    "id": 54532,
+    "name": "greatbludgeoning",
+    "profession": "bundle"
+  },
+  {
+    "id": 54544,
+    "name": "steadfaststrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 54581,
+    "name": "waterblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 54585,
+    "name": "brandgust",
+    "profession": "bundle"
+  },
+  {
+    "id": 54619,
+    "name": "wraithslightning",
+    "profession": "bundle"
+  },
+  {
+    "id": 54620,
+    "name": "energywave",
+    "profession": "bundle"
+  },
+  {
+    "id": 54626,
+    "name": "flameseeker",
+    "profession": "bundle"
+  },
+  {
+    "id": 54688,
+    "name": "throwanchor",
+    "profession": "bundle"
+  },
+  {
+    "id": 54699,
+    "name": "deathlychill",
+    "profession": "bundle"
+  },
+  {
+    "id": 54700,
+    "name": "wildstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 54744,
+    "name": "tailslam",
+    "profession": "bundle"
+  },
+  {
+    "id": 54748,
+    "name": "hack",
+    "profession": "bundle"
+  },
+  {
+    "id": 54749,
+    "name": "teethfromthedeep",
+    "profession": "bundle"
+  },
+  {
+    "id": 54804,
+    "name": "brandstoneslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 54806,
+    "name": "macesmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 54823,
+    "name": "crushingblow",
+    "profession": "bundle"
+  },
+  {
+    "id": 54849,
+    "name": "frostblades",
+    "profession": "bundle"
+  },
+  {
+    "id": 54870,
+    "name": "sandstormshroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 55019,
+    "name": "swordofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 55024,
+    "name": "glyphofthestars",
+    "profession": "ranger"
+  },
+  {
+    "id": 55027,
+    "name": "swordofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 55029,
+    "name": "ancientecho",
+    "profession": "revenant"
+  },
+  {
+    "id": 55031,
+    "name": "swipe",
+    "profession": "thief"
+  },
+  {
+    "id": 55035,
+    "name": "shieldoftheavenger",
+    "profession": "guardian"
+  },
+  {
+    "id": 55037,
+    "name": "shieldoftheavenger",
+    "profession": "guardian"
+  },
+  {
+    "id": 55038,
+    "name": "soulgrasp",
+    "profession": "necromancer"
+  },
+  {
+    "id": 55040,
+    "name": "hammerofwisdom",
+    "profession": "guardian"
+  },
+  {
+    "id": 55046,
+    "name": "glyphofthestars",
+    "profession": "ranger"
+  },
+  {
+    "id": 55050,
+    "name": "soulgrasp",
+    "profession": "necromancer"
+  },
+  {
+    "id": 55053,
+    "name": "hammerofwisdom",
+    "profession": "guardian"
+  },
+  {
+    "id": 55131,
+    "name": "wispofwill",
+    "profession": "bundle"
+  },
+  {
+    "id": 55244,
+    "name": "unearthlyfissure",
+    "profession": "bundle"
+  },
+  {
+    "id": 55258,
+    "name": "hungeringmiasma",
+    "profession": "bundle"
+  },
+  {
+    "id": 55316,
+    "name": "barrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 55342,
+    "name": "ambush",
+    "profession": "bundle"
+  },
+  {
+    "id": 55406,
+    "name": "icebomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 55549,
+    "name": "crushingblow",
+    "profession": "bundle"
+  },
+  {
+    "id": 55596,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 55845,
+    "name": "unearthlyfissure",
+    "profession": "bundle"
+  },
+  {
+    "id": 55907,
+    "name": "wispofwill",
+    "profession": "bundle"
+  },
+  {
+    "id": 55941,
+    "name": "markofanguish",
+    "profession": "bundle"
+  },
+  {
+    "id": 56012,
+    "profession": "bundle"
+  },
+  {
+    "id": 56017,
+    "name": "forceofhavoc",
+    "profession": "bundle"
+  },
+  {
+    "id": 56020,
+    "name": "energizedaffliction",
+    "profession": "bundle"
+  },
+  {
+    "id": 56035,
+    "name": "quantumquake",
+    "profession": "bundle"
+  },
+  {
+    "id": 56038,
+    "name": "unbearablepower",
+    "profession": "bundle"
+  },
+  {
+    "id": 56040,
+    "name": "blindingradiance",
+    "profession": "bundle"
+  },
+  {
+    "id": 56042,
+    "name": "sandgeyser",
+    "profession": "bundle"
+  },
+  {
+    "id": 56047,
+    "profession": "bundle"
+  },
+  {
+    "id": 56049,
+    "name": "terraform",
+    "profession": "bundle"
+  },
+  {
+    "id": 56055,
+    "name": "dynamicdeterrent",
+    "profession": "bundle"
+  },
+  {
+    "id": 56056,
+    "name": "brandstoneslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 56064,
+    "profession": "bundle"
+  },
+  {
+    "id": 56068,
+    "name": "chaoticsurcharge",
+    "profession": "bundle"
+  },
+  {
+    "id": 56070,
+    "profession": "bundle"
+  },
+  {
+    "id": 56072,
+    "profession": "bundle"
+  },
+  {
+    "id": 56077,
+    "profession": "bundle"
+  },
+  {
+    "id": 56078,
+    "name": "etherstrikes",
+    "profession": "bundle"
+  },
+  {
+    "id": 56083,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56092,
+    "profession": "bundle"
+  },
+  {
+    "id": 56093,
+    "name": "exponentialrepercussion",
+    "profession": "bundle"
+  },
+  {
+    "id": 56094,
+    "name": "wallopingwind",
+    "profession": "bundle"
+  },
+  {
+    "id": 56098,
+    "name": "ruinousnova",
+    "profession": "bundle"
+  },
+  {
+    "id": 56105,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56114,
+    "name": "diamondpalisade",
+    "profession": "bundle"
+  },
+  {
+    "id": 56128,
+    "profession": "bundle"
+  },
+  {
+    "id": 56134,
+    "name": "forceofretaliation",
+    "profession": "bundle"
+  },
+  {
+    "id": 56141,
+    "name": "stalagmites",
+    "profession": "bundle"
+  },
+  {
+    "id": 56143,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56145,
+    "name": "chaoscalled",
+    "profession": "bundle"
+  },
+  {
+    "id": 56148,
+    "profession": "bundle"
+  },
+  {
+    "id": 56162,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56173,
+    "name": "brandstoneimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 56179,
+    "name": "boulderbarrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 56180,
+    "name": "residualimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 56187,
+    "profession": "bundle"
+  },
+  {
+    "id": 56194,
+    "profession": "bundle"
+  },
+  {
+    "id": 56196,
+    "name": "dynamicdeterrent",
+    "profession": "bundle"
+  },
+  {
+    "id": 56199,
+    "name": "unbridledchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 56202,
+    "name": "diredrafts",
+    "profession": "bundle"
+  },
+  {
+    "id": 56206,
+    "name": "tremorwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 56218,
+    "name": "chaoticoverflow",
+    "profession": "bundle"
+  },
+  {
+    "id": 56222,
+    "profession": "bundle"
+  },
+  {
+    "id": 56232,
+    "profession": "bundle"
+  },
+  {
+    "id": 56237,
+    "name": "cleansedconductor",
+    "profession": "bundle"
+  },
+  {
+    "id": 56242,
+    "profession": "bundle"
+  },
+  {
+    "id": 56246,
+    "profession": "bundle"
+  },
+  {
+    "id": 56254,
+    "name": "exponentialrepercussion",
+    "profession": "bundle"
+  },
+  {
+    "id": 56273,
+    "name": "tempestsspike",
+    "profession": "bundle"
+  },
+  {
+    "id": 56277,
+    "profession": "bundle"
+  },
+  {
+    "id": 56288,
+    "name": "tectonicupheaval",
+    "profession": "bundle"
+  },
+  {
+    "id": 56303,
+    "profession": "bundle"
+  },
+  {
+    "id": 56307,
+    "name": "stormsedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 56316,
+    "name": "eclipsedbacklash",
+    "profession": "bundle"
+  },
+  {
+    "id": 56332,
+    "name": "causticchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 56338,
+    "profession": "bundle"
+  },
+  {
+    "id": 56340,
+    "name": "venomousvoltage",
+    "profession": "bundle"
+  },
+  {
+    "id": 56341,
+    "profession": "bundle"
+  },
+  {
+    "id": 56349,
+    "profession": "bundle"
+  },
+  {
+    "id": 56351,
+    "name": "seismicsuffering",
+    "profession": "bundle"
+  },
+  {
+    "id": 56354,
+    "name": "stoneclaw",
+    "profession": "bundle"
+  },
+  {
+    "id": 56359,
+    "profession": "bundle"
+  },
+  {
+    "id": 56372,
+    "name": "furyofthestorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 56378,
+    "name": "residualimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 56381,
+    "name": "quantumquake",
+    "profession": "bundle"
+  },
+  {
+    "id": 56387,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56390,
+    "name": "perilouspulse",
+    "profession": "bundle"
+  },
+  {
+    "id": 56391,
+    "name": "electricalrepulsion",
+    "profession": "bundle"
+  },
+  {
+    "id": 56412,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56414,
+    "name": "quantumquake",
+    "profession": "bundle"
+  },
+  {
+    "id": 56420,
+    "profession": "bundle"
+  },
+  {
+    "id": 56431,
+    "name": "boltbreak",
+    "profession": "bundle"
+  },
+  {
+    "id": 56435,
+    "name": "volatilefusion",
+    "profession": "bundle"
+  },
+  {
+    "id": 56441,
+    "name": "forceofhavoc",
+    "profession": "bundle"
+  },
+  {
+    "id": 56444,
+    "profession": "bundle"
+  },
+  {
+    "id": 56451,
+    "name": "electrospark",
+    "profession": "bundle"
+  },
+  {
+    "id": 56455,
+    "name": "stonefist",
+    "profession": "bundle"
+  },
+  {
+    "id": 56467,
+    "name": "unbridledchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 56474,
+    "name": "electrorepulsion",
+    "profession": "bundle"
+  },
+  {
+    "id": 56487,
+    "name": "brandstoneslash",
+    "profession": "bundle"
+  },
+  {
+    "id": 56492,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56496,
+    "name": "stonefist",
+    "profession": "bundle"
+  },
+  {
+    "id": 56501,
+    "name": "stonevolley",
+    "profession": "bundle"
+  },
+  {
+    "id": 56502,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56513,
+    "name": "shockingbarrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 56516,
+    "name": "diamondpalisade",
+    "profession": "bundle"
+  },
+  {
+    "id": 56521,
+    "name": "stonefist",
+    "profession": "bundle"
+  },
+  {
+    "id": 56523,
+    "name": "boltbreak",
+    "profession": "bundle"
+  },
+  {
+    "id": 56527,
+    "name": "rainofchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 56528,
+    "profession": "bundle"
+  },
+  {
+    "id": 56529,
+    "profession": "bundle"
+  },
+  {
+    "id": 56537,
+    "name": "brandstormlightning",
+    "profession": "bundle"
+  },
+  {
+    "id": 56541,
+    "name": "pylondebrisfield",
+    "profession": "bundle"
+  },
+  {
+    "id": 56543,
+    "name": "causticchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 56551,
+    "name": "residualimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 56552,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56555,
+    "name": "recharging",
+    "profession": "bundle"
+  },
+  {
+    "id": 56558,
+    "name": "tectonicupheaval",
+    "profession": "bundle"
+  },
+  {
+    "id": 56569,
+    "profession": "bundle"
+  },
+  {
+    "id": 56579,
+    "profession": "bundle"
+  },
+  {
+    "id": 56580,
+    "name": "boulderbarrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 56586,
+    "name": "erodingcurse",
+    "profession": "bundle"
+  },
+  {
+    "id": 56588,
+    "profession": "bundle"
+  },
+  {
+    "id": 56590,
+    "name": "energyeclipse",
+    "profession": "bundle"
+  },
+  {
+    "id": 56598,
+    "name": "showerofchaos",
+    "profession": "bundle"
+  },
+  {
+    "id": 56599,
+    "name": "sandcall",
+    "profession": "bundle"
+  },
+  {
+    "id": 56611,
+    "profession": "bundle"
+  },
+  {
+    "id": 56614,
+    "name": "residualimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 56617,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56620,
+    "name": "stormsedge",
+    "profession": "bundle"
+  },
+  {
+    "id": 56629,
+    "name": "chainlightning",
+    "profession": "bundle"
+  },
+  {
+    "id": 56638,
+    "name": "stoneclaw",
+    "profession": "bundle"
+  },
+  {
+    "id": 56642,
+    "name": "boltbreak",
+    "profession": "bundle"
+  },
+  {
+    "id": 56643,
+    "name": "unbridledtempest",
+    "profession": "bundle"
+  },
+  {
+    "id": 56648,
+    "name": "boulderbarrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 56649,
+    "name": "stalagmites",
+    "profession": "bundle"
+  },
+  {
+    "id": 56652,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 56653,
+    "profession": "bundle"
+  },
+  {
+    "id": 56655,
+    "name": "poisonedpower",
+    "profession": "bundle"
+  },
+  {
+    "id": 56656,
+    "name": "brandstormlightning",
+    "profession": "bundle"
+  },
+  {
+    "id": 56713,
+    "name": "bonusinspiration",
+    "profession": "bundle"
+  },
+  {
+    "id": 56723,
+    "name": "holographicstrain",
+    "profession": "bundle"
+  },
+  {
+    "id": 56833,
+    "name": "energizedhologram",
+    "profession": "bundle"
+  },
+  {
+    "id": 56873,
+    "name": "timesink",
+    "profession": "mesmer"
+  },
+  {
+    "id": 56880,
+    "name": "pitfall",
+    "profession": "thief"
+  },
+  {
+    "id": 56883,
+    "name": "sunspot",
+    "profession": "bundle"
+  },
+  {
+    "id": 56898,
+    "name": "thousandneedles",
+    "profession": "thief"
+  },
+  {
+    "id": 56916,
+    "name": "darkpursuit",
+    "profession": "necromancer"
+  },
+  {
+    "id": 56920,
+    "name": "functiongyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 56921,
+    "name": "functiongyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 56925,
+    "name": "splitsecond",
+    "profession": "mesmer"
+  },
+  {
+    "id": 56928,
+    "name": "rewinder",
+    "profession": "mesmer"
+  },
+  {
+    "id": 56930,
+    "name": "splitsecond",
+    "profession": "mesmer"
+  },
+  {
+    "id": 56971,
+    "name": "waterbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 56994,
+    "name": "gnawed",
+    "profession": "bundle"
+  },
+  {
+    "id": 57011,
+    "name": "electrifiedshield",
+    "profession": "bundle"
+  },
+  {
+    "id": 57012,
+    "name": "eruption",
+    "profession": "bundle"
+  },
+  {
+    "id": 57014,
+    "name": "stab",
+    "profession": "bundle"
+  },
+  {
+    "id": 57025,
+    "name": "gnawed",
+    "profession": "bundle"
+  },
+  {
+    "id": 57593,
+    "name": "frostbiteaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 57690,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 57951,
+    "name": "charrvolley",
+    "profession": "bundle"
+  },
+  {
+    "id": 58000,
+    "name": "globollamarble",
+    "profession": "bundle"
+  },
+  {
+    "id": 58073,
+    "name": "",
+    "profession": "bundle"
+  },
+  {
+    "id": 58076,
+    "name": "charrvolley",
+    "profession": "bundle"
+  },
+  {
+    "id": 58090,
+    "name": "medblaster",
+    "profession": "engineer"
+  },
+  {
+    "id": 58104,
+    "name": "infusionbomb",
+    "profession": "engineer"
+  },
+  {
+    "id": 58132,
+    "name": "hammerspin",
+    "profession": "bundle"
+  },
+  {
+    "id": 58139,
+    "name": "unrelentingpain",
+    "profession": "bundle"
+  },
+  {
+    "id": 58160,
+    "name": "aberrantwill",
+    "profession": "bundle"
+  },
+  {
+    "id": 58174,
+    "name": "vengefulaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 58179,
+    "name": "barrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 58184,
+    "name": "iceshockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 58199,
+    "name": "torrentofice",
+    "profession": "bundle"
+  },
+  {
+    "id": 58219,
+    "name": "frostbiteaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 58230,
+    "name": "iceshockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 58262,
+    "name": "ghostlygrasp",
+    "profession": "bundle"
+  },
+  {
+    "id": 58276,
+    "name": "snowblind",
+    "profession": "bundle"
+  },
+  {
+    "id": 58300,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 58301,
+    "name": "barrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 58310,
+    "name": "aberrantwill",
+    "profession": "bundle"
+  },
+  {
+    "id": 58392,
+    "name": "aberrantwill",
+    "profession": "bundle"
+  },
+  {
+    "id": 58429,
+    "name": "slice",
+    "profession": "bundle"
+  },
+  {
+    "id": 58450,
+    "name": "jab",
+    "profession": "bundle"
+  },
+  {
+    "id": 58458,
+    "name": "escape",
+    "profession": "bundle"
+  },
+  {
+    "id": 58489,
+    "name": "daggerstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 58497,
+    "name": "hammerlunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 58501,
+    "name": "iceflail",
+    "profession": "bundle"
+  },
+  {
+    "id": 58518,
+    "name": "seismiccrush",
+    "profession": "bundle"
+  },
+  {
+    "id": 58520,
+    "name": "frozenmissile",
+    "profession": "bundle"
+  },
+  {
+    "id": 58546,
+    "name": "deathwind",
+    "profession": "bundle"
+  },
+  {
+    "id": 58605,
+    "name": "lunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 58606,
+    "name": "aberrantwill",
+    "profession": "bundle"
+  },
+  {
+    "id": 58638,
+    "name": "ghostlyarrow",
+    "profession": "bundle"
+  },
+  {
+    "id": 58645,
+    "name": "aberrantwill",
+    "profession": "bundle"
+  },
+  {
+    "id": 58647,
+    "name": "iceflail",
+    "profession": "bundle"
+  },
+  {
+    "id": 58664,
+    "name": "ambush",
+    "profession": "bundle"
+  },
+  {
+    "id": 58669,
+    "name": "barrage",
+    "profession": "bundle"
+  },
+  {
+    "id": 58694,
+    "name": "frostbiteaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 58736,
+    "name": "unnaturalaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 58740,
+    "name": "iceshockwave",
+    "profession": "bundle"
+  },
+  {
+    "id": 58746,
+    "name": "cyclone",
+    "profession": "bundle"
+  },
+  {
+    "id": 58750,
+    "name": "ambush",
+    "profession": "bundle"
+  },
+  {
+    "id": 58809,
+    "name": "douseindarkness",
+    "profession": "bundle"
+  },
+  {
+    "id": 58811,
+    "name": "icequake",
+    "profession": "bundle"
+  },
+  {
+    "id": 58828,
+    "name": "daggerstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 58833,
+    "name": "aberrantwill",
+    "profession": "bundle"
+  },
+  {
+    "id": 58854,
+    "name": "daggerstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 58861,
+    "name": "tormentingaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 58886,
+    "name": "snowball",
+    "profession": "bundle"
+  },
+  {
+    "id": 58954,
+    "name": "aurorabeam",
+    "profession": "bundle"
+  },
+  {
+    "id": 59029,
+    "name": "mistbomb",
+    "profession": "bundle"
+  },
+  {
+    "id": 59059,
+    "name": "icedrop",
+    "profession": "bundle"
+  },
+  {
+    "id": 59078,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59082,
+    "name": "icetempest",
+    "profession": "bundle"
+  },
+  {
+    "id": 59089,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 59096,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59101,
+    "name": "noxiouswind",
+    "profession": "bundle"
+  },
+  {
+    "id": 59102,
+    "name": "spreadingice",
+    "profession": "bundle"
+  },
+  {
+    "id": 59147,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59149,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59155,
+    "name": "icetempest",
+    "profession": "bundle"
+  },
+  {
+    "id": 59158,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59159,
+    "name": "chainsoffrost",
+    "profession": "bundle"
+  },
+  {
+    "id": 59174,
+    "name": "flurry",
+    "profession": "bundle"
+  },
+  {
+    "id": 59192,
+    "name": "fallingice",
+    "profession": "bundle"
+  },
+  {
+    "id": 59202,
+    "name": "frostbiteaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 59213,
+    "name": "frigidvortex",
+    "profession": "bundle"
+  },
+  {
+    "id": 59220,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 59236,
+    "name": "smash",
+    "profession": "bundle"
+  },
+  {
+    "id": 59255,
+    "name": "icetempest",
+    "profession": "bundle"
+  },
+  {
+    "id": 59288,
+    "name": "fallingice",
+    "profession": "bundle"
+  },
+  {
+    "id": 59308,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59321,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 59331,
+    "name": "corruptedground",
+    "profession": "bundle"
+  },
+  {
+    "id": 59339,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 59340,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 59345,
+    "name": "icetempest",
+    "profession": "bundle"
+  },
+  {
+    "id": 59347,
+    "name": "leapingstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 59391,
+    "name": "spiralstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 59408,
+    "name": "coldfront",
+    "profession": "bundle"
+  },
+  {
+    "id": 59425,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59441,
+    "name": "lethalcoalescence",
+    "profession": "bundle"
+  },
+  {
+    "id": 59450,
+    "name": "vortexofhail",
+    "profession": "bundle"
+  },
+  {
+    "id": 59455,
+    "name": "fallingice",
+    "profession": "bundle"
+  },
+  {
+    "id": 59462,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59468,
+    "name": "spreadingice",
+    "profession": "bundle"
+  },
+  {
+    "id": 59489,
+    "name": "iceshatter",
+    "profession": "bundle"
+  },
+  {
+    "id": 59493,
+    "name": "supernova",
+    "profession": "bundle"
+  },
+  {
+    "id": 59526,
+    "name": "repeater",
+    "profession": "thief"
+  },
+  {
+    "id": 59562,
+    "name": "explosiveentrance",
+    "profession": "bundle"
+  },
+  {
+    "id": 59591,
+    "name": "invoketorment",
+    "profession": "bundle"
+  },
+  {
+    "id": 59627,
+    "profession": "bundle"
+  },
+  {
+    "id": 59656,
+    "name": "bombdrop",
+    "profession": "bundle"
+  },
+  {
+    "id": 59837,
+    "profession": "bundle"
+  },
+  {
+    "id": 59961,
+    "name": "shadowaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 59989,
+    "name": "icetempest",
+    "profession": "bundle"
+  },
+  {
+    "id": 60006,
+    "name": "detonate",
+    "profession": "bundle"
+  },
+  {
+    "id": 60067,
+    "name": "frozenbarrier",
+    "profession": "bundle"
+  },
+  {
+    "id": 60080,
+    "name": "frostblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 60085,
+    "name": "clawsofice",
+    "profession": "bundle"
+  },
+  {
+    "id": 60089,
+    "name": "flurryofice",
+    "profession": "bundle"
+  },
+  {
+    "id": 60132,
+    "name": "charge",
+    "profession": "bundle"
+  },
+  {
+    "id": 60133,
+    "name": "flamewall",
+    "profession": "bundle"
+  },
+  {
+    "id": 60138,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 60171,
+    "name": "flamewall",
+    "profession": "bundle"
+  },
+  {
+    "id": 60174,
+    "name": "mightyspin",
+    "profession": "bundle"
+  },
+  {
+    "id": 60193,
+    "name": "frostbiteaura",
+    "profession": "bundle"
+  },
+  {
+    "id": 60195,
+    "name": "icestorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 60200,
+    "name": "icewhip",
+    "profession": "bundle"
+  },
+  {
+    "id": 60208,
+    "name": "giantstomp",
+    "profession": "bundle"
+  },
+  {
+    "id": 60222,
+    "name": "breathofcorruption",
+    "profession": "bundle"
+  },
+  {
+    "id": 60233,
+    "name": "thrust",
+    "profession": "bundle"
+  },
+  {
+    "id": 60289,
+    "name": "bloodcharge",
+    "profession": "bundle"
+  },
+  {
+    "id": 60308,
+    "name": "callassassins",
+    "profession": "bundle"
+  },
+  {
+    "id": 60315,
+    "name": "frigidtrail",
+    "profession": "bundle"
+  },
+  {
+    "id": 60328,
+    "name": "conjureflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 60344,
+    "name": "boonofflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 60354,
+    "name": "icyechoes",
+    "profession": "bundle"
+  },
+  {
+    "id": 60369,
+    "name": "bodyslam",
+    "profession": "bundle"
+  },
+  {
+    "id": 60370,
+    "name": "mightyspin",
+    "profession": "bundle"
+  },
+  {
+    "id": 60379,
+    "name": "mightyslashes",
+    "profession": "bundle"
+  },
+  {
+    "id": 60473,
+    "name": "giantkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 60524,
+    "name": "giantflurry",
+    "profession": "bundle"
+  },
+  {
+    "id": 60527,
+    "name": "bloodcharge",
+    "profession": "bundle"
+  },
+  {
+    "id": 60545,
+    "name": "lethalcoalescence",
+    "profession": "bundle"
+  },
+  {
+    "id": 60574,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 60577,
+    "name": "lunge",
+    "profession": "bundle"
+  },
+  {
+    "id": 60633,
+    "name": "bombardment",
+    "profession": "bundle"
+  },
+  {
+    "id": 60664,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 60673,
+    "name": "icebreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 60696,
+    "name": "avalanche",
+    "profession": "bundle"
+  },
+  {
+    "id": 60842,
+    "name": "claw",
+    "profession": "bundle"
+  },
+  {
+    "id": 60856,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 60871,
+    "name": "clawsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 60896,
+    "name": "avalanche",
+    "profession": "bundle"
+  },
+  {
+    "id": 60902,
+    "name": "avalanche",
+    "profession": "bundle"
+  },
+  {
+    "id": 60907,
+    "name": "avalanche",
+    "profession": "bundle"
+  },
+  {
+    "id": 60932,
+    "name": "crash",
+    "profession": "bundle"
+  },
+  {
+    "id": 60947,
+    "name": "icebreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 60990,
+    "name": "clawsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 61060,
+    "name": "avalanche",
+    "profession": "bundle"
+  },
+  {
+    "id": 61118,
+    "name": "windsofjormag",
+    "profession": "bundle"
+  },
+  {
+    "id": 61132,
+    "name": "crash",
+    "profession": "bundle"
+  },
+  {
+    "id": 61137,
+    "name": "clawsmash",
+    "profession": "bundle"
+  },
+  {
+    "id": 61172,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61173,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61175,
+    "profession": "bundle"
+  },
+  {
+    "id": 61176,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61177,
+    "name": "torrentialbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 61179,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61181,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61182,
+    "name": "rush",
+    "profession": "bundle"
+  },
+  {
+    "id": 61184,
+    "name": "terrorstorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 61185,
+    "profession": "bundle"
+  },
+  {
+    "id": 61186,
+    "name": "fulgorsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 61189,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61190,
+    "name": "callofstorms",
+    "profession": "bundle"
+  },
+  {
+    "id": 61194,
+    "name": "roilingflames",
+    "profession": "bundle"
+  },
+  {
+    "id": 61195,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61196,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61197,
+    "name": "lightningstrikes",
+    "profession": "bundle"
+  },
+  {
+    "id": 61199,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61203,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61204,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61205,
+    "name": "windburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 61207,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61208,
+    "name": "crushingguilt",
+    "profession": "bundle"
+  },
+  {
+    "id": 61210,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61211,
+    "name": "surgeofdarkness",
+    "profession": "bundle"
+  },
+  {
+    "id": 61212,
+    "name": "rush",
+    "profession": "bundle"
+  },
+  {
+    "id": 61214,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61215,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61216,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61217,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61222,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61228,
+    "profession": "bundle"
+  },
+  {
+    "id": 61230,
+    "name": "roilingflames",
+    "profession": "bundle"
+  },
+  {
+    "id": 61231,
+    "name": "firestorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 61234,
+    "name": "fulgorsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 61235,
+    "name": "fulgorsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 61239,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61240,
+    "name": "tempestofflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 61241,
+    "name": "overwhelmingsorrow",
+    "profession": "bundle"
+  },
+  {
+    "id": 61243,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61245,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61246,
+    "name": "pleaoftides",
+    "profession": "bundle"
+  },
+  {
+    "id": 61247,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61248,
+    "name": "flameburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 61251,
+    "name": "aquaticburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 61255,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61256,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61258,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61260,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61261,
+    "name": "arcdivider",
+    "profession": "bundle"
+  },
+  {
+    "id": 61263,
+    "name": "voltaicexpulsion",
+    "profession": "bundle"
+  },
+  {
+    "id": 61264,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61265,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61266,
+    "name": "uppercut",
+    "profession": "bundle"
+  },
+  {
+    "id": 61268,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61270,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61271,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61273,
+    "name": "roilingflames",
+    "profession": "bundle"
+  },
+  {
+    "id": 61275,
+    "profession": "bundle"
+  },
+  {
+    "id": 61276,
+    "name": "brutalstrike",
+    "profession": "bundle"
+  },
+  {
+    "id": 61279,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61280,
+    "name": "torrentialbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 61282,
+    "name": "explosion",
+    "profession": "bundle"
+  },
+  {
+    "id": 61284,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61287,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61288,
+    "name": "callofstorms",
+    "profession": "bundle"
+  },
+  {
+    "id": 61289,
+    "name": "negativeburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 61292,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61293,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61294,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61299,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61305,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61308,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61309,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61313,
+    "name": "tidalbargain",
+    "profession": "bundle"
+  },
+  {
+    "id": 61317,
+    "name": "explosion",
+    "profession": "bundle"
+  },
+  {
+    "id": 61318,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61321,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61323,
+    "name": "fulgorsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 61325,
+    "name": "surgeofdarkness",
+    "profession": "bundle"
+  },
+  {
+    "id": 61329,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61330,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61336,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61340,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61341,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61343,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61344,
+    "name": "focusedwrath",
+    "profession": "bundle"
+  },
+  {
+    "id": 61345,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61346,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61347,
+    "name": "greatswordslice",
+    "profession": "bundle"
+  },
+  {
+    "id": 61348,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61349,
+    "name": "torrentialbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 61352,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61356,
+    "name": "surgeofdarkness",
+    "profession": "bundle"
+  },
+  {
+    "id": 61362,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61364,
+    "name": "torrentialbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 61365,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61366,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61367,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61369,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61370,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61376,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61378,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61382,
+    "name": "rushend",
+    "profession": "bundle"
+  },
+  {
+    "id": 61384,
+    "name": "aquaticburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 61387,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61394,
+    "name": "voltaicexpulsion",
+    "profession": "bundle"
+  },
+  {
+    "id": 61396,
+    "name": "aquaticburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 61398,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61400,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61401,
+    "name": "pleaoftides",
+    "profession": "bundle"
+  },
+  {
+    "id": 61407,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61409,
+    "profession": "bundle"
+  },
+  {
+    "id": 61411,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61412,
+    "name": "tidalbarrier",
+    "profession": "bundle"
+  },
+  {
+    "id": 61414,
+    "profession": "bundle"
+  },
+  {
+    "id": 61417,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61418,
+    "name": "torrentialbolt",
+    "profession": "bundle"
+  },
+  {
+    "id": 61419,
+    "name": "volatilewaters",
+    "profession": "bundle"
+  },
+  {
+    "id": 61423,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61425,
+    "profession": "bundle"
+  },
+  {
+    "id": 61428,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61429,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61431,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61434,
+    "profession": "bundle"
+  },
+  {
+    "id": 61436,
+    "profession": "bundle"
+  },
+  {
+    "id": 61438,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61439,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61440,
+    "name": "hundredblades",
+    "profession": "bundle"
+  },
+  {
+    "id": 61441,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61442,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61445,
+    "name": "firestorm",
+    "profession": "bundle"
+  },
+  {
+    "id": 61449,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61453,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61454,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61455,
+    "name": "greatswordswing",
+    "profession": "bundle"
+  },
+  {
+    "id": 61456,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61457,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61463,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61466,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61469,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61470,
+    "name": "volatilewind",
+    "profession": "bundle"
+  },
+  {
+    "id": 61480,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61484,
+    "profession": "bundle"
+  },
+  {
+    "id": 61486,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61487,
+    "name": "fulgorsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 61489,
+    "profession": "bundle"
+  },
+  {
+    "id": 61491,
+    "name": "fulgorsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 61495,
+    "name": "roilingflames",
+    "profession": "bundle"
+  },
+  {
+    "id": 61498,
+    "name": "tempestofflame",
+    "profession": "bundle"
+  },
+  {
+    "id": 61499,
+    "name": "focusedwrath",
+    "profession": "bundle"
+  },
+  {
+    "id": 61500,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61504,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61505,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61507,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61508,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61510,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61512,
+    "name": "tidalbargain",
+    "profession": "bundle"
+  },
+  {
+    "id": 61513,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61519,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61520,
+    "profession": "bundle"
+  },
+  {
+    "id": 61525,
+    "name": "surgeofdarkness",
+    "profession": "bundle"
+  },
+  {
+    "id": 61526,
+    "profession": "bundle"
+  },
+  {
+    "id": 61527,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61528,
+    "name": "rush",
+    "profession": "bundle"
+  },
+  {
+    "id": 61529,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61530,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61533,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61534,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61539,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61541,
+    "name": "aquaticburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 61542,
+    "name": "voltaicexpulsion",
+    "profession": "bundle"
+  },
+  {
+    "id": 61548,
+    "name": "volatilefire",
+    "profession": "bundle"
+  },
+  {
+    "id": 61549,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61551,
+    "name": "airblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 61554,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61555,
+    "name": "rush",
+    "profession": "bundle"
+  },
+  {
+    "id": 61556,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61559,
+    "profession": "bundle"
+  },
+  {
+    "id": 61560,
+    "name": "elementalsurge",
+    "profession": "bundle"
+  },
+  {
+    "id": 61561,
+    "name": "fulgorsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 61562,
+    "profession": "bundle"
+  },
+  {
+    "id": 61565,
+    "name": "fulgorsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 61567,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61569,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61573,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61574,
+    "name": "elementalmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61576,
+    "name": "aquaticburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 61581,
+    "name": "callmeteor",
+    "profession": "bundle"
+  },
+  {
+    "id": 61582,
+    "name": "roilingflames",
+    "profession": "bundle"
+  },
+  {
+    "id": 61587,
+    "name": "explosion",
+    "profession": "bundle"
+  },
+  {
+    "id": 61590,
+    "name": "elementalsweep",
+    "profession": "bundle"
+  },
+  {
+    "id": 61591,
+    "name": "elementalwhirl",
+    "profession": "bundle"
+  },
+  {
+    "id": 61592,
+    "name": "lightningstrikes",
+    "profession": "bundle"
+  },
+  {
+    "id": 61597,
+    "name": "aquajet",
+    "profession": "bundle"
+  },
+  {
+    "id": 61600,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61601,
+    "name": "pleaoftides",
+    "profession": "bundle"
+  },
+  {
+    "id": 61602,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61603,
+    "name": "pleaoftides",
+    "profession": "bundle"
+  },
+  {
+    "id": 61604,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61606,
+    "name": "empathicmanipulation",
+    "profession": "bundle"
+  },
+  {
+    "id": 61609,
+    "profession": "bundle"
+  },
+  {
+    "id": 61614,
+    "profession": "bundle"
+  },
+  {
+    "id": 61686,
+    "name": "slash",
+    "profession": "bundle"
+  },
+  {
+    "id": 61741,
+    "name": "claw",
+    "profession": "bundle"
+  },
+  {
+    "id": 61758,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 61762,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 61782,
+    "name": "leap",
+    "profession": "bundle"
+  },
+  {
+    "id": 61799,
+    "name": "bursterexplosion",
+    "profession": "bundle"
+  },
+  {
+    "id": 62027,
+    "name": "firebreath",
+    "profession": "bundle"
+  },
+  {
+    "id": 62076,
+    "name": "giantkick",
+    "profession": "bundle"
+  },
+  {
+    "id": 62123,
+    "name": "frostblast",
+    "profession": "bundle"
+  },
+  {
+    "id": 62183,
+    "name": "cataclysm",
+    "profession": "bundle"
+  },
+  {
+    "id": 62216,
+    "name": "cataclysm",
+    "profession": "bundle"
+  },
+  {
+    "id": 62262,
+    "name": "cataclysm",
+    "profession": "bundle"
+  },
+  {
+    "id": 62335,
+    "name": "apocalypserain",
+    "profession": "bundle"
+  },
+  {
+    "id": 62338,
+    "name": "cataclysm",
+    "profession": "bundle"
+  },
+  {
+    "id": 62340,
+    "name": "cataclysm",
+    "profession": "bundle"
+  },
+  {
+    "id": 62358,
+    "name": "cataclysm",
+    "profession": "bundle"
+  },
+  {
+    "id": 62454,
+    "name": "deception",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62510,
+    "name": "flyingcutter",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62511,
+    "name": "vileblast",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62513,
+    "name": "weepingshots",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62514,
+    "name": "elixirofbliss",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62517,
+    "name": "viciousshot",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62521,
+    "name": "roilinglight",
+    "profession": "guardian"
+  },
+  {
+    "id": 62522,
+    "name": "twinbladerestoration",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62525,
+    "name": "executionerscalling",
+    "profession": "guardian"
+  },
+  {
+    "id": 62528,
+    "name": "willbenderflames",
+    "profession": "guardian"
+  },
+  {
+    "id": 62530,
+    "name": "elixirofrisk",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62532,
+    "name": "crashingcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 62539,
+    "name": "voraciousarc",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62540,
+    "name": "exitharbingershroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62549,
+    "name": "heelcrack",
+    "profession": "guardian"
+  },
+  {
+    "id": 62552,
+    "name": "willbenderflames",
+    "profession": "guardian"
+  },
+  {
+    "id": 62553,
+    "name": "rainofswords",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62555,
+    "name": "crashingcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 62558,
+    "name": "approachingdoom",
+    "profession": "bundle"
+  },
+  {
+    "id": 62560,
+    "name": "bladecall",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62561,
+    "name": "heavenspalm",
+    "profession": "guardian"
+  },
+  {
+    "id": 62563,
+    "name": "vitaldraw",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62565,
+    "name": "whirlinglight",
+    "profession": "guardian"
+  },
+  {
+    "id": 62567,
+    "name": "harbingershroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62568,
+    "name": "bladeleap",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62573,
+    "name": "psychicforce",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62586,
+    "name": "bladesongharmony",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62596,
+    "name": "crashingcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 62597,
+    "name": "bladeturnrequiem",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62602,
+    "name": "bladesongdissonance",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62603,
+    "name": "flowingresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 62607,
+    "name": "unstablebladestorm",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62608,
+    "name": "flashcombo",
+    "profession": "guardian"
+  },
+  {
+    "id": 62611,
+    "name": "taintedbolts",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62616,
+    "name": "bladesongsorrow",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62617,
+    "name": "bladesongharmony",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62618,
+    "name": "willbenderflames",
+    "profession": "guardian"
+  },
+  {
+    "id": 62621,
+    "name": "darkbarrage",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62622,
+    "name": "reversaloffortune",
+    "profession": "guardian"
+  },
+  {
+    "id": 62635,
+    "name": "flowingresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 62646,
+    "name": "elixirofignorance",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62648,
+    "name": "crashingcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 62650,
+    "name": "advancingstrike",
+    "profession": "guardian"
+  },
+  {
+    "id": 62655,
+    "name": "elixirofambition",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62660,
+    "name": "cascadingcorruption",
+    "profession": "bundle"
+  },
+  {
+    "id": 62662,
+    "name": "elixirofanguish",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62664,
+    "name": "ripostingblade",
+    "profession": "bundle"
+  },
+  {
+    "id": 62667,
+    "name": "elixirofpromise",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62668,
+    "name": "rushingjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 62669,
+    "name": "repose",
+    "profession": "guardian"
+  },
+  {
+    "id": 62671,
+    "name": "deathlyhaste",
+    "profession": "bundle"
+  },
+  {
+    "id": 62672,
+    "name": "devouringcut",
+    "profession": "necromancer"
+  },
+  {
+    "id": 62675,
+    "name": "returningedge",
+    "profession": "mesmer"
+  },
+  {
+    "id": 62676,
+    "name": "quickretribution",
+    "profession": "guardian"
+  },
+  {
+    "id": 62680,
+    "name": "selflessspirit",
+    "profession": "revenant"
+  },
+  {
+    "id": 62683,
+    "name": "stonestrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62687,
+    "name": "urnofsaintviktor",
+    "profession": "revenant"
+  },
+  {
+    "id": 62688,
+    "name": "mistslash",
+    "profession": "revenant"
+  },
+  {
+    "id": 62689,
+    "name": "saintsshield",
+    "profession": "bundle"
+  },
+  {
+    "id": 62692,
+    "name": "mistunleashed",
+    "profession": "revenant"
+  },
+  {
+    "id": 62693,
+    "name": "deathdrop",
+    "profession": "bundle"
+  },
+  {
+    "id": 62694,
+    "name": "waterrush",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62697,
+    "name": "gunstinger",
+    "profession": "warrior"
+  },
+  {
+    "id": 62698,
+    "name": "shatteringice",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62702,
+    "name": "battledance",
+    "profession": "revenant"
+  },
+  {
+    "id": 62705,
+    "name": "callofthealliance",
+    "profession": "bundle"
+  },
+  {
+    "id": 62716,
+    "name": "shockblast",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62719,
+    "name": "selfishspirit",
+    "profession": "revenant"
+  },
+  {
+    "id": 62723,
+    "name": "deployjadesphere",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62725,
+    "name": "elementalcelerity",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62729,
+    "name": "alliancetactics",
+    "profession": "revenant"
+  },
+  {
+    "id": 62735,
+    "name": "recalljadesphere",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62738,
+    "name": "dropurnofsaintviktor",
+    "profession": "revenant"
+  },
+  {
+    "id": 62745,
+    "name": "unsheathegunsaber",
+    "profession": "warrior"
+  },
+  {
+    "id": 62747,
+    "name": "windslam",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62749,
+    "name": "legendaryalliance",
+    "profession": "revenant"
+  },
+  {
+    "id": 62752,
+    "name": "arcingmists",
+    "profession": "revenant"
+  },
+  {
+    "id": 62757,
+    "name": "energymeld",
+    "profession": "revenant"
+  },
+  {
+    "id": 62758,
+    "name": "flamewheel",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62778,
+    "name": "groundpound",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62793,
+    "name": "treesong",
+    "profession": "revenant"
+  },
+  {
+    "id": 62796,
+    "name": "awakening",
+    "profession": "revenant"
+  },
+  {
+    "id": 62800,
+    "name": "dragonsroar",
+    "profession": "warrior"
+  },
+  {
+    "id": 62803,
+    "name": "dragontrigger",
+    "profession": "warrior"
+  },
+  {
+    "id": 62804,
+    "name": "electricfence",
+    "profession": "warrior"
+  },
+  {
+    "id": 62807,
+    "name": "triplesear",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62812,
+    "name": "hurricaneofpain",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62813,
+    "name": "deployjadesphere",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62826,
+    "name": "fortifiedearth",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62827,
+    "name": "soothingwater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62828,
+    "name": "truestrike",
+    "profession": "revenant"
+  },
+  {
+    "id": 62830,
+    "name": "recalljadesphere",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62832,
+    "name": "nomadsadvance",
+    "profession": "revenant"
+  },
+  {
+    "id": 62834,
+    "name": "icycoil",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62835,
+    "name": "recalljadesphere",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62837,
+    "name": "deployjadesphere",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62839,
+    "name": "watersphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 62841,
+    "name": "scavengerburst",
+    "profession": "revenant"
+  },
+  {
+    "id": 62842,
+    "name": "airsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 62843,
+    "name": "cleansingtyphoon",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62847,
+    "name": "unseensword",
+    "profession": "bundle"
+  },
+  {
+    "id": 62857,
+    "name": "",
+    "profession": "warrior"
+  },
+  {
+    "id": 62859,
+    "name": "imperialimpact",
+    "profession": "bundle"
+  },
+  {
+    "id": 62861,
+    "name": "sheathegunsaber",
+    "profession": "warrior"
+  },
+  {
+    "id": 62862,
+    "name": "chillingcrack",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62865,
+    "name": "streamstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62868,
+    "name": "recalljadesphere",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62876,
+    "name": "grandfinale",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62878,
+    "name": "reaversrage",
+    "profession": "revenant"
+  },
+  {
+    "id": 62881,
+    "name": "earthsphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 62884,
+    "name": "surgingflames",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62887,
+    "name": "crescentwind",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62891,
+    "name": "legendaryalliancestance",
+    "profession": "revenant"
+  },
+  {
+    "id": 62895,
+    "name": "phantomsonslaught",
+    "profession": "revenant"
+  },
+  {
+    "id": 62901,
+    "name": "tacticalreload",
+    "profession": "warrior"
+  },
+  {
+    "id": 62910,
+    "name": "moltenend",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62913,
+    "name": "mistswing",
+    "profession": "revenant"
+  },
+  {
+    "id": 62921,
+    "name": "imperialguard",
+    "profession": "revenant"
+  },
+  {
+    "id": 62925,
+    "name": "singeingstrike",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62929,
+    "name": "eternitysrequiem",
+    "profession": "revenant"
+  },
+  {
+    "id": 62940,
+    "name": "deployjadesphere",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62941,
+    "name": "treesong",
+    "profession": "revenant"
+  },
+  {
+    "id": 62942,
+    "name": "spearofarchemorus",
+    "profession": "revenant"
+  },
+  {
+    "id": 62943,
+    "name": "bulletproofbarrier",
+    "profession": "warrior"
+  },
+  {
+    "id": 62947,
+    "name": "windstorm",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62948,
+    "name": "crashingfont",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62949,
+    "name": "firesphere",
+    "profession": "bundle"
+  },
+  {
+    "id": 62958,
+    "name": "rainofblows",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62960,
+    "name": "dragonspikemine",
+    "profession": "warrior"
+  },
+  {
+    "id": 62962,
+    "name": "scavengerburst",
+    "profession": "revenant"
+  },
+  {
+    "id": 62965,
+    "name": "relentlessfire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62967,
+    "name": "flowstabilizer",
+    "profession": "warrior"
+  },
+  {
+    "id": 62969,
+    "name": "flow",
+    "profession": "bundle"
+  },
+  {
+    "id": 62975,
+    "name": "rockyloop",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62976,
+    "name": "whirlingstones",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62978,
+    "name": "combatstimulant",
+    "profession": "warrior"
+  },
+  {
+    "id": 62979,
+    "name": "flameshellburst",
+    "profession": "bundle"
+  },
+  {
+    "id": 62981,
+    "name": "dragontriggerlocked",
+    "profession": "warrior"
+  },
+  {
+    "id": 62982,
+    "name": "invigoratingair",
+    "profession": "elementalist"
+  },
+  {
+    "id": 62992,
+    "name": "immutablestone",
+    "profession": "elementalist"
+  }
+]

--- a/src/utils/mapping/specializations.json
+++ b/src/utils/mapping/specializations.json
@@ -1,1 +1,1451 @@
-[{"id":1,"name":"dueling","profession":"mesmer","minor_traits":[706,710,707],"major_traits":[701,705,700,1889,1960,708,692,1950,704]},{"id":2,"name":"deathmagic","profession":"necromancer","minor_traits":[856,839,1929],"major_traits":[820,857,1922,858,860,855,842,1940,1694]},{"id":3,"name":"invocation","profession":"revenant","minor_traits":[1778,1758,1769],"major_traits":[1732,1761,1784,1774,1760,1781,1749,1791,1719]},{"id":4,"name":"strength","profession":"warrior","minor_traits":[1446,1448,1453],"major_traits":[1447,1451,1444,2000,1338,1449,1437,1454,1440]},{"id":5,"name":"druid","profession":"ranger","minor_traits":[1874,1862,1992],"major_traits":[1868,2016,1935,2053,2001,2056,2057,2058,2055]},{"id":6,"name":"explosives","profession":"engineer","minor_traits":[432,517,429],"major_traits":[514,525,1882,482,1892,1944,1541,505,1947]},{"id":7,"name":"daredevil","profession":"thief","minor_traits":[1994,1887,1837],"major_traits":[1933,2023,1949,1884,1893,1975,1833,1964,2047]},{"id":8,"name":"marksmanship","profession":"ranger","minor_traits":[1010,1009,1011],"major_traits":[1021,1014,986,1001,1000,1070,996,1015,1698]},{"id":9,"name":"retribution","profession":"revenant","minor_traits":[1783,1757,1713],"major_traits":[1811,1728,1810,1766,1782,1740,1779,1770,1790]},{"id":10,"name":"domination","profession":"mesmer","minor_traits":[685,694,1941],"major_traits":[686,682,687,693,713,712,681,680,1688]},{"id":11,"name":"tactics","profession":"warrior","minor_traits":[1480,1485,1481],"major_traits":[1469,1474,1471,1486,1479,1482,1667,1470,1711]},{"id":12,"name":"salvation","profession":"revenant","minor_traits":[1816,1821,1814],"major_traits":[1823,1824,1822,1819,1817,1818,1815,1825,1820]},{"id":13,"name":"valor","profession":"guardian","minor_traits":[582,594,583],"major_traits":[588,581,633,580,584,1684,585,586,589]},{"id":14,"name":"corruption","profession":"revenant","minor_traits":[1799,1801,1744],"major_traits":[1793,1789,1741,1727,1726,1714,1795,1720,1721]},{"id":15,"name":"devastation","profession":"revenant","minor_traits":[1808,1724,1792],"major_traits":[1776,1767,1755,1786,1765,1802,1715,1800,1754]},{"id":16,"name":"radiance","profession":"guardian","minor_traits":[572,571,568],"major_traits":[577,566,574,578,567,565,1686,579,1683]},{"id":17,"name":"water","profession":"elementalist","minor_traits":[350,351,1676],"major_traits":[348,363,360,364,358,349,362,361,2028]},{"id":18,"name":"berserker","profession":"warrior","minor_traits":[1831,1993,2046],"major_traits":[2049,2039,1977,2011,2042,2002,1928,2038,2043]},{"id":19,"name":"bloodmagic","profession":"necromancer","minor_traits":[792,783,1931],"major_traits":[780,788,1876,789,799,1844,782,1692,778]},{"id":20,"name":"shadowarts","profession":"thief","minor_traits":[1294,1136,1705],"major_traits":[1160,1293,1284,1297,1130,1300,1134,1135,1162]},{"id":21,"name":"tools","profession":"engineer","minor_traits":[1979,1872,1936],"major_traits":[532,1997,531,512,1946,1832,1856,523,1679]},{"id":22,"name":"defense","profession":"warrior","minor_traits":[1350,1348,1380],"major_traits":[1376,1488,1372,1368,1379,1367,1375,1649,1708]},{"id":23,"name":"inspiration","profession":"mesmer","minor_traits":[757,1852,1915],"major_traits":[756,738,744,751,740,1980,2005,1866,752]},{"id":24,"name":"illusions","profession":"mesmer","minor_traits":[734,723,731],"major_traits":[721,1869,691,722,729,1690,733,2035,753]},{"id":25,"name":"naturemagic","profession":"ranger","minor_traits":[1055,1056,1059],"major_traits":[1062,978,1060,1054,965,964,1038,1988,1697]},{"id":26,"name":"earth","profession":"elementalist","minor_traits":[278,279,280],"major_traits":[282,1507,289,275,281,277,1508,287,1674]},{"id":27,"name":"dragonhunter","profession":"guardian","minor_traits":[1848,1896,1926],"major_traits":[1898,1983,1911,2037,1835,1943,1908,1963,1955]},{"id":28,"name":"deadlyarts","profession":"thief","minor_traits":[1279,1280,1257],"major_traits":[1245,1276,1164,1169,1292,1704,1291,1167,1269]},{"id":29,"name":"alchemy","profession":"engineer","minor_traits":[468,487,413],"major_traits":[396,509,521,520,469,470,473,1871,1854]},{"id":30,"name":"skirmishing","profession":"ranger","minor_traits":[1080,1083,1068],"major_traits":[1069,1067,1075,1016,1700,1846,1064,1912,1888]},{"id":31,"name":"fire","profession":"elementalist","minor_traits":[320,318,319],"major_traits":[296,328,335,325,340,334,1510,294,1675]},{"id":32,"name":"beastmastery","profession":"ranger","minor_traits":[1900,974,1065],"major_traits":[1861,1072,1606,975,1047,970,1945,968,1066]},{"id":33,"name":"wildernesssurvival","profession":"ranger","minor_traits":[1096,1090,1089],"major_traits":[1098,1086,1099,1101,2032,1100,1094,1699,1701]},{"id":34,"name":"reaper","profession":"necromancer","minor_traits":[1905,1879,2018],"major_traits":[1974,2020,2026,1969,2008,2031,1932,1919,2021]},{"id":35,"name":"criticalstrikes","profession":"thief","minor_traits":[1281,1210,1282],"major_traits":[1209,1267,1268,1170,1272,1299,1904,1215,1702]},{"id":36,"name":"arms","profession":"warrior","minor_traits":[1342,1343,1337],"major_traits":[1455,1344,1334,1315,1316,1333,1336,1346,1707]},{"id":37,"name":"arcane","profession":"elementalist","minor_traits":[268,264,2004],"major_traits":[253,266,1487,265,1673,257,238,263,1511]},{"id":38,"name":"firearms","profession":"engineer","minor_traits":[515,536,516],"major_traits":[1878,1930,1914,1984,2006,1923,510,526,433]},{"id":39,"name":"curses","profession":"necromancer","minor_traits":[802,803,810],"major_traits":[1883,2013,815,816,1693,812,813,1696,801]},{"id":40,"name":"chronomancer","profession":"mesmer","minor_traits":[2030,1927,1859],"major_traits":[1838,1995,1987,2009,1913,1978,1942,2022,1890]},{"id":41,"name":"air","profession":"elementalist","minor_traits":[221,222,223],"major_traits":[227,224,232,229,214,1502,226,1503,1672]},{"id":42,"name":"zeal","profession":"guardian","minor_traits":[648,646,649],"major_traits":[563,634,1925,628,653,1556,635,637,2017]},{"id":43,"name":"scrapper","profession":"engineer","minor_traits":[1959,2014,1877],"major_traits":[1917,1971,1867,1954,1999,1860,1981,2052,1849]},{"id":44,"name":"trickery","profession":"thief","minor_traits":[1137,1232,1157],"major_traits":[1159,1252,1163,1277,1286,1190,1187,1158,1706]},{"id":45,"name":"chaos","profession":"mesmer","minor_traits":[666,667,1865],"major_traits":[670,675,677,673,668,669,671,674,1687]},{"id":46,"name":"virtues","profession":"guardian","minor_traits":[621,604,620],"major_traits":[624,625,617,603,610,587,622,554,612]},{"id":47,"name":"inventions","profession":"engineer","minor_traits":[518,508,519],"major_traits":[394,1901,507,1678,1834,445,472,1680,1916]},{"id":48,"name":"tempest","profession":"elementalist","minor_traits":[2025,1938,1948],"major_traits":[1952,1962,1886,1891,1902,2015,1839,2033,1986]},{"id":49,"name":"honor","profession":"guardian","minor_traits":[564,551,1685],"major_traits":[1899,559,654,557,549,562,553,558,1682]},{"id":50,"name":"soulreaping","profession":"necromancer","minor_traits":[887,891,874],"major_traits":[875,898,888,894,861,892,889,893,905]},{"id":51,"name":"discipline","profession":"warrior","minor_traits":[1415,1416,1417],"major_traits":[1329,1413,1381,1484,1489,1709,1369,1317,1657]},{"id":52,"name":"herald","profession":"revenant","minor_traits":[1777,1737,1788],"major_traits":[1813,1806,1716,1738,1743,1730,1746,1772,1803]},{"id":53,"name":"spite","profession":"necromancer","minor_traits":[913,915,917],"major_traits":[914,916,1863,899,829,909,919,853,903]},{"id":54,"name":"acrobatics","profession":"thief","minor_traits":[1240,1234,1242],"major_traits":[1112,1289,1237,1241,1192,1290,1238,1295,1703]},{"id":55,"name":"soulbeast","profession":"ranger","minor_traits":[2151,2156,2127],"major_traits":[2134,2071,2072,2119,2085,2161,2155,2128,2143]},{"id":56,"name":"weaver","profession":"elementalist","minor_traits":[2109,2077,2081],"major_traits":[2177,2165,2115,2180,2061,2170,2131,2090,2138]},{"id":57,"name":"holosmith","profession":"engineer","minor_traits":[2158,2135,2122],"major_traits":[2114,2157,2106,2103,2152,2091,2066,2137,2064]},{"id":58,"name":"deadeye","profession":"thief","minor_traits":[2171,2172,2084],"major_traits":[2145,2173,2136,2118,2078,2160,2111,2093,2146]},{"id":59,"name":"mirage","profession":"mesmer","minor_traits":[2150,2069,2117],"major_traits":[2141,2082,2110,2178,2174,2098,2070,2113,2169]},{"id":60,"name":"scourge","profession":"necromancer","minor_traits":[2147,2121,2096],"major_traits":[2167,2074,2102,2059,2067,2123,2112,2164,2080]},{"id":61,"name":"spellbreaker","profession":"warrior","minor_traits":[2175,2162,2130],"major_traits":[2107,2153,2140,2126,2097,2095,2163,2168,2060]},{"id":62,"name":"firebrand","profession":"guardian","minor_traits":[2089,2062,2148],"major_traits":[2075,2101,2086,2063,2076,2116,2105,2179,2159]},{"id":63,"name":"renegade","profession":"revenant","minor_traits":[2181,2154,2142],"major_traits":[2166,2079,2120,2133,2092,2108,2094,2100,2182]},{"id":64,"name":"harbinger","profession":"necromancer","minor_traits":[2183,2186,2217],"major_traits":[2188,2219,2185,2192,2220,2209,2218,2194,2203]},{"id":65,"name":"willbender","profession":"guardian","minor_traits":[2200,2222,2189],"major_traits":[2191,2190,2187,2197,2210,2199,2195,2201,2198]},{"id":66,"name":"virtuoso","profession":"mesmer","minor_traits":[2216,2204,2193],"major_traits":[2212,2208,2202,2215,2205,2207,2211,2206,2223]},{"id":67,"name":"catalyst","profession":"elementalist","minor_traits":[2227,2250,2231],"major_traits":[2230,2252,2224,2247,2249,2234,2233,2241,2251]},{"id":68,"name":"bladesworn","profession":"warrior","minor_traits":[2226,2242,2236],"major_traits":[2237,2260,2225,2253,2244,2240,2261,2239,2245]},{"id":69,"name":"vindicator","profession":"revenant","minor_traits":[2262,2254,2229],"major_traits":[2258,2248,2228,2259,2243,2255,2257,2232,2238]}]
+[
+  {
+    "id": 1,
+    "name": "dueling",
+    "profession": "mesmer",
+    "minor_traits": [
+      706,
+      710,
+      707
+    ],
+    "major_traits": [
+      701,
+      705,
+      700,
+      1889,
+      1960,
+      708,
+      692,
+      1950,
+      704
+    ]
+  },
+  {
+    "id": 2,
+    "name": "deathmagic",
+    "profession": "necromancer",
+    "minor_traits": [
+      856,
+      839,
+      1929
+    ],
+    "major_traits": [
+      820,
+      857,
+      1922,
+      858,
+      860,
+      855,
+      842,
+      1940,
+      1694
+    ]
+  },
+  {
+    "id": 3,
+    "name": "invocation",
+    "profession": "revenant",
+    "minor_traits": [
+      1778,
+      1758,
+      1769
+    ],
+    "major_traits": [
+      1732,
+      1761,
+      1784,
+      1774,
+      1760,
+      1781,
+      1749,
+      1791,
+      1719
+    ]
+  },
+  {
+    "id": 4,
+    "name": "strength",
+    "profession": "warrior",
+    "minor_traits": [
+      1446,
+      1448,
+      1453
+    ],
+    "major_traits": [
+      1447,
+      1451,
+      1444,
+      2000,
+      1338,
+      1449,
+      1437,
+      1454,
+      1440
+    ]
+  },
+  {
+    "id": 5,
+    "name": "druid",
+    "profession": "ranger",
+    "minor_traits": [
+      1874,
+      1862,
+      1992
+    ],
+    "major_traits": [
+      1868,
+      2016,
+      1935,
+      2053,
+      2001,
+      2056,
+      2057,
+      2058,
+      2055
+    ]
+  },
+  {
+    "id": 6,
+    "name": "explosives",
+    "profession": "engineer",
+    "minor_traits": [
+      432,
+      517,
+      429
+    ],
+    "major_traits": [
+      514,
+      525,
+      1882,
+      482,
+      1892,
+      1944,
+      1541,
+      505,
+      1947
+    ]
+  },
+  {
+    "id": 7,
+    "name": "daredevil",
+    "profession": "thief",
+    "minor_traits": [
+      1994,
+      1887,
+      1837
+    ],
+    "major_traits": [
+      1933,
+      2023,
+      1949,
+      1884,
+      1893,
+      1975,
+      1833,
+      1964,
+      2047
+    ]
+  },
+  {
+    "id": 8,
+    "name": "marksmanship",
+    "profession": "ranger",
+    "minor_traits": [
+      1010,
+      1009,
+      1011
+    ],
+    "major_traits": [
+      1021,
+      1014,
+      986,
+      1001,
+      1000,
+      1070,
+      996,
+      1015,
+      1698
+    ]
+  },
+  {
+    "id": 9,
+    "name": "retribution",
+    "profession": "revenant",
+    "minor_traits": [
+      1783,
+      1757,
+      1713
+    ],
+    "major_traits": [
+      1811,
+      1728,
+      1810,
+      1766,
+      1782,
+      1740,
+      1779,
+      1770,
+      1790
+    ]
+  },
+  {
+    "id": 10,
+    "name": "domination",
+    "profession": "mesmer",
+    "minor_traits": [
+      685,
+      694,
+      1941
+    ],
+    "major_traits": [
+      686,
+      682,
+      687,
+      693,
+      713,
+      712,
+      681,
+      680,
+      1688
+    ]
+  },
+  {
+    "id": 11,
+    "name": "tactics",
+    "profession": "warrior",
+    "minor_traits": [
+      1480,
+      1485,
+      1481
+    ],
+    "major_traits": [
+      1469,
+      1474,
+      1471,
+      1486,
+      1479,
+      1482,
+      1667,
+      1470,
+      1711
+    ]
+  },
+  {
+    "id": 12,
+    "name": "salvation",
+    "profession": "revenant",
+    "minor_traits": [
+      1816,
+      1821,
+      1814
+    ],
+    "major_traits": [
+      1823,
+      1824,
+      1822,
+      1819,
+      1817,
+      1818,
+      1815,
+      1825,
+      1820
+    ]
+  },
+  {
+    "id": 13,
+    "name": "valor",
+    "profession": "guardian",
+    "minor_traits": [
+      582,
+      594,
+      583
+    ],
+    "major_traits": [
+      588,
+      581,
+      633,
+      580,
+      584,
+      1684,
+      585,
+      586,
+      589
+    ]
+  },
+  {
+    "id": 14,
+    "name": "corruption",
+    "profession": "revenant",
+    "minor_traits": [
+      1799,
+      1801,
+      1744
+    ],
+    "major_traits": [
+      1793,
+      1789,
+      1741,
+      1727,
+      1726,
+      1714,
+      1795,
+      1720,
+      1721
+    ]
+  },
+  {
+    "id": 15,
+    "name": "devastation",
+    "profession": "revenant",
+    "minor_traits": [
+      1808,
+      1724,
+      1792
+    ],
+    "major_traits": [
+      1776,
+      1767,
+      1755,
+      1786,
+      1765,
+      1802,
+      1715,
+      1800,
+      1754
+    ]
+  },
+  {
+    "id": 16,
+    "name": "radiance",
+    "profession": "guardian",
+    "minor_traits": [
+      572,
+      571,
+      568
+    ],
+    "major_traits": [
+      577,
+      566,
+      574,
+      578,
+      567,
+      565,
+      1686,
+      579,
+      1683
+    ]
+  },
+  {
+    "id": 17,
+    "name": "water",
+    "profession": "elementalist",
+    "minor_traits": [
+      350,
+      351,
+      1676
+    ],
+    "major_traits": [
+      348,
+      363,
+      360,
+      364,
+      358,
+      349,
+      362,
+      361,
+      2028
+    ]
+  },
+  {
+    "id": 18,
+    "name": "berserker",
+    "profession": "warrior",
+    "minor_traits": [
+      1831,
+      1993,
+      2046
+    ],
+    "major_traits": [
+      2049,
+      2039,
+      1977,
+      2011,
+      2042,
+      2002,
+      1928,
+      2038,
+      2043
+    ]
+  },
+  {
+    "id": 19,
+    "name": "bloodmagic",
+    "profession": "necromancer",
+    "minor_traits": [
+      792,
+      783,
+      1931
+    ],
+    "major_traits": [
+      780,
+      788,
+      1876,
+      789,
+      799,
+      1844,
+      782,
+      1692,
+      778
+    ]
+  },
+  {
+    "id": 20,
+    "name": "shadowarts",
+    "profession": "thief",
+    "minor_traits": [
+      1294,
+      1136,
+      1705
+    ],
+    "major_traits": [
+      1160,
+      1293,
+      1284,
+      1297,
+      1130,
+      1300,
+      1134,
+      1135,
+      1162
+    ]
+  },
+  {
+    "id": 21,
+    "name": "tools",
+    "profession": "engineer",
+    "minor_traits": [
+      1979,
+      1872,
+      1936
+    ],
+    "major_traits": [
+      532,
+      1997,
+      531,
+      512,
+      1946,
+      1832,
+      1856,
+      523,
+      1679
+    ]
+  },
+  {
+    "id": 22,
+    "name": "defense",
+    "profession": "warrior",
+    "minor_traits": [
+      1350,
+      1348,
+      1380
+    ],
+    "major_traits": [
+      1376,
+      1488,
+      1372,
+      1368,
+      1379,
+      1367,
+      1375,
+      1649,
+      1708
+    ]
+  },
+  {
+    "id": 23,
+    "name": "inspiration",
+    "profession": "mesmer",
+    "minor_traits": [
+      757,
+      1852,
+      1915
+    ],
+    "major_traits": [
+      756,
+      738,
+      744,
+      751,
+      740,
+      1980,
+      2005,
+      1866,
+      752
+    ]
+  },
+  {
+    "id": 24,
+    "name": "illusions",
+    "profession": "mesmer",
+    "minor_traits": [
+      734,
+      723,
+      731
+    ],
+    "major_traits": [
+      721,
+      1869,
+      691,
+      722,
+      729,
+      1690,
+      733,
+      2035,
+      753
+    ]
+  },
+  {
+    "id": 25,
+    "name": "naturemagic",
+    "profession": "ranger",
+    "minor_traits": [
+      1055,
+      1056,
+      1059
+    ],
+    "major_traits": [
+      1062,
+      978,
+      1060,
+      1054,
+      965,
+      964,
+      1038,
+      1988,
+      1697
+    ]
+  },
+  {
+    "id": 26,
+    "name": "earth",
+    "profession": "elementalist",
+    "minor_traits": [
+      278,
+      279,
+      280
+    ],
+    "major_traits": [
+      282,
+      1507,
+      289,
+      275,
+      281,
+      277,
+      1508,
+      287,
+      1674
+    ]
+  },
+  {
+    "id": 27,
+    "name": "dragonhunter",
+    "profession": "guardian",
+    "minor_traits": [
+      1848,
+      1896,
+      1926
+    ],
+    "major_traits": [
+      1898,
+      1983,
+      1911,
+      2037,
+      1835,
+      1943,
+      1908,
+      1963,
+      1955
+    ]
+  },
+  {
+    "id": 28,
+    "name": "deadlyarts",
+    "profession": "thief",
+    "minor_traits": [
+      1279,
+      1280,
+      1257
+    ],
+    "major_traits": [
+      1245,
+      1276,
+      1164,
+      1169,
+      1292,
+      1704,
+      1291,
+      1167,
+      1269
+    ]
+  },
+  {
+    "id": 29,
+    "name": "alchemy",
+    "profession": "engineer",
+    "minor_traits": [
+      468,
+      487,
+      413
+    ],
+    "major_traits": [
+      396,
+      509,
+      521,
+      520,
+      469,
+      470,
+      473,
+      1871,
+      1854
+    ]
+  },
+  {
+    "id": 30,
+    "name": "skirmishing",
+    "profession": "ranger",
+    "minor_traits": [
+      1080,
+      1083,
+      1068
+    ],
+    "major_traits": [
+      1069,
+      1067,
+      1075,
+      1016,
+      1700,
+      1846,
+      1064,
+      1912,
+      1888
+    ]
+  },
+  {
+    "id": 31,
+    "name": "fire",
+    "profession": "elementalist",
+    "minor_traits": [
+      320,
+      318,
+      319
+    ],
+    "major_traits": [
+      296,
+      328,
+      335,
+      325,
+      340,
+      334,
+      1510,
+      294,
+      1675
+    ]
+  },
+  {
+    "id": 32,
+    "name": "beastmastery",
+    "profession": "ranger",
+    "minor_traits": [
+      1900,
+      974,
+      1065
+    ],
+    "major_traits": [
+      1861,
+      1072,
+      1606,
+      975,
+      1047,
+      970,
+      1945,
+      968,
+      1066
+    ]
+  },
+  {
+    "id": 33,
+    "name": "wildernesssurvival",
+    "profession": "ranger",
+    "minor_traits": [
+      1096,
+      1090,
+      1089
+    ],
+    "major_traits": [
+      1098,
+      1086,
+      1099,
+      1101,
+      2032,
+      1100,
+      1094,
+      1699,
+      1701
+    ]
+  },
+  {
+    "id": 34,
+    "name": "reaper",
+    "profession": "necromancer",
+    "minor_traits": [
+      1905,
+      1879,
+      2018
+    ],
+    "major_traits": [
+      1974,
+      2020,
+      2026,
+      1969,
+      2008,
+      2031,
+      1932,
+      1919,
+      2021
+    ]
+  },
+  {
+    "id": 35,
+    "name": "criticalstrikes",
+    "profession": "thief",
+    "minor_traits": [
+      1281,
+      1210,
+      1282
+    ],
+    "major_traits": [
+      1209,
+      1267,
+      1268,
+      1170,
+      1272,
+      1299,
+      1904,
+      1215,
+      1702
+    ]
+  },
+  {
+    "id": 36,
+    "name": "arms",
+    "profession": "warrior",
+    "minor_traits": [
+      1342,
+      1343,
+      1337
+    ],
+    "major_traits": [
+      1455,
+      1344,
+      1334,
+      1315,
+      1316,
+      1333,
+      1336,
+      1346,
+      1707
+    ]
+  },
+  {
+    "id": 37,
+    "name": "arcane",
+    "profession": "elementalist",
+    "minor_traits": [
+      268,
+      264,
+      2004
+    ],
+    "major_traits": [
+      253,
+      266,
+      1487,
+      265,
+      1673,
+      257,
+      238,
+      263,
+      1511
+    ]
+  },
+  {
+    "id": 38,
+    "name": "firearms",
+    "profession": "engineer",
+    "minor_traits": [
+      515,
+      536,
+      516
+    ],
+    "major_traits": [
+      1878,
+      1930,
+      1914,
+      1984,
+      2006,
+      1923,
+      510,
+      526,
+      433
+    ]
+  },
+  {
+    "id": 39,
+    "name": "curses",
+    "profession": "necromancer",
+    "minor_traits": [
+      802,
+      803,
+      810
+    ],
+    "major_traits": [
+      1883,
+      2013,
+      815,
+      816,
+      1693,
+      812,
+      813,
+      1696,
+      801
+    ]
+  },
+  {
+    "id": 40,
+    "name": "chronomancer",
+    "profession": "mesmer",
+    "minor_traits": [
+      2030,
+      1927,
+      1859
+    ],
+    "major_traits": [
+      1838,
+      1995,
+      1987,
+      2009,
+      1913,
+      1978,
+      1942,
+      2022,
+      1890
+    ]
+  },
+  {
+    "id": 41,
+    "name": "air",
+    "profession": "elementalist",
+    "minor_traits": [
+      221,
+      222,
+      223
+    ],
+    "major_traits": [
+      227,
+      224,
+      232,
+      229,
+      214,
+      1502,
+      226,
+      1503,
+      1672
+    ]
+  },
+  {
+    "id": 42,
+    "name": "zeal",
+    "profession": "guardian",
+    "minor_traits": [
+      648,
+      646,
+      649
+    ],
+    "major_traits": [
+      563,
+      634,
+      1925,
+      628,
+      653,
+      1556,
+      635,
+      637,
+      2017
+    ]
+  },
+  {
+    "id": 43,
+    "name": "scrapper",
+    "profession": "engineer",
+    "minor_traits": [
+      1959,
+      2014,
+      1877
+    ],
+    "major_traits": [
+      1917,
+      1971,
+      1867,
+      1954,
+      1999,
+      1860,
+      1981,
+      2052,
+      1849
+    ]
+  },
+  {
+    "id": 44,
+    "name": "trickery",
+    "profession": "thief",
+    "minor_traits": [
+      1137,
+      1232,
+      1157
+    ],
+    "major_traits": [
+      1159,
+      1252,
+      1163,
+      1277,
+      1286,
+      1190,
+      1187,
+      1158,
+      1706
+    ]
+  },
+  {
+    "id": 45,
+    "name": "chaos",
+    "profession": "mesmer",
+    "minor_traits": [
+      666,
+      667,
+      1865
+    ],
+    "major_traits": [
+      670,
+      675,
+      677,
+      673,
+      668,
+      669,
+      671,
+      674,
+      1687
+    ]
+  },
+  {
+    "id": 46,
+    "name": "virtues",
+    "profession": "guardian",
+    "minor_traits": [
+      621,
+      604,
+      620
+    ],
+    "major_traits": [
+      624,
+      625,
+      617,
+      603,
+      610,
+      587,
+      622,
+      554,
+      612
+    ]
+  },
+  {
+    "id": 47,
+    "name": "inventions",
+    "profession": "engineer",
+    "minor_traits": [
+      518,
+      508,
+      519
+    ],
+    "major_traits": [
+      394,
+      1901,
+      507,
+      1678,
+      1834,
+      445,
+      472,
+      1680,
+      1916
+    ]
+  },
+  {
+    "id": 48,
+    "name": "tempest",
+    "profession": "elementalist",
+    "minor_traits": [
+      2025,
+      1938,
+      1948
+    ],
+    "major_traits": [
+      1952,
+      1962,
+      1886,
+      1891,
+      1902,
+      2015,
+      1839,
+      2033,
+      1986
+    ]
+  },
+  {
+    "id": 49,
+    "name": "honor",
+    "profession": "guardian",
+    "minor_traits": [
+      564,
+      551,
+      1685
+    ],
+    "major_traits": [
+      1899,
+      559,
+      654,
+      557,
+      549,
+      562,
+      553,
+      558,
+      1682
+    ]
+  },
+  {
+    "id": 50,
+    "name": "soulreaping",
+    "profession": "necromancer",
+    "minor_traits": [
+      887,
+      891,
+      874
+    ],
+    "major_traits": [
+      875,
+      898,
+      888,
+      894,
+      861,
+      892,
+      889,
+      893,
+      905
+    ]
+  },
+  {
+    "id": 51,
+    "name": "discipline",
+    "profession": "warrior",
+    "minor_traits": [
+      1415,
+      1416,
+      1417
+    ],
+    "major_traits": [
+      1329,
+      1413,
+      1381,
+      1484,
+      1489,
+      1709,
+      1369,
+      1317,
+      1657
+    ]
+  },
+  {
+    "id": 52,
+    "name": "herald",
+    "profession": "revenant",
+    "minor_traits": [
+      1777,
+      1737,
+      1788
+    ],
+    "major_traits": [
+      1813,
+      1806,
+      1716,
+      1738,
+      1743,
+      1730,
+      1746,
+      1772,
+      1803
+    ]
+  },
+  {
+    "id": 53,
+    "name": "spite",
+    "profession": "necromancer",
+    "minor_traits": [
+      913,
+      915,
+      917
+    ],
+    "major_traits": [
+      914,
+      916,
+      1863,
+      899,
+      829,
+      909,
+      919,
+      853,
+      903
+    ]
+  },
+  {
+    "id": 54,
+    "name": "acrobatics",
+    "profession": "thief",
+    "minor_traits": [
+      1240,
+      1234,
+      1242
+    ],
+    "major_traits": [
+      1112,
+      1289,
+      1237,
+      1241,
+      1192,
+      1290,
+      1238,
+      1295,
+      1703
+    ]
+  },
+  {
+    "id": 55,
+    "name": "soulbeast",
+    "profession": "ranger",
+    "minor_traits": [
+      2151,
+      2156,
+      2127
+    ],
+    "major_traits": [
+      2134,
+      2071,
+      2072,
+      2119,
+      2085,
+      2161,
+      2155,
+      2128,
+      2143
+    ]
+  },
+  {
+    "id": 56,
+    "name": "weaver",
+    "profession": "elementalist",
+    "minor_traits": [
+      2109,
+      2077,
+      2081
+    ],
+    "major_traits": [
+      2177,
+      2165,
+      2115,
+      2180,
+      2061,
+      2170,
+      2131,
+      2090,
+      2138
+    ]
+  },
+  {
+    "id": 57,
+    "name": "holosmith",
+    "profession": "engineer",
+    "minor_traits": [
+      2158,
+      2135,
+      2122
+    ],
+    "major_traits": [
+      2114,
+      2157,
+      2106,
+      2103,
+      2152,
+      2091,
+      2066,
+      2137,
+      2064
+    ]
+  },
+  {
+    "id": 58,
+    "name": "deadeye",
+    "profession": "thief",
+    "minor_traits": [
+      2171,
+      2172,
+      2084
+    ],
+    "major_traits": [
+      2145,
+      2173,
+      2136,
+      2118,
+      2078,
+      2160,
+      2111,
+      2093,
+      2146
+    ]
+  },
+  {
+    "id": 59,
+    "name": "mirage",
+    "profession": "mesmer",
+    "minor_traits": [
+      2150,
+      2069,
+      2117
+    ],
+    "major_traits": [
+      2141,
+      2082,
+      2110,
+      2178,
+      2174,
+      2098,
+      2070,
+      2113,
+      2169
+    ]
+  },
+  {
+    "id": 60,
+    "name": "scourge",
+    "profession": "necromancer",
+    "minor_traits": [
+      2147,
+      2121,
+      2096
+    ],
+    "major_traits": [
+      2167,
+      2074,
+      2102,
+      2059,
+      2067,
+      2123,
+      2112,
+      2164,
+      2080
+    ]
+  },
+  {
+    "id": 61,
+    "name": "spellbreaker",
+    "profession": "warrior",
+    "minor_traits": [
+      2175,
+      2162,
+      2130
+    ],
+    "major_traits": [
+      2107,
+      2153,
+      2140,
+      2126,
+      2097,
+      2095,
+      2163,
+      2168,
+      2060
+    ]
+  },
+  {
+    "id": 62,
+    "name": "firebrand",
+    "profession": "guardian",
+    "minor_traits": [
+      2089,
+      2062,
+      2148
+    ],
+    "major_traits": [
+      2075,
+      2101,
+      2086,
+      2063,
+      2076,
+      2116,
+      2105,
+      2179,
+      2159
+    ]
+  },
+  {
+    "id": 63,
+    "name": "renegade",
+    "profession": "revenant",
+    "minor_traits": [
+      2181,
+      2154,
+      2142
+    ],
+    "major_traits": [
+      2166,
+      2079,
+      2120,
+      2133,
+      2092,
+      2108,
+      2094,
+      2100,
+      2182
+    ]
+  },
+  {
+    "id": 64,
+    "name": "harbinger",
+    "profession": "necromancer",
+    "minor_traits": [
+      2183,
+      2186,
+      2217
+    ],
+    "major_traits": [
+      2188,
+      2219,
+      2185,
+      2192,
+      2220,
+      2209,
+      2218,
+      2194,
+      2203
+    ]
+  },
+  {
+    "id": 65,
+    "name": "willbender",
+    "profession": "guardian",
+    "minor_traits": [
+      2200,
+      2222,
+      2189
+    ],
+    "major_traits": [
+      2191,
+      2190,
+      2187,
+      2197,
+      2210,
+      2199,
+      2195,
+      2201,
+      2198
+    ]
+  },
+  {
+    "id": 66,
+    "name": "virtuoso",
+    "profession": "mesmer",
+    "minor_traits": [
+      2216,
+      2204,
+      2193
+    ],
+    "major_traits": [
+      2212,
+      2208,
+      2202,
+      2215,
+      2205,
+      2207,
+      2211,
+      2206,
+      2223
+    ]
+  },
+  {
+    "id": 67,
+    "name": "catalyst",
+    "profession": "elementalist",
+    "minor_traits": [
+      2227,
+      2250,
+      2231
+    ],
+    "major_traits": [
+      2230,
+      2252,
+      2224,
+      2247,
+      2249,
+      2234,
+      2233,
+      2241,
+      2251
+    ]
+  },
+  {
+    "id": 68,
+    "name": "bladesworn",
+    "profession": "warrior",
+    "minor_traits": [
+      2226,
+      2242,
+      2236
+    ],
+    "major_traits": [
+      2237,
+      2260,
+      2225,
+      2253,
+      2244,
+      2240,
+      2261,
+      2239,
+      2245
+    ]
+  },
+  {
+    "id": 69,
+    "name": "vindicator",
+    "profession": "revenant",
+    "minor_traits": [
+      2262,
+      2254,
+      2229
+    ],
+    "major_traits": [
+      2258,
+      2248,
+      2228,
+      2259,
+      2243,
+      2255,
+      2257,
+      2232,
+      2238
+    ]
+  }
+]

--- a/src/utils/mapping/traits.json
+++ b/src/utils/mapping/traits.json
@@ -1,1 +1,4251 @@
-[{"id":214,"name":"ragingstorm","profession":"elementalist"},{"id":221,"name":"zephyrsspeed","profession":"elementalist"},{"id":222,"name":"electricdischarge","profession":"elementalist"},{"id":223,"name":"aeromancerstraining","profession":"elementalist"},{"id":224,"name":"onewithair","profession":"elementalist"},{"id":226,"name":"bolttotheheart","profession":"elementalist"},{"id":227,"name":"zephyrsboon","profession":"elementalist"},{"id":229,"name":"inscription","profession":"elementalist"},{"id":232,"name":"ferociouswinds","profession":"elementalist"},{"id":238,"name":"evasivearcana","profession":"elementalist"},{"id":253,"name":"arcaneprecision","profession":"elementalist"},{"id":257,"name":"finalshielding","profession":"elementalist"},{"id":263,"name":"elementalsurge","profession":"elementalist"},{"id":264,"name":"elementalattunement","profession":"elementalist"},{"id":265,"name":"arcaneresurrection","profession":"elementalist"},{"id":266,"name":"renewingstamina","profession":"elementalist"},{"id":268,"name":"arcaneprowess","profession":"elementalist"},{"id":275,"name":"strengthofstone","profession":"elementalist"},{"id":277,"name":"earthenblessing","profession":"elementalist"},{"id":278,"name":"stoneflesh","profession":"elementalist"},{"id":279,"name":"earthenblast","profession":"elementalist"},{"id":280,"name":"geomancerstraining","profession":"elementalist"},{"id":281,"name":"rocksolid","profession":"elementalist"},{"id":282,"name":"earthsembrace","profession":"elementalist"},{"id":287,"name":"writteninstone","profession":"elementalist"},{"id":289,"name":"elementalshielding","profession":"elementalist"},{"id":294,"name":"pyromancerspuissance","profession":"elementalist"},{"id":296,"name":"burningprecision","profession":"elementalist"},{"id":318,"name":"sunspot","profession":"elementalist"},{"id":319,"name":"pyromancerstraining","profession":"elementalist"},{"id":320,"name":"empoweringflame","profession":"elementalist"},{"id":325,"name":"burningrage","profession":"elementalist"},{"id":328,"name":"conjurer","profession":"elementalist"},{"id":334,"name":"poweroverwhelming","profession":"elementalist"},{"id":335,"name":"burningfire","profession":"elementalist"},{"id":340,"name":"smotheringauras","profession":"elementalist"},{"id":348,"name":"soothingice","profession":"elementalist"},{"id":349,"name":"flowlikewater","profession":"elementalist"},{"id":350,"name":"soothingmist","profession":"elementalist"},{"id":351,"name":"healingripple","profession":"elementalist"},{"id":358,"name":"cleansingwave","profession":"elementalist"},{"id":360,"name":"stopdropandroll","profession":"elementalist"},{"id":361,"name":"powerfulaura","profession":"elementalist"},{"id":362,"name":"cleansingwater","profession":"elementalist"},{"id":363,"name":"piercingshards","profession":"elementalist"},{"id":364,"name":"soothingdisruption","profession":"elementalist"},{"id":394,"name":"overshield","profession":"engineer"},{"id":396,"name":"invigoratingspeed","profession":"engineer"},{"id":413,"name":"compoundingchemicals","profession":"engineer"},{"id":429,"name":"shapedcharge","profession":"engineer"},{"id":432,"name":"explosiveentrance","profession":"engineer"},{"id":433,"name":"incendiarypowder","profession":"engineer"},{"id":445,"name":"mechalegs","profession":"engineer"},{"id":468,"name":"hiddenflask","profession":"engineer"},{"id":469,"name":"emergencyelixir","profession":"engineer"},{"id":470,"name":"backpackregenerator","profession":"engineer"},{"id":472,"name":"anticorrosionplating","profession":"engineer"},{"id":473,"name":"hgh","profession":"engineer"},{"id":482,"name":"aimassistedrocket","profession":"engineer"},{"id":487,"name":"transmute","profession":"engineer"},{"id":505,"name":"shrapnel","profession":"engineer"},{"id":507,"name":"autodefensebombdispenser","profession":"engineer"},{"id":508,"name":"reconstructionenclosure","profession":"engineer"},{"id":509,"name":"protectioninjection","profession":"engineer"},{"id":510,"name":"juggernaut","profession":"engineer"},{"id":512,"name":"streamlinedkits","profession":"engineer"},{"id":514,"name":"grenadier","profession":"engineer"},{"id":515,"name":"sharpshooter","profession":"engineer"},{"id":516,"name":"serratedsteel","profession":"engineer"},{"id":517,"name":"steelpackedpowder","profession":"engineer"},{"id":518,"name":"cleansingsynergy","profession":"engineer"},{"id":519,"name":"energyamplifier","profession":"engineer"},{"id":520,"name":"comebackcure","profession":"engineer"},{"id":521,"name":"healthinsurance","profession":"engineer"},{"id":523,"name":"adrenalimplant","profession":"engineer"},{"id":525,"name":"shortfuse","profession":"engineer"},{"id":526,"name":"modifiedammunition","profession":"engineer"},{"id":531,"name":"powerwrench","profession":"engineer"},{"id":532,"name":"staticdischarge","profession":"engineer"},{"id":536,"name":"hematicfocus","profession":"engineer"},{"id":549,"name":"pureofheart","profession":"guardian"},{"id":551,"name":"selflessdaring","profession":"guardian"},{"id":553,"name":"pureofvoice","profession":"guardian"},{"id":554,"name":"battlepresence","profession":"guardian"},{"id":557,"name":"honorablestaff","profession":"guardian"},{"id":558,"name":"writofpersistence","profession":"guardian"},{"id":559,"name":"protectivereviver","profession":"guardian"},{"id":562,"name":"empoweringmight","profession":"guardian"},{"id":563,"name":"wrathfulspirit","profession":"guardian"},{"id":564,"name":"vigorousprecision","profession":"guardian"},{"id":565,"name":"retribution","profession":"guardian"},{"id":566,"name":"righthandstrength","profession":"guardian"},{"id":567,"name":"radiantfire","profession":"guardian"},{"id":568,"name":"radiantpower","profession":"guardian"},{"id":571,"name":"renewedjustice","profession":"guardian"},{"id":572,"name":"justiceisblind","profession":"guardian"},{"id":574,"name":"healersresolution","profession":"guardian"},{"id":577,"name":"innerfire","profession":"guardian"},{"id":578,"name":"wrathofjustice","profession":"guardian"},{"id":579,"name":"perfectinscriptions","profession":"guardian"},{"id":580,"name":"stalwartdefender","profession":"guardian"},{"id":581,"name":"smitersboon","profession":"guardian"},{"id":582,"name":"valorousdefense","profession":"guardian"},{"id":583,"name":"mightoftheprotector","profession":"guardian"},{"id":584,"name":"strengthinnumbers","profession":"guardian"},{"id":585,"name":"altruistichealing","profession":"guardian"},{"id":586,"name":"monksfocus","profession":"guardian"},{"id":587,"name":"glacialheart","profession":"guardian"},{"id":588,"name":"strengthofthefallen","profession":"guardian"},{"id":589,"name":"tenaciousdefense","profession":"guardian"},{"id":594,"name":"steadfastcourage","profession":"guardian"},{"id":603,"name":"inspiringvirtue","profession":"guardian"},{"id":604,"name":"virtueofresolution","profession":"guardian"},{"id":610,"name":"absoluteresolve","profession":"guardian"},{"id":612,"name":"indomitablecourage","profession":"guardian"},{"id":617,"name":"masterofconsecrations","profession":"guardian"},{"id":620,"name":"powerofthevirtuous","profession":"guardian"},{"id":621,"name":"inspiredvirtue","profession":"guardian"},{"id":622,"name":"permeatingwrath","profession":"guardian"},{"id":624,"name":"unscathedcontender","profession":"guardian"},{"id":625,"name":"resolutesubconscious","profession":"guardian"},{"id":628,"name":"furiousfocus","profession":"guardian"},{"id":633,"name":"focusmastery","profession":"guardian"},{"id":634,"name":"fierywrath","profession":"guardian"},{"id":635,"name":"eternalarmory","profession":"guardian"},{"id":637,"name":"shatteredaegis","profession":"guardian"},{"id":646,"name":"symbolicexposure","profession":"guardian"},{"id":648,"name":"zealotsresolution","profession":"guardian"},{"id":649,"name":"symbolicpower","profession":"guardian"},{"id":653,"name":"zealousblade","profession":"guardian"},{"id":654,"name":"protectorsrestoration","profession":"guardian"},{"id":666,"name":"metaphysicalrejuvenation","profession":"mesmer"},{"id":667,"name":"illusionarymembrane","profession":"mesmer"},{"id":668,"name":"chaotictransference","profession":"mesmer"},{"id":669,"name":"chaoticpotency","profession":"mesmer"},{"id":670,"name":"methodofmadness","profession":"mesmer"},{"id":671,"name":"chaoticinterruption","profession":"mesmer"},{"id":673,"name":"auspiciousanguish","profession":"mesmer"},{"id":674,"name":"prismaticunderstanding","profession":"mesmer"},{"id":675,"name":"illusionarydefense","profession":"mesmer"},{"id":677,"name":"masterofmanipulation","profession":"mesmer"},{"id":680,"name":"mentalanguish","profession":"mesmer"},{"id":681,"name":"viciousexpression","profession":"mesmer"},{"id":682,"name":"empoweredillusions","profession":"mesmer"},{"id":685,"name":"illusionofvulnerability","profession":"mesmer"},{"id":686,"name":"bountifulblades","profession":"mesmer"},{"id":687,"name":"rendingshatter","profession":"mesmer"},{"id":691,"name":"thepledge","profession":"mesmer"},{"id":692,"name":"superioritycomplex","profession":"mesmer"},{"id":693,"name":"shatteredconcentration","profession":"mesmer"},{"id":694,"name":"dazzling","profession":"mesmer"},{"id":700,"name":"duelistsdiscipline","profession":"mesmer"},{"id":701,"name":"phantasmalfury","profession":"mesmer"},{"id":704,"name":"deceptiveevasion","profession":"mesmer"},{"id":705,"name":"desperatedecoy","profession":"mesmer"},{"id":706,"name":"criticalinfusion","profession":"mesmer"},{"id":707,"name":"masterfencer","profession":"mesmer"},{"id":708,"name":"fencersfinesse","profession":"mesmer"},{"id":710,"name":"sharperimages","profession":"mesmer"},{"id":712,"name":"furiousinterruption","profession":"mesmer"},{"id":713,"name":"egotism","profession":"mesmer"},{"id":721,"name":"shatterstorm","profession":"mesmer"},{"id":722,"name":"escapeartist","profession":"mesmer"},{"id":723,"name":"compoundingpower","profession":"mesmer"},{"id":729,"name":"phantasmalhaste","profession":"mesmer"},{"id":731,"name":"masterofmisdirection","profession":"mesmer"},{"id":733,"name":"phantasmalforce","profession":"mesmer"},{"id":734,"name":"cryofpain","profession":"mesmer"},{"id":738,"name":"restorativemantras","profession":"mesmer"},{"id":740,"name":"restorativeillusions","profession":"mesmer"},{"id":744,"name":"sympatheticvisage","profession":"mesmer"},{"id":751,"name":"wardensfeedback","profession":"mesmer"},{"id":752,"name":"blurredinscriptions","profession":"mesmer"},{"id":753,"name":"malicioussorcery","profession":"mesmer"},{"id":756,"name":"medicsfeedback","profession":"mesmer"},{"id":757,"name":"menderspurity","profession":"mesmer"},{"id":778,"name":"transfusion","profession":"necromancer"},{"id":780,"name":"ritualoflife","profession":"necromancer"},{"id":782,"name":"bloodbank","profession":"necromancer"},{"id":783,"name":"vampiric","profession":"necromancer"},{"id":788,"name":"quickeningthirst","profession":"necromancer"},{"id":789,"name":"lifefromdeath","profession":"necromancer"},{"id":792,"name":"markofevasion","profession":"necromancer"},{"id":799,"name":"bansheeswail","profession":"necromancer"},{"id":801,"name":"lingeringcurse","profession":"necromancer"},{"id":802,"name":"barbedprecision","profession":"necromancer"},{"id":803,"name":"furiousdemise","profession":"necromancer"},{"id":810,"name":"targettheweak","profession":"necromancer"},{"id":812,"name":"terror","profession":"necromancer"},{"id":813,"name":"weakeningshroud","profession":"necromancer"},{"id":815,"name":"chillingdarkness","profession":"necromancer"},{"id":816,"name":"masterofcorruption","profession":"necromancer"},{"id":820,"name":"fleshofthemaster","profession":"necromancer"},{"id":829,"name":"awakenthepain","profession":"necromancer"},{"id":839,"name":"soulcomprehension","profession":"necromancer"},{"id":842,"name":"deathnova","profession":"necromancer"},{"id":853,"name":"closetodeath","profession":"necromancer"},{"id":855,"name":"deadlystrength","profession":"necromancer"},{"id":856,"name":"armoredshroud","profession":"necromancer"},{"id":857,"name":"putriddefense","profession":"necromancer"},{"id":858,"name":"necromanticcorruption","profession":"necromancer"},{"id":860,"name":"darkdefiance","profession":"necromancer"},{"id":861,"name":"vitalpersistence","profession":"necromancer"},{"id":874,"name":"soulbattery","profession":"necromancer"},{"id":875,"name":"unyieldingblast","profession":"necromancer"},{"id":887,"name":"gluttony","profession":"necromancer"},{"id":888,"name":"speedofshadows","profession":"necromancer"},{"id":889,"name":"eternallife","profession":"necromancer"},{"id":891,"name":"sinistershroud","profession":"necromancer"},{"id":892,"name":"fearofdeath","profession":"necromancer"},{"id":893,"name":"deathperception","profession":"necromancer"},{"id":894,"name":"soulbarbs","profession":"necromancer"},{"id":898,"name":"soulmarks","profession":"necromancer"},{"id":899,"name":"chillofdeath","profession":"necromancer"},{"id":903,"name":"spitefulspirit","profession":"necromancer"},{"id":905,"name":"dhuumfire","profession":"necromancer"},{"id":909,"name":"signetsofsuffering","profession":"necromancer"},{"id":913,"name":"reapersmight","profession":"necromancer"},{"id":914,"name":"spitefultalisman","profession":"necromancer"},{"id":915,"name":"deathsembrace","profession":"necromancer"},{"id":916,"name":"spitefulrenewal","profession":"necromancer"},{"id":917,"name":"siphonedpower","profession":"necromancer"},{"id":919,"name":"dread","profession":"necromancer"},{"id":964,"name":"windbornenotes","profession":"ranger"},{"id":965,"name":"spiritedarrival","profession":"ranger"},{"id":968,"name":"zephyrsspeed","profession":"ranger"},{"id":970,"name":"naturalhealing","profession":"ranger"},{"id":974,"name":"loudwhistle","profession":"ranger"},{"id":975,"name":"wiltingstrike","profession":"ranger"},{"id":978,"name":"instinctivereaction","profession":"ranger"},{"id":986,"name":"clarionbond","profession":"ranger"},{"id":996,"name":"predatorsonslaught","profession":"ranger"},{"id":1000,"name":"farsighted","profession":"ranger"},{"id":1001,"name":"brutishseals","profession":"ranger"},{"id":1009,"name":"alphafocus","profession":"ranger"},{"id":1010,"name":"openingstrike","profession":"ranger"},{"id":1011,"name":"precisestrike","profession":"ranger"},{"id":1014,"name":"huntersgaze","profession":"ranger"},{"id":1015,"name":"remorseless","profession":"ranger"},{"id":1016,"name":"spotter","profession":"ranger"},{"id":1021,"name":"stoneform","profession":"ranger"},{"id":1038,"name":"naturesvengeance","profession":"ranger"},{"id":1047,"name":"twohandedtraining","profession":"ranger"},{"id":1054,"name":"evasivepurity","profession":"ranger"},{"id":1055,"name":"rejuvenation","profession":"ranger"},{"id":1056,"name":"fortifyingbond","profession":"ranger"},{"id":1059,"name":"lingeringmagic","profession":"ranger"},{"id":1060,"name":"alliesaid","profession":"ranger"},{"id":1062,"name":"bountifulhunter","profession":"ranger"},{"id":1064,"name":"quickdraw","profession":"ranger"},{"id":1065,"name":"petsprowess","profession":"ranger"},{"id":1066,"name":"honedaxes","profession":"ranger"},{"id":1067,"name":"primalreflexes","profession":"ranger"},{"id":1068,"name":"hunterstactics","profession":"ranger"},{"id":1069,"name":"sharpenededges","profession":"ranger"},{"id":1070,"name":"momentofclarity","profession":"ranger"},{"id":1072,"name":"potentally","profession":"ranger"},{"id":1075,"name":"trappersexpertise","profession":"ranger"},{"id":1080,"name":"tailwind","profession":"ranger"},{"id":1083,"name":"furiousgrip","profession":"ranger"},{"id":1086,"name":"oakheartsalve","profession":"ranger"},{"id":1089,"name":"ruggedgrowth","profession":"ranger"},{"id":1090,"name":"companionsdefense","profession":"ranger"},{"id":1094,"name":"empathicbond","profession":"ranger"},{"id":1096,"name":"naturalvigor","profession":"ranger"},{"id":1098,"name":"childofearth","profession":"ranger"},{"id":1099,"name":"tastefordanger","profession":"ranger"},{"id":1100,"name":"sharedanguish","profession":"ranger"},{"id":1101,"name":"ambidexterity","profession":"ranger"},{"id":1112,"name":"instantreflexes","profession":"thief"},{"id":1130,"name":"leechingvenoms","profession":"thief"},{"id":1134,"name":"cloakedinshadow","profession":"thief"},{"id":1135,"name":"shadowsrejuvenation","profession":"thief"},{"id":1136,"name":"meldwithshadows","profession":"thief"},{"id":1137,"name":"kleptomaniac","profession":"thief"},{"id":1157,"name":"leadattacks","profession":"thief"},{"id":1158,"name":"sleightofhand","profession":"thief"},{"id":1159,"name":"uncatchable","profession":"thief"},{"id":1160,"name":"mercifulambush","profession":"thief"},{"id":1162,"name":"rendingshade","profession":"thief"},{"id":1163,"name":"thrillofthecrime","profession":"thief"},{"id":1164,"name":"deadlyambition","profession":"thief"},{"id":1167,"name":"improvisation","profession":"thief"},{"id":1169,"name":"eventheodds","profession":"thief"},{"id":1170,"name":"sunderingshade","profession":"thief"},{"id":1187,"name":"quickpockets","profession":"thief"},{"id":1190,"name":"pressurestriking","profession":"thief"},{"id":1192,"name":"swindlersequilibrium","profession":"thief"},{"id":1209,"name":"assassinsfury","profession":"thief"},{"id":1210,"name":"unrelentingstrikes","profession":"thief"},{"id":1215,"name":"hiddenkiller","profession":"thief"},{"id":1232,"name":"preparedness","profession":"thief"},{"id":1234,"name":"felinegrace","profession":"thief"},{"id":1237,"name":"painresponse","profession":"thief"},{"id":1238,"name":"assassinsreward","profession":"thief"},{"id":1240,"name":"expeditiousdodger","profession":"thief"},{"id":1241,"name":"guardedinitiation","profession":"thief"},{"id":1242,"name":"endlessstamina","profession":"thief"},{"id":1245,"name":"daggertraining","profession":"thief"},{"id":1252,"name":"burstofagility","profession":"thief"},{"id":1257,"name":"exposedweakness","profession":"thief"},{"id":1267,"name":"signetsofpower","profession":"thief"},{"id":1268,"name":"twinfangs","profession":"thief"},{"id":1269,"name":"executioner","profession":"thief"},{"id":1272,"name":"practicedtolerance","profession":"thief"},{"id":1276,"name":"mug","profession":"thief"},{"id":1277,"name":"bountifultheft","profession":"thief"},{"id":1279,"name":"serpentstouch","profession":"thief"},{"id":1280,"name":"lotuspoison","profession":"thief"},{"id":1281,"name":"keenobserver","profession":"thief"},{"id":1282,"name":"ferociousstrikes","profession":"thief"},{"id":1284,"name":"hiddenthief","profession":"thief"},{"id":1286,"name":"trickster","profession":"thief"},{"id":1289,"name":"vigorousrecovery","profession":"thief"},{"id":1290,"name":"hardtocatch","profession":"thief"},{"id":1291,"name":"potentpoison","profession":"thief"},{"id":1292,"name":"panicstrike","profession":"thief"},{"id":1293,"name":"shadowsembrace","profession":"thief"},{"id":1294,"name":"concealingrestoration","profession":"thief"},{"id":1295,"name":"upperhand","profession":"thief"},{"id":1297,"name":"shadowsavior","profession":"thief"},{"id":1299,"name":"deadlyaim","profession":"thief"},{"id":1300,"name":"flickeringshadows","profession":"thief"},{"id":1315,"name":"unsuspectingfoe","profession":"warrior"},{"id":1316,"name":"sunderingburst","profession":"warrior"},{"id":1317,"name":"heightenedfocus","profession":"warrior"},{"id":1329,"name":"crackshot","profession":"warrior"},{"id":1333,"name":"blademaster","profession":"warrior"},{"id":1334,"name":"opportunist","profession":"warrior"},{"id":1336,"name":"burstprecision","profession":"warrior"},{"id":1337,"name":"bloodlust","profession":"warrior"},{"id":1338,"name":"forcefulgreatsword","profession":"warrior"},{"id":1342,"name":"furiousburst","profession":"warrior"},{"id":1343,"name":"deepstrikes","profession":"warrior"},{"id":1344,"name":"signetmastery","profession":"warrior"},{"id":1346,"name":"furious","profession":"warrior"},{"id":1348,"name":"adrenalhealth","profession":"warrior"},{"id":1350,"name":"thickskin","profession":"warrior"},{"id":1367,"name":"sunderingmace","profession":"warrior"},{"id":1368,"name":"defypain","profession":"warrior"},{"id":1369,"name":"axemastery","profession":"warrior"},{"id":1372,"name":"culltheweak","profession":"warrior"},{"id":1375,"name":"laststand","profession":"warrior"},{"id":1376,"name":"shieldmaster","profession":"warrior"},{"id":1379,"name":"armoredattack","profession":"warrior"},{"id":1380,"name":"hardenedarmor","profession":"warrior"},{"id":1381,"name":"vengefulreturn","profession":"warrior"},{"id":1413,"name":"warriorssprint","profession":"warrior"},{"id":1415,"name":"versatilerage","profession":"warrior"},{"id":1416,"name":"fasthands","profession":"warrior"},{"id":1417,"name":"versatilepower","profession":"warrior"},{"id":1437,"name":"berserkerspower","profession":"warrior"},{"id":1440,"name":"mercilesshammer","profession":"warrior"},{"id":1444,"name":"peakperformance","profession":"warrior"},{"id":1446,"name":"recklessdodge","profession":"warrior"},{"id":1447,"name":"bravestride","profession":"warrior"},{"id":1448,"name":"buildingmomentum","profession":"warrior"},{"id":1449,"name":"greatfortitude","profession":"warrior"},{"id":1451,"name":"restorativestrength","profession":"warrior"},{"id":1453,"name":"pinnacleofstrength","profession":"warrior"},{"id":1454,"name":"mightmakesright","profession":"warrior"},{"id":1455,"name":"woundingprecision","profession":"warrior"},{"id":1469,"name":"legspecialist","profession":"warrior"},{"id":1470,"name":"vigorousshouts","profession":"warrior"},{"id":1471,"name":"roaringreveille","profession":"warrior"},{"id":1474,"name":"soldierscomfort","profession":"warrior"},{"id":1479,"name":"shrugitoff","profession":"warrior"},{"id":1480,"name":"marchingorders","profession":"warrior"},{"id":1481,"name":"mendingmight","profession":"warrior"},{"id":1482,"name":"empowerallies","profession":"warrior"},{"id":1484,"name":"doubledstandards","profession":"warrior"},{"id":1485,"name":"empowered","profession":"warrior"},{"id":1486,"name":"warriorscunning","profession":"warrior"},{"id":1487,"name":"arcanerestoration","profession":"elementalist"},{"id":1488,"name":"doggedmarch","profession":"warrior"},{"id":1489,"name":"destructionoftheempowered","profession":"warrior"},{"id":1502,"name":"stormsoul","profession":"elementalist"},{"id":1503,"name":"freshair","profession":"elementalist"},{"id":1507,"name":"serratedstones","profession":"elementalist"},{"id":1508,"name":"diamondskin","profession":"elementalist"},{"id":1510,"name":"persistingflames","profession":"elementalist"},{"id":1511,"name":"bountifulpower","profession":"elementalist"},{"id":1541,"name":"flashbang","profession":"engineer"},{"id":1556,"name":"kindledzeal","profession":"guardian"},{"id":1606,"name":"resoundingtimbre","profession":"ranger"},{"id":1649,"name":"cleansingire","profession":"warrior"},{"id":1657,"name":"burstmastery","profession":"warrior"},{"id":1667,"name":"martialcadence","profession":"warrior"},{"id":1672,"name":"lightningrod","profession":"elementalist"},{"id":1673,"name":"elementallockdown","profession":"elementalist"},{"id":1674,"name":"stoneheart","profession":"elementalist"},{"id":1675,"name":"blindingashes","profession":"elementalist"},{"id":1676,"name":"aquamancerstraining","profession":"elementalist"},{"id":1678,"name":"experimentalturrets","profession":"engineer"},{"id":1679,"name":"gadgeteer","profession":"engineer"},{"id":1680,"name":"bunkerdown","profession":"engineer"},{"id":1682,"name":"forceofwill","profession":"guardian"},{"id":1683,"name":"righteousinstincts","profession":"guardian"},{"id":1684,"name":"communaldefenses","profession":"guardian"},{"id":1685,"name":"purityofbody","profession":"guardian"},{"id":1686,"name":"amplifiedwrath","profession":"guardian"},{"id":1687,"name":"bountifuldisillusionment","profession":"mesmer"},{"id":1688,"name":"powerblock","profession":"mesmer"},{"id":1690,"name":"maimthedisillusioned","profession":"mesmer"},{"id":1692,"name":"unholymartyr","profession":"necromancer"},{"id":1693,"name":"pathofcorruption","profession":"necromancer"},{"id":1694,"name":"unholysanctuary","profession":"necromancer"},{"id":1696,"name":"parasiticcontagion","profession":"necromancer"},{"id":1697,"name":"invigoratingbond","profession":"ranger"},{"id":1698,"name":"leadthewind","profession":"ranger"},{"id":1699,"name":"wildernessknowledge","profession":"ranger"},{"id":1700,"name":"stridersdefense","profession":"ranger"},{"id":1701,"name":"poisonmaster","profession":"ranger"},{"id":1702,"name":"invigoratingprecision","profession":"thief"},{"id":1703,"name":"dontstop","profession":"thief"},{"id":1704,"name":"revealedtraining","profession":"thief"},{"id":1705,"name":"shadowsiphoning","profession":"thief"},{"id":1706,"name":"deadlyambush","profession":"thief"},{"id":1707,"name":"dualwielding","profession":"warrior"},{"id":1708,"name":"rousingresilience","profession":"warrior"},{"id":1709,"name":"brawlersrecovery","profession":"warrior"},{"id":1711,"name":"phalanxstrength","profession":"warrior"},{"id":1713,"name":"determinedresolution","profession":"revenant"},{"id":1714,"name":"pactofpain","profession":"revenant"},{"id":1715,"name":"brutality","profession":"revenant"},{"id":1716,"name":"risingmomentum","profession":"revenant"},{"id":1719,"name":"roilingmists","profession":"revenant"},{"id":1720,"name":"fiendishtenacity","profession":"revenant"},{"id":1721,"name":"permeatingpestilence","profession":"revenant"},{"id":1724,"name":"destructiveimpulses","profession":"revenant"},{"id":1726,"name":"demonicresistance","profession":"revenant"},{"id":1727,"name":"abyssalchill","profession":"revenant"},{"id":1728,"name":"closequarters","profession":"revenant"},{"id":1730,"name":"hardeningpersistence","profession":"revenant"},{"id":1732,"name":"cleansingchannel","profession":"revenant"},{"id":1737,"name":"draconicfortitude","profession":"revenant"},{"id":1738,"name":"sharedempowerment","profession":"revenant"},{"id":1740,"name":"dwarvenbattletraining","profession":"revenant"},{"id":1741,"name":"replenishingdespair","profession":"revenant"},{"id":1743,"name":"shiningaspects","profession":"revenant"},{"id":1744,"name":"yearningempowerment","profession":"revenant"},{"id":1746,"name":"elevatedcompassion","profession":"revenant"},{"id":1749,"name":"songofthemists","profession":"revenant"},{"id":1754,"name":"danceofdeath","profession":"revenant"},{"id":1755,"name":"battlescarred","profession":"revenant"},{"id":1757,"name":"unwaveringavoidance","profession":"revenant"},{"id":1758,"name":"ferociousaggression","profession":"revenant"},{"id":1760,"name":"rapidflow","profession":"revenant"},{"id":1761,"name":"risingtide","profession":"revenant"},{"id":1765,"name":"notoriety","profession":"revenant"},{"id":1766,"name":"eyeforaneye","profession":"revenant"},{"id":1767,"name":"unsuspectingstrikes","profession":"revenant"},{"id":1769,"name":"containedtemper","profession":"revenant"},{"id":1770,"name":"versedinstone","profession":"revenant"},{"id":1772,"name":"draconicecho","profession":"revenant"},{"id":1774,"name":"spiritboon","profession":"revenant"},{"id":1776,"name":"aggressiveagility","profession":"revenant"},{"id":1777,"name":"crystalharbinger","profession":"revenant"},{"id":1778,"name":"invokersrage","profession":"revenant"},{"id":1779,"name":"viciousreprisal","profession":"revenant"},{"id":1781,"name":"incensedresponse","profession":"revenant"},{"id":1782,"name":"resoluteevasion","profession":"revenant"},{"id":1783,"name":"enduringrecovery","profession":"revenant"},{"id":1784,"name":"glaringresolve","profession":"revenant"},{"id":1786,"name":"assassinspresence","profession":"revenant"},{"id":1788,"name":"reinforcedpotency","profession":"revenant"},{"id":1789,"name":"demonicdefiance","profession":"revenant"},{"id":1790,"name":"steadfastrejuvenation","profession":"revenant"},{"id":1791,"name":"chargedmists","profession":"revenant"},{"id":1792,"name":"targeteddestruction","profession":"revenant"},{"id":1793,"name":"acolyteoftorment","profession":"revenant"},{"id":1795,"name":"diabolicinferno","profession":"revenant"},{"id":1799,"name":"invokingtorment","profession":"revenant"},{"id":1800,"name":"swifttermination","profession":"revenant"},{"id":1801,"name":"seethingmalice","profession":"revenant"},{"id":1802,"name":"thrillofcombat","profession":"revenant"},{"id":1803,"name":"forcefulpersistence","profession":"revenant"},{"id":1806,"name":"corevalue","profession":"revenant"},{"id":1808,"name":"exposedefenses","profession":"revenant"},{"id":1810,"name":"spiritualreckoning","profession":"revenant"},{"id":1811,"name":"planarprotection","profession":"revenant"},{"id":1813,"name":"eldersrespite","profession":"revenant"},{"id":1814,"name":"serenerejuvenation","profession":"revenant"},{"id":1815,"name":"generousabundance","profession":"revenant"},{"id":1816,"name":"healersgift","profession":"revenant"},{"id":1817,"name":"resilientspirit","profession":"revenant"},{"id":1818,"name":"invokingharmony","profession":"revenant"},{"id":1819,"name":"wordsofcensure","profession":"revenant"},{"id":1820,"name":"selflessamplification","profession":"revenant"},{"id":1821,"name":"lifeattunement","profession":"revenant"},{"id":1822,"name":"tranquilbalance","profession":"revenant"},{"id":1823,"name":"vitalblessing","profession":"revenant"},{"id":1824,"name":"blindingtruths","profession":"revenant"},{"id":1825,"name":"unyieldingdevotion","profession":"revenant"},{"id":1826,"name":"longbowproficiency","profession":"guardian"},{"id":1829,"name":"torchproficiency","profession":"warrior"},{"id":1831,"name":"primalrage","profession":"warrior"},{"id":1832,"name":"takedownround","profession":"engineer"},{"id":1833,"name":"lotustraining","profession":"thief"},{"id":1834,"name":"soothingdetonation","profession":"engineer"},{"id":1835,"name":"zealotsaggression","profession":"guardian"},{"id":1837,"name":"endurancethief","profession":"thief"},{"id":1838,"name":"delayedreactions","profession":"mesmer"},{"id":1839,"name":"transcendenttempest","profession":"elementalist"},{"id":1844,"name":"vampiricpresence","profession":"necromancer"},{"id":1846,"name":"hiddenbarbs","profession":"ranger"},{"id":1848,"name":"virtuousaction","profession":"guardian"},{"id":1849,"name":"appliedforce","profession":"engineer"},{"id":1852,"name":"inspiringdistortion","profession":"mesmer"},{"id":1854,"name":"ironblooded","profession":"engineer"},{"id":1856,"name":"kineticbattery","profession":"engineer"},{"id":1859,"name":"timemarcheson","profession":"mesmer"},{"id":1860,"name":"objectinmotion","profession":"engineer"},{"id":1861,"name":"gofortheeyes","profession":"ranger"},{"id":1862,"name":"livevicariously","profession":"ranger"},{"id":1863,"name":"bitterchill","profession":"necromancer"},{"id":1865,"name":"chaoticpersistence","profession":"mesmer"},{"id":1866,"name":"illusionaryinspiration","profession":"mesmer"},{"id":1867,"name":"massmomentum","profession":"engineer"},{"id":1868,"name":"druidicclarity","profession":"ranger"},{"id":1869,"name":"persistenceofmemory","profession":"mesmer"},{"id":1871,"name":"purityofpurpose","profession":"engineer"},{"id":1872,"name":"mechanizeddeployment","profession":"engineer"},{"id":1874,"name":"celestialbeing","profession":"ranger"},{"id":1876,"name":"bloodbond","profession":"necromancer"},{"id":1877,"name":"impactsavant","profession":"engineer"},{"id":1878,"name":"chemicalrounds","profession":"engineer"},{"id":1879,"name":"shiversofdread","profession":"necromancer"},{"id":1882,"name":"glasscannon","profession":"engineer"},{"id":1883,"name":"insidiousdisruption","profession":"necromancer"},{"id":1884,"name":"staffmaster","profession":"thief"},{"id":1886,"name":"unstableconduit","profession":"elementalist"},{"id":1887,"name":"weakeningstrikes","profession":"thief"},{"id":1888,"name":"viciousquarry","profession":"ranger"},{"id":1889,"name":"blindingdissipation","profession":"mesmer"},{"id":1890,"name":"chronophantasma","profession":"mesmer"},{"id":1891,"name":"tempestuousaria","profession":"elementalist"},{"id":1892,"name":"explosivetemper","profession":"engineer"},{"id":1893,"name":"havocspecialist","profession":"thief"},{"id":1896,"name":"defendersdogma","profession":"guardian"},{"id":1898,"name":"piercinglight","profession":"guardian"},{"id":1899,"name":"invigoratedbulwark","profession":"guardian"},{"id":1900,"name":"packalpha","profession":"ranger"},{"id":1901,"name":"automatedmedicalresponse","profession":"engineer"},{"id":1902,"name":"harmoniousconduit","profession":"elementalist"},{"id":1904,"name":"noquarter","profession":"thief"},{"id":1905,"name":"shroudknight","profession":"necromancer"},{"id":1908,"name":"huntersfortification","profession":"guardian"},{"id":1910,"name":"shieldproficiency","profession":"mesmer"},{"id":1911,"name":"soaringdevastation","profession":"guardian"},{"id":1912,"name":"lightonyourfeet","profession":"ranger"},{"id":1913,"name":"illusionaryreversion","profession":"mesmer"},{"id":1914,"name":"highcaliber","profession":"engineer"},{"id":1915,"name":"healingprism","profession":"mesmer"},{"id":1916,"name":"medicaldispersionfield","profession":"engineer"},{"id":1917,"name":"gyroscopicacceleration","profession":"engineer"},{"id":1919,"name":"deathlychill","profession":"necromancer"},{"id":1922,"name":"shroudedremoval","profession":"necromancer"},{"id":1923,"name":"noscope","profession":"engineer"},{"id":1925,"name":"zealousscepter","profession":"guardian"},{"id":1926,"name":"pureofsight","profession":"guardian"},{"id":1927,"name":"flowoftime","profession":"mesmer"},{"id":1928,"name":"bloodyroar","profession":"warrior"},{"id":1929,"name":"beyondtheveil","profession":"necromancer"},{"id":1930,"name":"sanguinearray","profession":"engineer"},{"id":1931,"name":"lastrites","profession":"necromancer"},{"id":1932,"name":"blightersboon","profession":"necromancer"},{"id":1933,"name":"maraudersresilience","profession":"thief"},{"id":1935,"name":"primalechoes","profession":"ranger"},{"id":1936,"name":"excessiveenergy","profession":"engineer"},{"id":1938,"name":"gatheredfocus","profession":"elementalist"},{"id":1940,"name":"corruptersfervor","profession":"necromancer"},{"id":1941,"name":"fragility","profession":"mesmer"},{"id":1942,"name":"losttime","profession":"mesmer"},{"id":1943,"name":"bulwark","profession":"guardian"},{"id":1944,"name":"blastshield","profession":"engineer"},{"id":1945,"name":"beastlywarden","profession":"ranger"},{"id":1946,"name":"lockon","profession":"engineer"},{"id":1947,"name":"bigboomer","profession":"engineer"},{"id":1948,"name":"hardyconduit","profession":"elementalist"},{"id":1949,"name":"brawlerstenacity","profession":"thief"},{"id":1950,"name":"ineptitude","profession":"mesmer"},{"id":1951,"name":"hammerproficiency","profession":"engineer"},{"id":1952,"name":"galesong","profession":"elementalist"},{"id":1954,"name":"damagedampener","profession":"engineer"},{"id":1955,"name":"biggamehunter","profession":"guardian"},{"id":1957,"name":"staffproficiency","profession":"thief"},{"id":1959,"name":"functiongyro","profession":"engineer"},{"id":1960,"name":"evasivemirror","profession":"mesmer"},{"id":1962,"name":"latentstamina","profession":"elementalist"},{"id":1963,"name":"heavylight","profession":"guardian"},{"id":1964,"name":"unhinderedcombatant","profession":"thief"},{"id":1965,"name":"staffproficiency","profession":"ranger"},{"id":1969,"name":"souleater","profession":"necromancer"},{"id":1971,"name":"systemshocker","profession":"engineer"},{"id":1974,"name":"auguryofdeath","profession":"necromancer"},{"id":1975,"name":"impactingdisruption","profession":"thief"},{"id":1977,"name":"savageinstinct","profession":"warrior"},{"id":1978,"name":"improvedalacrity","profession":"mesmer"},{"id":1979,"name":"optimizedactivation","profession":"engineer"},{"id":1980,"name":"protectedphantasms","profession":"mesmer"},{"id":1981,"name":"adaptivearmor","profession":"engineer"},{"id":1983,"name":"dulledsenses","profession":"guardian"},{"id":1984,"name":"pinpointdistribution","profession":"engineer"},{"id":1985,"name":"greatswordproficiency","profession":"necromancer"},{"id":1986,"name":"elementalbastion","profession":"elementalist"},{"id":1987,"name":"allswellthatendswell","profession":"mesmer"},{"id":1988,"name":"protectiveward","profession":"ranger"},{"id":1992,"name":"naturalmender","profession":"ranger"},{"id":1993,"name":"burstofaggression","profession":"warrior"},{"id":1994,"name":"physicalsupremacy","profession":"thief"},{"id":1995,"name":"timecatchesup","profession":"mesmer"},{"id":1997,"name":"reactivelenses","profession":"engineer"},{"id":1999,"name":"expertexamination","profession":"engineer"},{"id":2000,"name":"bodyblow","profession":"warrior"},{"id":2001,"name":"verdantetching","profession":"ranger"},{"id":2002,"name":"deadoralive","profession":"warrior"},{"id":2004,"name":"elementalenchantment","profession":"elementalist"},{"id":2005,"name":"mentaldefense","profession":"mesmer"},{"id":2006,"name":"thermalvision","profession":"engineer"},{"id":2008,"name":"chillingvictory","profession":"necromancer"},{"id":2009,"name":"dangertime","profession":"mesmer"},{"id":2011,"name":"bloodreaction","profession":"warrior"},{"id":2013,"name":"plaguesending","profession":"necromancer"},{"id":2014,"name":"speedofsynergy","profession":"engineer"},{"id":2015,"name":"invigoratingtorrents","profession":"elementalist"},{"id":2016,"name":"cultivatedsynergy","profession":"ranger"},{"id":2017,"name":"symbolicavenger","profession":"guardian"},{"id":2018,"name":"coldshoulder","profession":"necromancer"},{"id":2020,"name":"chillingnova","profession":"necromancer"},{"id":2021,"name":"reapersonslaught","profession":"necromancer"},{"id":2022,"name":"seizethemoment","profession":"mesmer"},{"id":2023,"name":"escapistsfortitude","profession":"thief"},{"id":2025,"name":"singularity","profession":"elementalist"},{"id":2026,"name":"relentlesspursuit","profession":"necromancer"},{"id":2028,"name":"soothingpower","profession":"elementalist"},{"id":2030,"name":"timesplitter","profession":"mesmer"},{"id":2031,"name":"decimatedefenses","profession":"necromancer"},{"id":2032,"name":"refinedtoxins","profession":"ranger"},{"id":2033,"name":"lucidsingularity","profession":"elementalist"},{"id":2035,"name":"masteroffragmentation","profession":"mesmer"},{"id":2036,"name":"warhornproficiency","profession":"elementalist"},{"id":2037,"name":"huntersdetermination","profession":"guardian"},{"id":2038,"name":"kingoffires","profession":"warrior"},{"id":2039,"name":"lastblaze","profession":"warrior"},{"id":2042,"name":"heatthesoul","profession":"warrior"},{"id":2043,"name":"eternalchampion","profession":"warrior"},{"id":2046,"name":"fatalfrenzy","profession":"warrior"},{"id":2047,"name":"boundingdodger","profession":"thief"},{"id":2049,"name":"smashbrawler","profession":"warrior"},{"id":2050,"name":"shieldproficiency","profession":"revenant"},{"id":2052,"name":"kineticaccelerators","profession":"engineer"},{"id":2053,"name":"celestialshadow","profession":"ranger"},{"id":2055,"name":"ancientseeds","profession":"ranger"},{"id":2056,"name":"naturalstride","profession":"ranger"},{"id":2057,"name":"graceoftheland","profession":"ranger"},{"id":2058,"name":"lingeringlight","profession":"ranger"},{"id":2059,"name":"desertempowerment","profession":"necromancer"},{"id":2060,"name":"magebanetether","profession":"warrior"},{"id":2061,"name":"swiftrevenge","profession":"elementalist"},{"id":2062,"name":"swiftscholar","profession":"guardian"},{"id":2063,"name":"weightyterms","profession":"guardian"},{"id":2064,"name":"photonicblastingmodule","profession":"engineer"},{"id":2066,"name":"thermalreleasevalve","profession":"engineer"},{"id":2067,"name":"sadisticsearing","profession":"necromancer"},{"id":2069,"name":"nomadsendurance","profession":"mesmer"},{"id":2070,"name":"infinitehorizon","profession":"mesmer"},{"id":2071,"name":"livefast","profession":"ranger"},{"id":2072,"name":"unstoppableunion","profession":"ranger"},{"id":2073,"name":"axeproficiency","profession":"guardian"},{"id":2074,"name":"fellbeacon","profession":"necromancer"},{"id":2075,"name":"unrelentingcriticism","profession":"guardian"},{"id":2076,"name":"stalwartspeed","profession":"guardian"},{"id":2077,"name":"elementalrefreshment","profession":"elementalist"},{"id":2078,"name":"payback","profession":"thief"},{"id":2079,"name":"bloodfury","profession":"revenant"},{"id":2080,"name":"feedfromcorruption","profession":"necromancer"},{"id":2081,"name":"elementalpolyphony","profession":"elementalist"},{"id":2082,"name":"renewingoasis","profession":"mesmer"},{"id":2084,"name":"ironsight","profession":"thief"},{"id":2085,"name":"essenceofspeed","profession":"ranger"},{"id":2086,"name":"archivistofwhispers","profession":"guardian"},{"id":2087,"name":"axeproficiency","profession":"mesmer"},{"id":2088,"name":"daggerproficiency","profession":"ranger"},{"id":2089,"name":"purityofword","profession":"guardian"},{"id":2090,"name":"wovenstride","profession":"elementalist"},{"id":2091,"name":"crystalconfigurationzephyr","profession":"engineer"},{"id":2092,"name":"heartpiercer","profession":"revenant"},{"id":2093,"name":"bequickorbekilled","profession":"thief"},{"id":2094,"name":"vindication","profession":"revenant"},{"id":2095,"name":"sunandmoonstyle","profession":"warrior"},{"id":2096,"name":"bloodassand","profession":"necromancer"},{"id":2097,"name":"slowcounter","profession":"warrior"},{"id":2098,"name":"mirroredaxes","profession":"mesmer"},{"id":2099,"name":"shortbowproficiency","profession":"revenant"},{"id":2100,"name":"lastinglegacy","profession":"revenant"},{"id":2101,"name":"liberatorsvow","profession":"guardian"},{"id":2102,"name":"nourishingashes","profession":"necromancer"},{"id":2103,"name":"crystalconfigurationstorm","profession":"engineer"},{"id":2105,"name":"stoicdemeanor","profession":"guardian"},{"id":2106,"name":"solarfocusinglens","profession":"engineer"},{"id":2107,"name":"purestrike","profession":"warrior"},{"id":2108,"name":"allforone","profession":"revenant"},{"id":2109,"name":"weaver","profession":"elementalist"},{"id":2110,"name":"riddleofsand","profession":"mesmer"},{"id":2111,"name":"maleficentseven","profession":"thief"},{"id":2112,"name":"sandsavant","profession":"necromancer"},{"id":2113,"name":"elusivemind","profession":"mesmer"},{"id":2114,"name":"lightdensityamplifier","profession":"engineer"},{"id":2115,"name":"mastersfortitude","profession":"elementalist"},{"id":2116,"name":"legendarylore","profession":"guardian"},{"id":2117,"name":"speedofsand","profession":"mesmer"},{"id":2118,"name":"silentscope","profession":"thief"},{"id":2119,"name":"secondskin","profession":"ranger"},{"id":2120,"name":"wroughtironwill","profession":"revenant"},{"id":2121,"name":"sandsage","profession":"necromancer"},{"id":2122,"name":"lasersedge","profession":"engineer"},{"id":2123,"name":"heraldofsorrow","profession":"necromancer"},{"id":2124,"name":"daggerproficiency","profession":"warrior"},{"id":2125,"name":"swordproficiency","profession":"engineer"},{"id":2126,"name":"lossaversion","profession":"warrior"},{"id":2127,"name":"twiceasvicious","profession":"ranger"},{"id":2128,"name":"leaderofthepack","profession":"ranger"},{"id":2129,"name":"rifleproficiency","profession":"thief"},{"id":2130,"name":"attackersinsight","profession":"warrior"},{"id":2131,"name":"elementsofrage","profession":"elementalist"},{"id":2133,"name":"boldreversal","profession":"revenant"},{"id":2134,"name":"freshreinforcement","profession":"ranger"},{"id":2135,"name":"heattherapy","profession":"engineer"},{"id":2136,"name":"oneinthechamber","profession":"thief"},{"id":2137,"name":"enhancedcapacitystorageunit","profession":"engineer"},{"id":2138,"name":"invigoratingstrikes","profession":"elementalist"},{"id":2140,"name":"noescape","profession":"warrior"},{"id":2141,"name":"selfdeception","profession":"mesmer"},{"id":2142,"name":"brutalmomentum","profession":"revenant"},{"id":2143,"name":"oppressivesuperiority","profession":"ranger"},{"id":2144,"name":"torchproficiency","profession":"necromancer"},{"id":2145,"name":"maliciousintent","profession":"thief"},{"id":2146,"name":"fireforeffect","profession":"thief"},{"id":2147,"name":"mantleofsand","profession":"necromancer"},{"id":2148,"name":"imbuedhaste","profession":"guardian"},{"id":2149,"name":"swordproficiency","profession":"elementalist"},{"id":2150,"name":"miragecloak","profession":"mesmer"},{"id":2151,"name":"elevatedbond","profession":"ranger"},{"id":2152,"name":"crystalconfigurationeclipse","profession":"engineer"},{"id":2153,"name":"guardcounter","profession":"warrior"},{"id":2154,"name":"endlessenmity","profession":"revenant"},{"id":2155,"name":"eternalbond","profession":"ranger"},{"id":2156,"name":"furiousstrength","profession":"ranger"},{"id":2157,"name":"prismaticconverter","profession":"engineer"},{"id":2158,"name":"photonprojector","profession":"engineer"},{"id":2159,"name":"loremaster","profession":"guardian"},{"id":2160,"name":"premeditation","profession":"thief"},{"id":2161,"name":"predatorscunning","profession":"ranger"},{"id":2162,"name":"dispellingforce","profession":"warrior"},{"id":2163,"name":"enchantmentcollapse","profession":"warrior"},{"id":2164,"name":"demoniclore","profession":"necromancer"},{"id":2165,"name":"elementalpursuit","profession":"elementalist"},{"id":2166,"name":"ashendemeanor","profession":"revenant"},{"id":2167,"name":"abrasivegrit","profession":"necromancer"},{"id":2168,"name":"revengecounter","profession":"warrior"},{"id":2169,"name":"dunecloak","profession":"mesmer"},{"id":2170,"name":"bolsteredelements","profession":"elementalist"},{"id":2171,"name":"deadeyesgaze","profession":"thief"},{"id":2172,"name":"renewinggaze","profession":"thief"},{"id":2173,"name":"collateraldamage","profession":"thief"},{"id":2174,"name":"miragemantle","profession":"mesmer"},{"id":2175,"name":"spellbreakersconviction","profession":"warrior"},{"id":2177,"name":"superiorelements","profession":"elementalist"},{"id":2178,"name":"desertdistortion","profession":"mesmer"},{"id":2179,"name":"quickfire","profession":"guardian"},{"id":2180,"name":"weaversprowess","profession":"elementalist"},{"id":2181,"name":"ambushcommander","profession":"revenant"},{"id":2182,"name":"righteousrebel","profession":"revenant"},{"id":2183,"profession":"necromancer"},{"id":2185,"profession":"necromancer"},{"id":2186,"name":"alchemicvigor","profession":"necromancer"},{"id":2187,"name":"conceitedcurate","profession":"guardian"},{"id":2188,"profession":"necromancer"},{"id":2189,"name":"lethaltempo","profession":"guardian"},{"id":2190,"name":"powerforpower","profession":"guardian"},{"id":2191,"name":"boonpact","profession":"guardian"},{"id":2192,"name":"implacablefoe","profession":"necromancer"},{"id":2193,"name":"quietintensity","profession":"mesmer"},{"id":2194,"profession":"necromancer"},{"id":2195,"name":"phoenixprotocol","profession":"guardian"},{"id":2196,"name":"swordproficiency","profession":"guardian"},{"id":2197,"name":"restorativevirtues","profession":"guardian"},{"id":2198,"name":"deathlesscourage","profession":"guardian"},{"id":2199,"name":"vanguardtactics","profession":"guardian"},{"id":2200,"name":"willbendertraining","profession":"guardian"},{"id":2201,"name":"tyrantsmomentum","profession":"guardian"},{"id":2202,"name":"jaggedmind","profession":"mesmer"},{"id":2203,"name":"doomapproaches","profession":"necromancer"},{"id":2204,"name":"deadlyblades","profession":"mesmer"},{"id":2205,"name":"phantasmalblades","profession":"mesmer"},{"id":2206,"name":"infiniteforge","profession":"mesmer"},{"id":2207,"name":"sharpeningsorrow","profession":"mesmer"},{"id":2208,"name":"mentalfocus","profession":"mesmer"},{"id":2209,"name":"darkgunslinger","profession":"necromancer"},{"id":2210,"name":"holyreckoning","profession":"guardian"},{"id":2211,"name":"psychicriposte","profession":"mesmer"},{"id":2212,"name":"bladeturnrefrain","profession":"mesmer"},{"id":2213,"name":"pistolproficiency","profession":"necromancer"},{"id":2214,"name":"daggerproficiency","profession":"mesmer"},{"id":2215,"name":"duelistsreversal","profession":"mesmer"},{"id":2216,"name":"psychicblades","profession":"mesmer"},{"id":2217,"name":"corruptedtalent","profession":"necromancer"},{"id":2218,"profession":"necromancer"},{"id":2219,"profession":"necromancer"},{"id":2220,"name":"twistedmedicine","profession":"necromancer"},{"id":2222,"name":"righteoussprint","profession":"guardian"},{"id":2223,"name":"bloodsong","profession":"mesmer"}]
+[
+  {
+    "id": 214,
+    "name": "ragingstorm",
+    "profession": "elementalist"
+  },
+  {
+    "id": 221,
+    "name": "zephyrsspeed",
+    "profession": "elementalist"
+  },
+  {
+    "id": 222,
+    "name": "electricdischarge",
+    "profession": "elementalist"
+  },
+  {
+    "id": 223,
+    "name": "aeromancerstraining",
+    "profession": "elementalist"
+  },
+  {
+    "id": 224,
+    "name": "onewithair",
+    "profession": "elementalist"
+  },
+  {
+    "id": 226,
+    "name": "bolttotheheart",
+    "profession": "elementalist"
+  },
+  {
+    "id": 227,
+    "name": "zephyrsboon",
+    "profession": "elementalist"
+  },
+  {
+    "id": 229,
+    "name": "inscription",
+    "profession": "elementalist"
+  },
+  {
+    "id": 232,
+    "name": "ferociouswinds",
+    "profession": "elementalist"
+  },
+  {
+    "id": 238,
+    "name": "evasivearcana",
+    "profession": "elementalist"
+  },
+  {
+    "id": 253,
+    "name": "arcaneprecision",
+    "profession": "elementalist"
+  },
+  {
+    "id": 257,
+    "name": "finalshielding",
+    "profession": "elementalist"
+  },
+  {
+    "id": 263,
+    "name": "elementalsurge",
+    "profession": "elementalist"
+  },
+  {
+    "id": 264,
+    "name": "elementalattunement",
+    "profession": "elementalist"
+  },
+  {
+    "id": 265,
+    "name": "arcaneresurrection",
+    "profession": "elementalist"
+  },
+  {
+    "id": 266,
+    "name": "renewingstamina",
+    "profession": "elementalist"
+  },
+  {
+    "id": 268,
+    "name": "arcaneprowess",
+    "profession": "elementalist"
+  },
+  {
+    "id": 275,
+    "name": "strengthofstone",
+    "profession": "elementalist"
+  },
+  {
+    "id": 277,
+    "name": "earthenblessing",
+    "profession": "elementalist"
+  },
+  {
+    "id": 278,
+    "name": "stoneflesh",
+    "profession": "elementalist"
+  },
+  {
+    "id": 279,
+    "name": "earthenblast",
+    "profession": "elementalist"
+  },
+  {
+    "id": 280,
+    "name": "geomancerstraining",
+    "profession": "elementalist"
+  },
+  {
+    "id": 281,
+    "name": "rocksolid",
+    "profession": "elementalist"
+  },
+  {
+    "id": 282,
+    "name": "earthsembrace",
+    "profession": "elementalist"
+  },
+  {
+    "id": 287,
+    "name": "writteninstone",
+    "profession": "elementalist"
+  },
+  {
+    "id": 289,
+    "name": "elementalshielding",
+    "profession": "elementalist"
+  },
+  {
+    "id": 294,
+    "name": "pyromancerspuissance",
+    "profession": "elementalist"
+  },
+  {
+    "id": 296,
+    "name": "burningprecision",
+    "profession": "elementalist"
+  },
+  {
+    "id": 318,
+    "name": "sunspot",
+    "profession": "elementalist"
+  },
+  {
+    "id": 319,
+    "name": "pyromancerstraining",
+    "profession": "elementalist"
+  },
+  {
+    "id": 320,
+    "name": "empoweringflame",
+    "profession": "elementalist"
+  },
+  {
+    "id": 325,
+    "name": "burningrage",
+    "profession": "elementalist"
+  },
+  {
+    "id": 328,
+    "name": "conjurer",
+    "profession": "elementalist"
+  },
+  {
+    "id": 334,
+    "name": "poweroverwhelming",
+    "profession": "elementalist"
+  },
+  {
+    "id": 335,
+    "name": "burningfire",
+    "profession": "elementalist"
+  },
+  {
+    "id": 340,
+    "name": "smotheringauras",
+    "profession": "elementalist"
+  },
+  {
+    "id": 348,
+    "name": "soothingice",
+    "profession": "elementalist"
+  },
+  {
+    "id": 349,
+    "name": "flowlikewater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 350,
+    "name": "soothingmist",
+    "profession": "elementalist"
+  },
+  {
+    "id": 351,
+    "name": "healingripple",
+    "profession": "elementalist"
+  },
+  {
+    "id": 358,
+    "name": "cleansingwave",
+    "profession": "elementalist"
+  },
+  {
+    "id": 360,
+    "name": "stopdropandroll",
+    "profession": "elementalist"
+  },
+  {
+    "id": 361,
+    "name": "powerfulaura",
+    "profession": "elementalist"
+  },
+  {
+    "id": 362,
+    "name": "cleansingwater",
+    "profession": "elementalist"
+  },
+  {
+    "id": 363,
+    "name": "piercingshards",
+    "profession": "elementalist"
+  },
+  {
+    "id": 364,
+    "name": "soothingdisruption",
+    "profession": "elementalist"
+  },
+  {
+    "id": 394,
+    "name": "overshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 396,
+    "name": "invigoratingspeed",
+    "profession": "engineer"
+  },
+  {
+    "id": 413,
+    "name": "compoundingchemicals",
+    "profession": "engineer"
+  },
+  {
+    "id": 429,
+    "name": "shapedcharge",
+    "profession": "engineer"
+  },
+  {
+    "id": 432,
+    "name": "explosiveentrance",
+    "profession": "engineer"
+  },
+  {
+    "id": 433,
+    "name": "incendiarypowder",
+    "profession": "engineer"
+  },
+  {
+    "id": 445,
+    "name": "mechalegs",
+    "profession": "engineer"
+  },
+  {
+    "id": 468,
+    "name": "hiddenflask",
+    "profession": "engineer"
+  },
+  {
+    "id": 469,
+    "name": "emergencyelixir",
+    "profession": "engineer"
+  },
+  {
+    "id": 470,
+    "name": "backpackregenerator",
+    "profession": "engineer"
+  },
+  {
+    "id": 472,
+    "name": "anticorrosionplating",
+    "profession": "engineer"
+  },
+  {
+    "id": 473,
+    "name": "hgh",
+    "profession": "engineer"
+  },
+  {
+    "id": 482,
+    "name": "aimassistedrocket",
+    "profession": "engineer"
+  },
+  {
+    "id": 487,
+    "name": "transmute",
+    "profession": "engineer"
+  },
+  {
+    "id": 505,
+    "name": "shrapnel",
+    "profession": "engineer"
+  },
+  {
+    "id": 507,
+    "name": "autodefensebombdispenser",
+    "profession": "engineer"
+  },
+  {
+    "id": 508,
+    "name": "reconstructionenclosure",
+    "profession": "engineer"
+  },
+  {
+    "id": 509,
+    "name": "protectioninjection",
+    "profession": "engineer"
+  },
+  {
+    "id": 510,
+    "name": "juggernaut",
+    "profession": "engineer"
+  },
+  {
+    "id": 512,
+    "name": "streamlinedkits",
+    "profession": "engineer"
+  },
+  {
+    "id": 514,
+    "name": "grenadier",
+    "profession": "engineer"
+  },
+  {
+    "id": 515,
+    "name": "sharpshooter",
+    "profession": "engineer"
+  },
+  {
+    "id": 516,
+    "name": "serratedsteel",
+    "profession": "engineer"
+  },
+  {
+    "id": 517,
+    "name": "steelpackedpowder",
+    "profession": "engineer"
+  },
+  {
+    "id": 518,
+    "name": "cleansingsynergy",
+    "profession": "engineer"
+  },
+  {
+    "id": 519,
+    "name": "energyamplifier",
+    "profession": "engineer"
+  },
+  {
+    "id": 520,
+    "name": "comebackcure",
+    "profession": "engineer"
+  },
+  {
+    "id": 521,
+    "name": "healthinsurance",
+    "profession": "engineer"
+  },
+  {
+    "id": 523,
+    "name": "adrenalimplant",
+    "profession": "engineer"
+  },
+  {
+    "id": 525,
+    "name": "shortfuse",
+    "profession": "engineer"
+  },
+  {
+    "id": 526,
+    "name": "modifiedammunition",
+    "profession": "engineer"
+  },
+  {
+    "id": 531,
+    "name": "powerwrench",
+    "profession": "engineer"
+  },
+  {
+    "id": 532,
+    "name": "staticdischarge",
+    "profession": "engineer"
+  },
+  {
+    "id": 536,
+    "name": "hematicfocus",
+    "profession": "engineer"
+  },
+  {
+    "id": 549,
+    "name": "pureofheart",
+    "profession": "guardian"
+  },
+  {
+    "id": 551,
+    "name": "selflessdaring",
+    "profession": "guardian"
+  },
+  {
+    "id": 553,
+    "name": "pureofvoice",
+    "profession": "guardian"
+  },
+  {
+    "id": 554,
+    "name": "battlepresence",
+    "profession": "guardian"
+  },
+  {
+    "id": 557,
+    "name": "honorablestaff",
+    "profession": "guardian"
+  },
+  {
+    "id": 558,
+    "name": "writofpersistence",
+    "profession": "guardian"
+  },
+  {
+    "id": 559,
+    "name": "protectivereviver",
+    "profession": "guardian"
+  },
+  {
+    "id": 562,
+    "name": "empoweringmight",
+    "profession": "guardian"
+  },
+  {
+    "id": 563,
+    "name": "wrathfulspirit",
+    "profession": "guardian"
+  },
+  {
+    "id": 564,
+    "name": "vigorousprecision",
+    "profession": "guardian"
+  },
+  {
+    "id": 565,
+    "name": "retribution",
+    "profession": "guardian"
+  },
+  {
+    "id": 566,
+    "name": "righthandstrength",
+    "profession": "guardian"
+  },
+  {
+    "id": 567,
+    "name": "radiantfire",
+    "profession": "guardian"
+  },
+  {
+    "id": 568,
+    "name": "radiantpower",
+    "profession": "guardian"
+  },
+  {
+    "id": 571,
+    "name": "renewedjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 572,
+    "name": "justiceisblind",
+    "profession": "guardian"
+  },
+  {
+    "id": 574,
+    "name": "healersresolution",
+    "profession": "guardian"
+  },
+  {
+    "id": 577,
+    "name": "innerfire",
+    "profession": "guardian"
+  },
+  {
+    "id": 578,
+    "name": "wrathofjustice",
+    "profession": "guardian"
+  },
+  {
+    "id": 579,
+    "name": "perfectinscriptions",
+    "profession": "guardian"
+  },
+  {
+    "id": 580,
+    "name": "stalwartdefender",
+    "profession": "guardian"
+  },
+  {
+    "id": 581,
+    "name": "smitersboon",
+    "profession": "guardian"
+  },
+  {
+    "id": 582,
+    "name": "valorousdefense",
+    "profession": "guardian"
+  },
+  {
+    "id": 583,
+    "name": "mightoftheprotector",
+    "profession": "guardian"
+  },
+  {
+    "id": 584,
+    "name": "strengthinnumbers",
+    "profession": "guardian"
+  },
+  {
+    "id": 585,
+    "name": "altruistichealing",
+    "profession": "guardian"
+  },
+  {
+    "id": 586,
+    "name": "monksfocus",
+    "profession": "guardian"
+  },
+  {
+    "id": 587,
+    "name": "glacialheart",
+    "profession": "guardian"
+  },
+  {
+    "id": 588,
+    "name": "strengthofthefallen",
+    "profession": "guardian"
+  },
+  {
+    "id": 589,
+    "name": "tenaciousdefense",
+    "profession": "guardian"
+  },
+  {
+    "id": 594,
+    "name": "steadfastcourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 603,
+    "name": "inspiringvirtue",
+    "profession": "guardian"
+  },
+  {
+    "id": 604,
+    "name": "virtueofresolution",
+    "profession": "guardian"
+  },
+  {
+    "id": 610,
+    "name": "absoluteresolve",
+    "profession": "guardian"
+  },
+  {
+    "id": 612,
+    "name": "indomitablecourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 617,
+    "name": "masterofconsecrations",
+    "profession": "guardian"
+  },
+  {
+    "id": 620,
+    "name": "powerofthevirtuous",
+    "profession": "guardian"
+  },
+  {
+    "id": 621,
+    "name": "inspiredvirtue",
+    "profession": "guardian"
+  },
+  {
+    "id": 622,
+    "name": "permeatingwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 624,
+    "name": "unscathedcontender",
+    "profession": "guardian"
+  },
+  {
+    "id": 625,
+    "name": "resolutesubconscious",
+    "profession": "guardian"
+  },
+  {
+    "id": 628,
+    "name": "furiousfocus",
+    "profession": "guardian"
+  },
+  {
+    "id": 633,
+    "name": "focusmastery",
+    "profession": "guardian"
+  },
+  {
+    "id": 634,
+    "name": "fierywrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 635,
+    "name": "eternalarmory",
+    "profession": "guardian"
+  },
+  {
+    "id": 637,
+    "name": "shatteredaegis",
+    "profession": "guardian"
+  },
+  {
+    "id": 646,
+    "name": "symbolicexposure",
+    "profession": "guardian"
+  },
+  {
+    "id": 648,
+    "name": "zealotsresolution",
+    "profession": "guardian"
+  },
+  {
+    "id": 649,
+    "name": "symbolicpower",
+    "profession": "guardian"
+  },
+  {
+    "id": 653,
+    "name": "zealousblade",
+    "profession": "guardian"
+  },
+  {
+    "id": 654,
+    "name": "protectorsrestoration",
+    "profession": "guardian"
+  },
+  {
+    "id": 666,
+    "name": "metaphysicalrejuvenation",
+    "profession": "mesmer"
+  },
+  {
+    "id": 667,
+    "name": "illusionarymembrane",
+    "profession": "mesmer"
+  },
+  {
+    "id": 668,
+    "name": "chaotictransference",
+    "profession": "mesmer"
+  },
+  {
+    "id": 669,
+    "name": "chaoticpotency",
+    "profession": "mesmer"
+  },
+  {
+    "id": 670,
+    "name": "methodofmadness",
+    "profession": "mesmer"
+  },
+  {
+    "id": 671,
+    "name": "chaoticinterruption",
+    "profession": "mesmer"
+  },
+  {
+    "id": 673,
+    "name": "auspiciousanguish",
+    "profession": "mesmer"
+  },
+  {
+    "id": 674,
+    "name": "prismaticunderstanding",
+    "profession": "mesmer"
+  },
+  {
+    "id": 675,
+    "name": "illusionarydefense",
+    "profession": "mesmer"
+  },
+  {
+    "id": 677,
+    "name": "masterofmanipulation",
+    "profession": "mesmer"
+  },
+  {
+    "id": 680,
+    "name": "mentalanguish",
+    "profession": "mesmer"
+  },
+  {
+    "id": 681,
+    "name": "viciousexpression",
+    "profession": "mesmer"
+  },
+  {
+    "id": 682,
+    "name": "empoweredillusions",
+    "profession": "mesmer"
+  },
+  {
+    "id": 685,
+    "name": "illusionofvulnerability",
+    "profession": "mesmer"
+  },
+  {
+    "id": 686,
+    "name": "bountifulblades",
+    "profession": "mesmer"
+  },
+  {
+    "id": 687,
+    "name": "rendingshatter",
+    "profession": "mesmer"
+  },
+  {
+    "id": 691,
+    "name": "thepledge",
+    "profession": "mesmer"
+  },
+  {
+    "id": 692,
+    "name": "superioritycomplex",
+    "profession": "mesmer"
+  },
+  {
+    "id": 693,
+    "name": "shatteredconcentration",
+    "profession": "mesmer"
+  },
+  {
+    "id": 694,
+    "name": "dazzling",
+    "profession": "mesmer"
+  },
+  {
+    "id": 700,
+    "name": "duelistsdiscipline",
+    "profession": "mesmer"
+  },
+  {
+    "id": 701,
+    "name": "phantasmalfury",
+    "profession": "mesmer"
+  },
+  {
+    "id": 704,
+    "name": "deceptiveevasion",
+    "profession": "mesmer"
+  },
+  {
+    "id": 705,
+    "name": "desperatedecoy",
+    "profession": "mesmer"
+  },
+  {
+    "id": 706,
+    "name": "criticalinfusion",
+    "profession": "mesmer"
+  },
+  {
+    "id": 707,
+    "name": "masterfencer",
+    "profession": "mesmer"
+  },
+  {
+    "id": 708,
+    "name": "fencersfinesse",
+    "profession": "mesmer"
+  },
+  {
+    "id": 710,
+    "name": "sharperimages",
+    "profession": "mesmer"
+  },
+  {
+    "id": 712,
+    "name": "furiousinterruption",
+    "profession": "mesmer"
+  },
+  {
+    "id": 713,
+    "name": "egotism",
+    "profession": "mesmer"
+  },
+  {
+    "id": 721,
+    "name": "shatterstorm",
+    "profession": "mesmer"
+  },
+  {
+    "id": 722,
+    "name": "escapeartist",
+    "profession": "mesmer"
+  },
+  {
+    "id": 723,
+    "name": "compoundingpower",
+    "profession": "mesmer"
+  },
+  {
+    "id": 729,
+    "name": "phantasmalhaste",
+    "profession": "mesmer"
+  },
+  {
+    "id": 731,
+    "name": "masterofmisdirection",
+    "profession": "mesmer"
+  },
+  {
+    "id": 733,
+    "name": "phantasmalforce",
+    "profession": "mesmer"
+  },
+  {
+    "id": 734,
+    "name": "cryofpain",
+    "profession": "mesmer"
+  },
+  {
+    "id": 738,
+    "name": "restorativemantras",
+    "profession": "mesmer"
+  },
+  {
+    "id": 740,
+    "name": "restorativeillusions",
+    "profession": "mesmer"
+  },
+  {
+    "id": 744,
+    "name": "sympatheticvisage",
+    "profession": "mesmer"
+  },
+  {
+    "id": 751,
+    "name": "wardensfeedback",
+    "profession": "mesmer"
+  },
+  {
+    "id": 752,
+    "name": "blurredinscriptions",
+    "profession": "mesmer"
+  },
+  {
+    "id": 753,
+    "name": "malicioussorcery",
+    "profession": "mesmer"
+  },
+  {
+    "id": 756,
+    "name": "medicsfeedback",
+    "profession": "mesmer"
+  },
+  {
+    "id": 757,
+    "name": "menderspurity",
+    "profession": "mesmer"
+  },
+  {
+    "id": 778,
+    "name": "transfusion",
+    "profession": "necromancer"
+  },
+  {
+    "id": 780,
+    "name": "ritualoflife",
+    "profession": "necromancer"
+  },
+  {
+    "id": 782,
+    "name": "bloodbank",
+    "profession": "necromancer"
+  },
+  {
+    "id": 783,
+    "name": "vampiric",
+    "profession": "necromancer"
+  },
+  {
+    "id": 788,
+    "name": "quickeningthirst",
+    "profession": "necromancer"
+  },
+  {
+    "id": 789,
+    "name": "lifefromdeath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 792,
+    "name": "markofevasion",
+    "profession": "necromancer"
+  },
+  {
+    "id": 799,
+    "name": "bansheeswail",
+    "profession": "necromancer"
+  },
+  {
+    "id": 801,
+    "name": "lingeringcurse",
+    "profession": "necromancer"
+  },
+  {
+    "id": 802,
+    "name": "barbedprecision",
+    "profession": "necromancer"
+  },
+  {
+    "id": 803,
+    "name": "furiousdemise",
+    "profession": "necromancer"
+  },
+  {
+    "id": 810,
+    "name": "targettheweak",
+    "profession": "necromancer"
+  },
+  {
+    "id": 812,
+    "name": "terror",
+    "profession": "necromancer"
+  },
+  {
+    "id": 813,
+    "name": "weakeningshroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 815,
+    "name": "chillingdarkness",
+    "profession": "necromancer"
+  },
+  {
+    "id": 816,
+    "name": "masterofcorruption",
+    "profession": "necromancer"
+  },
+  {
+    "id": 820,
+    "name": "fleshofthemaster",
+    "profession": "necromancer"
+  },
+  {
+    "id": 829,
+    "name": "awakenthepain",
+    "profession": "necromancer"
+  },
+  {
+    "id": 839,
+    "name": "soulcomprehension",
+    "profession": "necromancer"
+  },
+  {
+    "id": 842,
+    "name": "deathnova",
+    "profession": "necromancer"
+  },
+  {
+    "id": 853,
+    "name": "closetodeath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 855,
+    "name": "deadlystrength",
+    "profession": "necromancer"
+  },
+  {
+    "id": 856,
+    "name": "armoredshroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 857,
+    "name": "putriddefense",
+    "profession": "necromancer"
+  },
+  {
+    "id": 858,
+    "name": "necromanticcorruption",
+    "profession": "necromancer"
+  },
+  {
+    "id": 860,
+    "name": "darkdefiance",
+    "profession": "necromancer"
+  },
+  {
+    "id": 861,
+    "name": "vitalpersistence",
+    "profession": "necromancer"
+  },
+  {
+    "id": 874,
+    "name": "soulbattery",
+    "profession": "necromancer"
+  },
+  {
+    "id": 875,
+    "name": "unyieldingblast",
+    "profession": "necromancer"
+  },
+  {
+    "id": 887,
+    "name": "gluttony",
+    "profession": "necromancer"
+  },
+  {
+    "id": 888,
+    "name": "speedofshadows",
+    "profession": "necromancer"
+  },
+  {
+    "id": 889,
+    "name": "eternallife",
+    "profession": "necromancer"
+  },
+  {
+    "id": 891,
+    "name": "sinistershroud",
+    "profession": "necromancer"
+  },
+  {
+    "id": 892,
+    "name": "fearofdeath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 893,
+    "name": "deathperception",
+    "profession": "necromancer"
+  },
+  {
+    "id": 894,
+    "name": "soulbarbs",
+    "profession": "necromancer"
+  },
+  {
+    "id": 898,
+    "name": "soulmarks",
+    "profession": "necromancer"
+  },
+  {
+    "id": 899,
+    "name": "chillofdeath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 903,
+    "name": "spitefulspirit",
+    "profession": "necromancer"
+  },
+  {
+    "id": 905,
+    "name": "dhuumfire",
+    "profession": "necromancer"
+  },
+  {
+    "id": 909,
+    "name": "signetsofsuffering",
+    "profession": "necromancer"
+  },
+  {
+    "id": 913,
+    "name": "reapersmight",
+    "profession": "necromancer"
+  },
+  {
+    "id": 914,
+    "name": "spitefultalisman",
+    "profession": "necromancer"
+  },
+  {
+    "id": 915,
+    "name": "deathsembrace",
+    "profession": "necromancer"
+  },
+  {
+    "id": 916,
+    "name": "spitefulrenewal",
+    "profession": "necromancer"
+  },
+  {
+    "id": 917,
+    "name": "siphonedpower",
+    "profession": "necromancer"
+  },
+  {
+    "id": 919,
+    "name": "dread",
+    "profession": "necromancer"
+  },
+  {
+    "id": 964,
+    "name": "windbornenotes",
+    "profession": "ranger"
+  },
+  {
+    "id": 965,
+    "name": "spiritedarrival",
+    "profession": "ranger"
+  },
+  {
+    "id": 968,
+    "name": "zephyrsspeed",
+    "profession": "ranger"
+  },
+  {
+    "id": 970,
+    "name": "naturalhealing",
+    "profession": "ranger"
+  },
+  {
+    "id": 974,
+    "name": "loudwhistle",
+    "profession": "ranger"
+  },
+  {
+    "id": 975,
+    "name": "wiltingstrike",
+    "profession": "ranger"
+  },
+  {
+    "id": 978,
+    "name": "instinctivereaction",
+    "profession": "ranger"
+  },
+  {
+    "id": 986,
+    "name": "clarionbond",
+    "profession": "ranger"
+  },
+  {
+    "id": 996,
+    "name": "predatorsonslaught",
+    "profession": "ranger"
+  },
+  {
+    "id": 1000,
+    "name": "farsighted",
+    "profession": "ranger"
+  },
+  {
+    "id": 1001,
+    "name": "brutishseals",
+    "profession": "ranger"
+  },
+  {
+    "id": 1009,
+    "name": "alphafocus",
+    "profession": "ranger"
+  },
+  {
+    "id": 1010,
+    "name": "openingstrike",
+    "profession": "ranger"
+  },
+  {
+    "id": 1011,
+    "name": "precisestrike",
+    "profession": "ranger"
+  },
+  {
+    "id": 1014,
+    "name": "huntersgaze",
+    "profession": "ranger"
+  },
+  {
+    "id": 1015,
+    "name": "remorseless",
+    "profession": "ranger"
+  },
+  {
+    "id": 1016,
+    "name": "spotter",
+    "profession": "ranger"
+  },
+  {
+    "id": 1021,
+    "name": "stoneform",
+    "profession": "ranger"
+  },
+  {
+    "id": 1038,
+    "name": "naturesvengeance",
+    "profession": "ranger"
+  },
+  {
+    "id": 1047,
+    "name": "twohandedtraining",
+    "profession": "ranger"
+  },
+  {
+    "id": 1054,
+    "name": "evasivepurity",
+    "profession": "ranger"
+  },
+  {
+    "id": 1055,
+    "name": "rejuvenation",
+    "profession": "ranger"
+  },
+  {
+    "id": 1056,
+    "name": "fortifyingbond",
+    "profession": "ranger"
+  },
+  {
+    "id": 1059,
+    "name": "lingeringmagic",
+    "profession": "ranger"
+  },
+  {
+    "id": 1060,
+    "name": "alliesaid",
+    "profession": "ranger"
+  },
+  {
+    "id": 1062,
+    "name": "bountifulhunter",
+    "profession": "ranger"
+  },
+  {
+    "id": 1064,
+    "name": "quickdraw",
+    "profession": "ranger"
+  },
+  {
+    "id": 1065,
+    "name": "petsprowess",
+    "profession": "ranger"
+  },
+  {
+    "id": 1066,
+    "name": "honedaxes",
+    "profession": "ranger"
+  },
+  {
+    "id": 1067,
+    "name": "primalreflexes",
+    "profession": "ranger"
+  },
+  {
+    "id": 1068,
+    "name": "hunterstactics",
+    "profession": "ranger"
+  },
+  {
+    "id": 1069,
+    "name": "sharpenededges",
+    "profession": "ranger"
+  },
+  {
+    "id": 1070,
+    "name": "momentofclarity",
+    "profession": "ranger"
+  },
+  {
+    "id": 1072,
+    "name": "potentally",
+    "profession": "ranger"
+  },
+  {
+    "id": 1075,
+    "name": "trappersexpertise",
+    "profession": "ranger"
+  },
+  {
+    "id": 1080,
+    "name": "tailwind",
+    "profession": "ranger"
+  },
+  {
+    "id": 1083,
+    "name": "furiousgrip",
+    "profession": "ranger"
+  },
+  {
+    "id": 1086,
+    "name": "oakheartsalve",
+    "profession": "ranger"
+  },
+  {
+    "id": 1089,
+    "name": "ruggedgrowth",
+    "profession": "ranger"
+  },
+  {
+    "id": 1090,
+    "name": "companionsdefense",
+    "profession": "ranger"
+  },
+  {
+    "id": 1094,
+    "name": "empathicbond",
+    "profession": "ranger"
+  },
+  {
+    "id": 1096,
+    "name": "naturalvigor",
+    "profession": "ranger"
+  },
+  {
+    "id": 1098,
+    "name": "childofearth",
+    "profession": "ranger"
+  },
+  {
+    "id": 1099,
+    "name": "tastefordanger",
+    "profession": "ranger"
+  },
+  {
+    "id": 1100,
+    "name": "sharedanguish",
+    "profession": "ranger"
+  },
+  {
+    "id": 1101,
+    "name": "ambidexterity",
+    "profession": "ranger"
+  },
+  {
+    "id": 1112,
+    "name": "instantreflexes",
+    "profession": "thief"
+  },
+  {
+    "id": 1130,
+    "name": "leechingvenoms",
+    "profession": "thief"
+  },
+  {
+    "id": 1134,
+    "name": "cloakedinshadow",
+    "profession": "thief"
+  },
+  {
+    "id": 1135,
+    "name": "shadowsrejuvenation",
+    "profession": "thief"
+  },
+  {
+    "id": 1136,
+    "name": "meldwithshadows",
+    "profession": "thief"
+  },
+  {
+    "id": 1137,
+    "name": "kleptomaniac",
+    "profession": "thief"
+  },
+  {
+    "id": 1157,
+    "name": "leadattacks",
+    "profession": "thief"
+  },
+  {
+    "id": 1158,
+    "name": "sleightofhand",
+    "profession": "thief"
+  },
+  {
+    "id": 1159,
+    "name": "uncatchable",
+    "profession": "thief"
+  },
+  {
+    "id": 1160,
+    "name": "mercifulambush",
+    "profession": "thief"
+  },
+  {
+    "id": 1162,
+    "name": "rendingshade",
+    "profession": "thief"
+  },
+  {
+    "id": 1163,
+    "name": "thrillofthecrime",
+    "profession": "thief"
+  },
+  {
+    "id": 1164,
+    "name": "deadlyambition",
+    "profession": "thief"
+  },
+  {
+    "id": 1167,
+    "name": "improvisation",
+    "profession": "thief"
+  },
+  {
+    "id": 1169,
+    "name": "eventheodds",
+    "profession": "thief"
+  },
+  {
+    "id": 1170,
+    "name": "sunderingshade",
+    "profession": "thief"
+  },
+  {
+    "id": 1187,
+    "name": "quickpockets",
+    "profession": "thief"
+  },
+  {
+    "id": 1190,
+    "name": "pressurestriking",
+    "profession": "thief"
+  },
+  {
+    "id": 1192,
+    "name": "swindlersequilibrium",
+    "profession": "thief"
+  },
+  {
+    "id": 1209,
+    "name": "assassinsfury",
+    "profession": "thief"
+  },
+  {
+    "id": 1210,
+    "name": "unrelentingstrikes",
+    "profession": "thief"
+  },
+  {
+    "id": 1215,
+    "name": "hiddenkiller",
+    "profession": "thief"
+  },
+  {
+    "id": 1232,
+    "name": "preparedness",
+    "profession": "thief"
+  },
+  {
+    "id": 1234,
+    "name": "felinegrace",
+    "profession": "thief"
+  },
+  {
+    "id": 1237,
+    "name": "painresponse",
+    "profession": "thief"
+  },
+  {
+    "id": 1238,
+    "name": "assassinsreward",
+    "profession": "thief"
+  },
+  {
+    "id": 1240,
+    "name": "expeditiousdodger",
+    "profession": "thief"
+  },
+  {
+    "id": 1241,
+    "name": "guardedinitiation",
+    "profession": "thief"
+  },
+  {
+    "id": 1242,
+    "name": "endlessstamina",
+    "profession": "thief"
+  },
+  {
+    "id": 1245,
+    "name": "daggertraining",
+    "profession": "thief"
+  },
+  {
+    "id": 1252,
+    "name": "burstofagility",
+    "profession": "thief"
+  },
+  {
+    "id": 1257,
+    "name": "exposedweakness",
+    "profession": "thief"
+  },
+  {
+    "id": 1267,
+    "name": "signetsofpower",
+    "profession": "thief"
+  },
+  {
+    "id": 1268,
+    "name": "twinfangs",
+    "profession": "thief"
+  },
+  {
+    "id": 1269,
+    "name": "executioner",
+    "profession": "thief"
+  },
+  {
+    "id": 1272,
+    "name": "practicedtolerance",
+    "profession": "thief"
+  },
+  {
+    "id": 1276,
+    "name": "mug",
+    "profession": "thief"
+  },
+  {
+    "id": 1277,
+    "name": "bountifultheft",
+    "profession": "thief"
+  },
+  {
+    "id": 1279,
+    "name": "serpentstouch",
+    "profession": "thief"
+  },
+  {
+    "id": 1280,
+    "name": "lotuspoison",
+    "profession": "thief"
+  },
+  {
+    "id": 1281,
+    "name": "keenobserver",
+    "profession": "thief"
+  },
+  {
+    "id": 1282,
+    "name": "ferociousstrikes",
+    "profession": "thief"
+  },
+  {
+    "id": 1284,
+    "name": "hiddenthief",
+    "profession": "thief"
+  },
+  {
+    "id": 1286,
+    "name": "trickster",
+    "profession": "thief"
+  },
+  {
+    "id": 1289,
+    "name": "vigorousrecovery",
+    "profession": "thief"
+  },
+  {
+    "id": 1290,
+    "name": "hardtocatch",
+    "profession": "thief"
+  },
+  {
+    "id": 1291,
+    "name": "potentpoison",
+    "profession": "thief"
+  },
+  {
+    "id": 1292,
+    "name": "panicstrike",
+    "profession": "thief"
+  },
+  {
+    "id": 1293,
+    "name": "shadowsembrace",
+    "profession": "thief"
+  },
+  {
+    "id": 1294,
+    "name": "concealingrestoration",
+    "profession": "thief"
+  },
+  {
+    "id": 1295,
+    "name": "upperhand",
+    "profession": "thief"
+  },
+  {
+    "id": 1297,
+    "name": "shadowsavior",
+    "profession": "thief"
+  },
+  {
+    "id": 1299,
+    "name": "deadlyaim",
+    "profession": "thief"
+  },
+  {
+    "id": 1300,
+    "name": "flickeringshadows",
+    "profession": "thief"
+  },
+  {
+    "id": 1315,
+    "name": "unsuspectingfoe",
+    "profession": "warrior"
+  },
+  {
+    "id": 1316,
+    "name": "sunderingburst",
+    "profession": "warrior"
+  },
+  {
+    "id": 1317,
+    "name": "heightenedfocus",
+    "profession": "warrior"
+  },
+  {
+    "id": 1329,
+    "name": "crackshot",
+    "profession": "warrior"
+  },
+  {
+    "id": 1333,
+    "name": "blademaster",
+    "profession": "warrior"
+  },
+  {
+    "id": 1334,
+    "name": "opportunist",
+    "profession": "warrior"
+  },
+  {
+    "id": 1336,
+    "name": "burstprecision",
+    "profession": "warrior"
+  },
+  {
+    "id": 1337,
+    "name": "bloodlust",
+    "profession": "warrior"
+  },
+  {
+    "id": 1338,
+    "name": "forcefulgreatsword",
+    "profession": "warrior"
+  },
+  {
+    "id": 1342,
+    "name": "furiousburst",
+    "profession": "warrior"
+  },
+  {
+    "id": 1343,
+    "name": "deepstrikes",
+    "profession": "warrior"
+  },
+  {
+    "id": 1344,
+    "name": "signetmastery",
+    "profession": "warrior"
+  },
+  {
+    "id": 1346,
+    "name": "furious",
+    "profession": "warrior"
+  },
+  {
+    "id": 1348,
+    "name": "adrenalhealth",
+    "profession": "warrior"
+  },
+  {
+    "id": 1350,
+    "name": "thickskin",
+    "profession": "warrior"
+  },
+  {
+    "id": 1367,
+    "name": "sunderingmace",
+    "profession": "warrior"
+  },
+  {
+    "id": 1368,
+    "name": "defypain",
+    "profession": "warrior"
+  },
+  {
+    "id": 1369,
+    "name": "axemastery",
+    "profession": "warrior"
+  },
+  {
+    "id": 1372,
+    "name": "culltheweak",
+    "profession": "warrior"
+  },
+  {
+    "id": 1375,
+    "name": "laststand",
+    "profession": "warrior"
+  },
+  {
+    "id": 1376,
+    "name": "shieldmaster",
+    "profession": "warrior"
+  },
+  {
+    "id": 1379,
+    "name": "armoredattack",
+    "profession": "warrior"
+  },
+  {
+    "id": 1380,
+    "name": "hardenedarmor",
+    "profession": "warrior"
+  },
+  {
+    "id": 1381,
+    "name": "vengefulreturn",
+    "profession": "warrior"
+  },
+  {
+    "id": 1413,
+    "name": "warriorssprint",
+    "profession": "warrior"
+  },
+  {
+    "id": 1415,
+    "name": "versatilerage",
+    "profession": "warrior"
+  },
+  {
+    "id": 1416,
+    "name": "fasthands",
+    "profession": "warrior"
+  },
+  {
+    "id": 1417,
+    "name": "versatilepower",
+    "profession": "warrior"
+  },
+  {
+    "id": 1437,
+    "name": "berserkerspower",
+    "profession": "warrior"
+  },
+  {
+    "id": 1440,
+    "name": "mercilesshammer",
+    "profession": "warrior"
+  },
+  {
+    "id": 1444,
+    "name": "peakperformance",
+    "profession": "warrior"
+  },
+  {
+    "id": 1446,
+    "name": "recklessdodge",
+    "profession": "warrior"
+  },
+  {
+    "id": 1447,
+    "name": "bravestride",
+    "profession": "warrior"
+  },
+  {
+    "id": 1448,
+    "name": "buildingmomentum",
+    "profession": "warrior"
+  },
+  {
+    "id": 1449,
+    "name": "greatfortitude",
+    "profession": "warrior"
+  },
+  {
+    "id": 1451,
+    "name": "restorativestrength",
+    "profession": "warrior"
+  },
+  {
+    "id": 1453,
+    "name": "pinnacleofstrength",
+    "profession": "warrior"
+  },
+  {
+    "id": 1454,
+    "name": "mightmakesright",
+    "profession": "warrior"
+  },
+  {
+    "id": 1455,
+    "name": "woundingprecision",
+    "profession": "warrior"
+  },
+  {
+    "id": 1469,
+    "name": "legspecialist",
+    "profession": "warrior"
+  },
+  {
+    "id": 1470,
+    "name": "vigorousshouts",
+    "profession": "warrior"
+  },
+  {
+    "id": 1471,
+    "name": "roaringreveille",
+    "profession": "warrior"
+  },
+  {
+    "id": 1474,
+    "name": "soldierscomfort",
+    "profession": "warrior"
+  },
+  {
+    "id": 1479,
+    "name": "shrugitoff",
+    "profession": "warrior"
+  },
+  {
+    "id": 1480,
+    "name": "marchingorders",
+    "profession": "warrior"
+  },
+  {
+    "id": 1481,
+    "name": "mendingmight",
+    "profession": "warrior"
+  },
+  {
+    "id": 1482,
+    "name": "empowerallies",
+    "profession": "warrior"
+  },
+  {
+    "id": 1484,
+    "name": "doubledstandards",
+    "profession": "warrior"
+  },
+  {
+    "id": 1485,
+    "name": "empowered",
+    "profession": "warrior"
+  },
+  {
+    "id": 1486,
+    "name": "warriorscunning",
+    "profession": "warrior"
+  },
+  {
+    "id": 1487,
+    "name": "arcanerestoration",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1488,
+    "name": "doggedmarch",
+    "profession": "warrior"
+  },
+  {
+    "id": 1489,
+    "name": "destructionoftheempowered",
+    "profession": "warrior"
+  },
+  {
+    "id": 1502,
+    "name": "stormsoul",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1503,
+    "name": "freshair",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1507,
+    "name": "serratedstones",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1508,
+    "name": "diamondskin",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1510,
+    "name": "persistingflames",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1511,
+    "name": "bountifulpower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1541,
+    "name": "flashbang",
+    "profession": "engineer"
+  },
+  {
+    "id": 1556,
+    "name": "kindledzeal",
+    "profession": "guardian"
+  },
+  {
+    "id": 1606,
+    "name": "resoundingtimbre",
+    "profession": "ranger"
+  },
+  {
+    "id": 1649,
+    "name": "cleansingire",
+    "profession": "warrior"
+  },
+  {
+    "id": 1657,
+    "name": "burstmastery",
+    "profession": "warrior"
+  },
+  {
+    "id": 1667,
+    "name": "martialcadence",
+    "profession": "warrior"
+  },
+  {
+    "id": 1672,
+    "name": "lightningrod",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1673,
+    "name": "elementallockdown",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1674,
+    "name": "stoneheart",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1675,
+    "name": "blindingashes",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1676,
+    "name": "aquamancerstraining",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1678,
+    "name": "experimentalturrets",
+    "profession": "engineer"
+  },
+  {
+    "id": 1679,
+    "name": "gadgeteer",
+    "profession": "engineer"
+  },
+  {
+    "id": 1680,
+    "name": "bunkerdown",
+    "profession": "engineer"
+  },
+  {
+    "id": 1682,
+    "name": "forceofwill",
+    "profession": "guardian"
+  },
+  {
+    "id": 1683,
+    "name": "righteousinstincts",
+    "profession": "guardian"
+  },
+  {
+    "id": 1684,
+    "name": "communaldefenses",
+    "profession": "guardian"
+  },
+  {
+    "id": 1685,
+    "name": "purityofbody",
+    "profession": "guardian"
+  },
+  {
+    "id": 1686,
+    "name": "amplifiedwrath",
+    "profession": "guardian"
+  },
+  {
+    "id": 1687,
+    "name": "bountifuldisillusionment",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1688,
+    "name": "powerblock",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1690,
+    "name": "maimthedisillusioned",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1692,
+    "name": "unholymartyr",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1693,
+    "name": "pathofcorruption",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1694,
+    "name": "unholysanctuary",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1696,
+    "name": "parasiticcontagion",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1697,
+    "name": "invigoratingbond",
+    "profession": "ranger"
+  },
+  {
+    "id": 1698,
+    "name": "leadthewind",
+    "profession": "ranger"
+  },
+  {
+    "id": 1699,
+    "name": "wildernessknowledge",
+    "profession": "ranger"
+  },
+  {
+    "id": 1700,
+    "name": "stridersdefense",
+    "profession": "ranger"
+  },
+  {
+    "id": 1701,
+    "name": "poisonmaster",
+    "profession": "ranger"
+  },
+  {
+    "id": 1702,
+    "name": "invigoratingprecision",
+    "profession": "thief"
+  },
+  {
+    "id": 1703,
+    "name": "dontstop",
+    "profession": "thief"
+  },
+  {
+    "id": 1704,
+    "name": "revealedtraining",
+    "profession": "thief"
+  },
+  {
+    "id": 1705,
+    "name": "shadowsiphoning",
+    "profession": "thief"
+  },
+  {
+    "id": 1706,
+    "name": "deadlyambush",
+    "profession": "thief"
+  },
+  {
+    "id": 1707,
+    "name": "dualwielding",
+    "profession": "warrior"
+  },
+  {
+    "id": 1708,
+    "name": "rousingresilience",
+    "profession": "warrior"
+  },
+  {
+    "id": 1709,
+    "name": "brawlersrecovery",
+    "profession": "warrior"
+  },
+  {
+    "id": 1711,
+    "name": "phalanxstrength",
+    "profession": "warrior"
+  },
+  {
+    "id": 1713,
+    "name": "determinedresolution",
+    "profession": "revenant"
+  },
+  {
+    "id": 1714,
+    "name": "pactofpain",
+    "profession": "revenant"
+  },
+  {
+    "id": 1715,
+    "name": "brutality",
+    "profession": "revenant"
+  },
+  {
+    "id": 1716,
+    "name": "risingmomentum",
+    "profession": "revenant"
+  },
+  {
+    "id": 1719,
+    "name": "roilingmists",
+    "profession": "revenant"
+  },
+  {
+    "id": 1720,
+    "name": "fiendishtenacity",
+    "profession": "revenant"
+  },
+  {
+    "id": 1721,
+    "name": "permeatingpestilence",
+    "profession": "revenant"
+  },
+  {
+    "id": 1724,
+    "name": "destructiveimpulses",
+    "profession": "revenant"
+  },
+  {
+    "id": 1726,
+    "name": "demonicresistance",
+    "profession": "revenant"
+  },
+  {
+    "id": 1727,
+    "name": "abyssalchill",
+    "profession": "revenant"
+  },
+  {
+    "id": 1728,
+    "name": "closequarters",
+    "profession": "revenant"
+  },
+  {
+    "id": 1730,
+    "name": "hardeningpersistence",
+    "profession": "revenant"
+  },
+  {
+    "id": 1732,
+    "name": "cleansingchannel",
+    "profession": "revenant"
+  },
+  {
+    "id": 1737,
+    "name": "draconicfortitude",
+    "profession": "revenant"
+  },
+  {
+    "id": 1738,
+    "name": "sharedempowerment",
+    "profession": "revenant"
+  },
+  {
+    "id": 1740,
+    "name": "dwarvenbattletraining",
+    "profession": "revenant"
+  },
+  {
+    "id": 1741,
+    "name": "replenishingdespair",
+    "profession": "revenant"
+  },
+  {
+    "id": 1743,
+    "name": "shiningaspects",
+    "profession": "revenant"
+  },
+  {
+    "id": 1744,
+    "name": "yearningempowerment",
+    "profession": "revenant"
+  },
+  {
+    "id": 1746,
+    "name": "elevatedcompassion",
+    "profession": "revenant"
+  },
+  {
+    "id": 1749,
+    "name": "songofthemists",
+    "profession": "revenant"
+  },
+  {
+    "id": 1754,
+    "name": "danceofdeath",
+    "profession": "revenant"
+  },
+  {
+    "id": 1755,
+    "name": "battlescarred",
+    "profession": "revenant"
+  },
+  {
+    "id": 1757,
+    "name": "unwaveringavoidance",
+    "profession": "revenant"
+  },
+  {
+    "id": 1758,
+    "name": "ferociousaggression",
+    "profession": "revenant"
+  },
+  {
+    "id": 1760,
+    "name": "rapidflow",
+    "profession": "revenant"
+  },
+  {
+    "id": 1761,
+    "name": "risingtide",
+    "profession": "revenant"
+  },
+  {
+    "id": 1765,
+    "name": "notoriety",
+    "profession": "revenant"
+  },
+  {
+    "id": 1766,
+    "name": "eyeforaneye",
+    "profession": "revenant"
+  },
+  {
+    "id": 1767,
+    "name": "unsuspectingstrikes",
+    "profession": "revenant"
+  },
+  {
+    "id": 1769,
+    "name": "containedtemper",
+    "profession": "revenant"
+  },
+  {
+    "id": 1770,
+    "name": "versedinstone",
+    "profession": "revenant"
+  },
+  {
+    "id": 1772,
+    "name": "draconicecho",
+    "profession": "revenant"
+  },
+  {
+    "id": 1774,
+    "name": "spiritboon",
+    "profession": "revenant"
+  },
+  {
+    "id": 1776,
+    "name": "aggressiveagility",
+    "profession": "revenant"
+  },
+  {
+    "id": 1777,
+    "name": "crystalharbinger",
+    "profession": "revenant"
+  },
+  {
+    "id": 1778,
+    "name": "invokersrage",
+    "profession": "revenant"
+  },
+  {
+    "id": 1779,
+    "name": "viciousreprisal",
+    "profession": "revenant"
+  },
+  {
+    "id": 1781,
+    "name": "incensedresponse",
+    "profession": "revenant"
+  },
+  {
+    "id": 1782,
+    "name": "resoluteevasion",
+    "profession": "revenant"
+  },
+  {
+    "id": 1783,
+    "name": "enduringrecovery",
+    "profession": "revenant"
+  },
+  {
+    "id": 1784,
+    "name": "glaringresolve",
+    "profession": "revenant"
+  },
+  {
+    "id": 1786,
+    "name": "assassinspresence",
+    "profession": "revenant"
+  },
+  {
+    "id": 1788,
+    "name": "reinforcedpotency",
+    "profession": "revenant"
+  },
+  {
+    "id": 1789,
+    "name": "demonicdefiance",
+    "profession": "revenant"
+  },
+  {
+    "id": 1790,
+    "name": "steadfastrejuvenation",
+    "profession": "revenant"
+  },
+  {
+    "id": 1791,
+    "name": "chargedmists",
+    "profession": "revenant"
+  },
+  {
+    "id": 1792,
+    "name": "targeteddestruction",
+    "profession": "revenant"
+  },
+  {
+    "id": 1793,
+    "name": "acolyteoftorment",
+    "profession": "revenant"
+  },
+  {
+    "id": 1795,
+    "name": "diabolicinferno",
+    "profession": "revenant"
+  },
+  {
+    "id": 1799,
+    "name": "invokingtorment",
+    "profession": "revenant"
+  },
+  {
+    "id": 1800,
+    "name": "swifttermination",
+    "profession": "revenant"
+  },
+  {
+    "id": 1801,
+    "name": "seethingmalice",
+    "profession": "revenant"
+  },
+  {
+    "id": 1802,
+    "name": "thrillofcombat",
+    "profession": "revenant"
+  },
+  {
+    "id": 1803,
+    "name": "forcefulpersistence",
+    "profession": "revenant"
+  },
+  {
+    "id": 1806,
+    "name": "corevalue",
+    "profession": "revenant"
+  },
+  {
+    "id": 1808,
+    "name": "exposedefenses",
+    "profession": "revenant"
+  },
+  {
+    "id": 1810,
+    "name": "spiritualreckoning",
+    "profession": "revenant"
+  },
+  {
+    "id": 1811,
+    "name": "planarprotection",
+    "profession": "revenant"
+  },
+  {
+    "id": 1813,
+    "name": "eldersrespite",
+    "profession": "revenant"
+  },
+  {
+    "id": 1814,
+    "name": "serenerejuvenation",
+    "profession": "revenant"
+  },
+  {
+    "id": 1815,
+    "name": "generousabundance",
+    "profession": "revenant"
+  },
+  {
+    "id": 1816,
+    "name": "healersgift",
+    "profession": "revenant"
+  },
+  {
+    "id": 1817,
+    "name": "resilientspirit",
+    "profession": "revenant"
+  },
+  {
+    "id": 1818,
+    "name": "invokingharmony",
+    "profession": "revenant"
+  },
+  {
+    "id": 1819,
+    "name": "wordsofcensure",
+    "profession": "revenant"
+  },
+  {
+    "id": 1820,
+    "name": "selflessamplification",
+    "profession": "revenant"
+  },
+  {
+    "id": 1821,
+    "name": "lifeattunement",
+    "profession": "revenant"
+  },
+  {
+    "id": 1822,
+    "name": "tranquilbalance",
+    "profession": "revenant"
+  },
+  {
+    "id": 1823,
+    "name": "vitalblessing",
+    "profession": "revenant"
+  },
+  {
+    "id": 1824,
+    "name": "blindingtruths",
+    "profession": "revenant"
+  },
+  {
+    "id": 1825,
+    "name": "unyieldingdevotion",
+    "profession": "revenant"
+  },
+  {
+    "id": 1826,
+    "name": "longbowproficiency",
+    "profession": "guardian"
+  },
+  {
+    "id": 1829,
+    "name": "torchproficiency",
+    "profession": "warrior"
+  },
+  {
+    "id": 1831,
+    "name": "primalrage",
+    "profession": "warrior"
+  },
+  {
+    "id": 1832,
+    "name": "takedownround",
+    "profession": "engineer"
+  },
+  {
+    "id": 1833,
+    "name": "lotustraining",
+    "profession": "thief"
+  },
+  {
+    "id": 1834,
+    "name": "soothingdetonation",
+    "profession": "engineer"
+  },
+  {
+    "id": 1835,
+    "name": "zealotsaggression",
+    "profession": "guardian"
+  },
+  {
+    "id": 1837,
+    "name": "endurancethief",
+    "profession": "thief"
+  },
+  {
+    "id": 1838,
+    "name": "delayedreactions",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1839,
+    "name": "transcendenttempest",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1844,
+    "name": "vampiricpresence",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1846,
+    "name": "hiddenbarbs",
+    "profession": "ranger"
+  },
+  {
+    "id": 1848,
+    "name": "virtuousaction",
+    "profession": "guardian"
+  },
+  {
+    "id": 1849,
+    "name": "appliedforce",
+    "profession": "engineer"
+  },
+  {
+    "id": 1852,
+    "name": "inspiringdistortion",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1854,
+    "name": "ironblooded",
+    "profession": "engineer"
+  },
+  {
+    "id": 1856,
+    "name": "kineticbattery",
+    "profession": "engineer"
+  },
+  {
+    "id": 1859,
+    "name": "timemarcheson",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1860,
+    "name": "objectinmotion",
+    "profession": "engineer"
+  },
+  {
+    "id": 1861,
+    "name": "gofortheeyes",
+    "profession": "ranger"
+  },
+  {
+    "id": 1862,
+    "name": "livevicariously",
+    "profession": "ranger"
+  },
+  {
+    "id": 1863,
+    "name": "bitterchill",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1865,
+    "name": "chaoticpersistence",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1866,
+    "name": "illusionaryinspiration",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1867,
+    "name": "massmomentum",
+    "profession": "engineer"
+  },
+  {
+    "id": 1868,
+    "name": "druidicclarity",
+    "profession": "ranger"
+  },
+  {
+    "id": 1869,
+    "name": "persistenceofmemory",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1871,
+    "name": "purityofpurpose",
+    "profession": "engineer"
+  },
+  {
+    "id": 1872,
+    "name": "mechanizeddeployment",
+    "profession": "engineer"
+  },
+  {
+    "id": 1874,
+    "name": "celestialbeing",
+    "profession": "ranger"
+  },
+  {
+    "id": 1876,
+    "name": "bloodbond",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1877,
+    "name": "impactsavant",
+    "profession": "engineer"
+  },
+  {
+    "id": 1878,
+    "name": "chemicalrounds",
+    "profession": "engineer"
+  },
+  {
+    "id": 1879,
+    "name": "shiversofdread",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1882,
+    "name": "glasscannon",
+    "profession": "engineer"
+  },
+  {
+    "id": 1883,
+    "name": "insidiousdisruption",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1884,
+    "name": "staffmaster",
+    "profession": "thief"
+  },
+  {
+    "id": 1886,
+    "name": "unstableconduit",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1887,
+    "name": "weakeningstrikes",
+    "profession": "thief"
+  },
+  {
+    "id": 1888,
+    "name": "viciousquarry",
+    "profession": "ranger"
+  },
+  {
+    "id": 1889,
+    "name": "blindingdissipation",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1890,
+    "name": "chronophantasma",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1891,
+    "name": "tempestuousaria",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1892,
+    "name": "explosivetemper",
+    "profession": "engineer"
+  },
+  {
+    "id": 1893,
+    "name": "havocspecialist",
+    "profession": "thief"
+  },
+  {
+    "id": 1896,
+    "name": "defendersdogma",
+    "profession": "guardian"
+  },
+  {
+    "id": 1898,
+    "name": "piercinglight",
+    "profession": "guardian"
+  },
+  {
+    "id": 1899,
+    "name": "invigoratedbulwark",
+    "profession": "guardian"
+  },
+  {
+    "id": 1900,
+    "name": "packalpha",
+    "profession": "ranger"
+  },
+  {
+    "id": 1901,
+    "name": "automatedmedicalresponse",
+    "profession": "engineer"
+  },
+  {
+    "id": 1902,
+    "name": "harmoniousconduit",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1904,
+    "name": "noquarter",
+    "profession": "thief"
+  },
+  {
+    "id": 1905,
+    "name": "shroudknight",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1908,
+    "name": "huntersfortification",
+    "profession": "guardian"
+  },
+  {
+    "id": 1910,
+    "name": "shieldproficiency",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1911,
+    "name": "soaringdevastation",
+    "profession": "guardian"
+  },
+  {
+    "id": 1912,
+    "name": "lightonyourfeet",
+    "profession": "ranger"
+  },
+  {
+    "id": 1913,
+    "name": "illusionaryreversion",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1914,
+    "name": "highcaliber",
+    "profession": "engineer"
+  },
+  {
+    "id": 1915,
+    "name": "healingprism",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1916,
+    "name": "medicaldispersionfield",
+    "profession": "engineer"
+  },
+  {
+    "id": 1917,
+    "name": "gyroscopicacceleration",
+    "profession": "engineer"
+  },
+  {
+    "id": 1919,
+    "name": "deathlychill",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1922,
+    "name": "shroudedremoval",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1923,
+    "name": "noscope",
+    "profession": "engineer"
+  },
+  {
+    "id": 1925,
+    "name": "zealousscepter",
+    "profession": "guardian"
+  },
+  {
+    "id": 1926,
+    "name": "pureofsight",
+    "profession": "guardian"
+  },
+  {
+    "id": 1927,
+    "name": "flowoftime",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1928,
+    "name": "bloodyroar",
+    "profession": "warrior"
+  },
+  {
+    "id": 1929,
+    "name": "beyondtheveil",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1930,
+    "name": "sanguinearray",
+    "profession": "engineer"
+  },
+  {
+    "id": 1931,
+    "name": "lastrites",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1932,
+    "name": "blightersboon",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1933,
+    "name": "maraudersresilience",
+    "profession": "thief"
+  },
+  {
+    "id": 1935,
+    "name": "primalechoes",
+    "profession": "ranger"
+  },
+  {
+    "id": 1936,
+    "name": "excessiveenergy",
+    "profession": "engineer"
+  },
+  {
+    "id": 1938,
+    "name": "gatheredfocus",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1940,
+    "name": "corruptersfervor",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1941,
+    "name": "fragility",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1942,
+    "name": "losttime",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1943,
+    "name": "bulwark",
+    "profession": "guardian"
+  },
+  {
+    "id": 1944,
+    "name": "blastshield",
+    "profession": "engineer"
+  },
+  {
+    "id": 1945,
+    "name": "beastlywarden",
+    "profession": "ranger"
+  },
+  {
+    "id": 1946,
+    "name": "lockon",
+    "profession": "engineer"
+  },
+  {
+    "id": 1947,
+    "name": "bigboomer",
+    "profession": "engineer"
+  },
+  {
+    "id": 1948,
+    "name": "hardyconduit",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1949,
+    "name": "brawlerstenacity",
+    "profession": "thief"
+  },
+  {
+    "id": 1950,
+    "name": "ineptitude",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1951,
+    "name": "hammerproficiency",
+    "profession": "engineer"
+  },
+  {
+    "id": 1952,
+    "name": "galesong",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1954,
+    "name": "damagedampener",
+    "profession": "engineer"
+  },
+  {
+    "id": 1955,
+    "name": "biggamehunter",
+    "profession": "guardian"
+  },
+  {
+    "id": 1957,
+    "name": "staffproficiency",
+    "profession": "thief"
+  },
+  {
+    "id": 1959,
+    "name": "functiongyro",
+    "profession": "engineer"
+  },
+  {
+    "id": 1960,
+    "name": "evasivemirror",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1962,
+    "name": "latentstamina",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1963,
+    "name": "heavylight",
+    "profession": "guardian"
+  },
+  {
+    "id": 1964,
+    "name": "unhinderedcombatant",
+    "profession": "thief"
+  },
+  {
+    "id": 1965,
+    "name": "staffproficiency",
+    "profession": "ranger"
+  },
+  {
+    "id": 1969,
+    "name": "souleater",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1971,
+    "name": "systemshocker",
+    "profession": "engineer"
+  },
+  {
+    "id": 1974,
+    "name": "auguryofdeath",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1975,
+    "name": "impactingdisruption",
+    "profession": "thief"
+  },
+  {
+    "id": 1977,
+    "name": "savageinstinct",
+    "profession": "warrior"
+  },
+  {
+    "id": 1978,
+    "name": "improvedalacrity",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1979,
+    "name": "optimizedactivation",
+    "profession": "engineer"
+  },
+  {
+    "id": 1980,
+    "name": "protectedphantasms",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1981,
+    "name": "adaptivearmor",
+    "profession": "engineer"
+  },
+  {
+    "id": 1983,
+    "name": "dulledsenses",
+    "profession": "guardian"
+  },
+  {
+    "id": 1984,
+    "name": "pinpointdistribution",
+    "profession": "engineer"
+  },
+  {
+    "id": 1985,
+    "name": "greatswordproficiency",
+    "profession": "necromancer"
+  },
+  {
+    "id": 1986,
+    "name": "elementalbastion",
+    "profession": "elementalist"
+  },
+  {
+    "id": 1987,
+    "name": "allswellthatendswell",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1988,
+    "name": "protectiveward",
+    "profession": "ranger"
+  },
+  {
+    "id": 1992,
+    "name": "naturalmender",
+    "profession": "ranger"
+  },
+  {
+    "id": 1993,
+    "name": "burstofaggression",
+    "profession": "warrior"
+  },
+  {
+    "id": 1994,
+    "name": "physicalsupremacy",
+    "profession": "thief"
+  },
+  {
+    "id": 1995,
+    "name": "timecatchesup",
+    "profession": "mesmer"
+  },
+  {
+    "id": 1997,
+    "name": "reactivelenses",
+    "profession": "engineer"
+  },
+  {
+    "id": 1999,
+    "name": "expertexamination",
+    "profession": "engineer"
+  },
+  {
+    "id": 2000,
+    "name": "bodyblow",
+    "profession": "warrior"
+  },
+  {
+    "id": 2001,
+    "name": "verdantetching",
+    "profession": "ranger"
+  },
+  {
+    "id": 2002,
+    "name": "deadoralive",
+    "profession": "warrior"
+  },
+  {
+    "id": 2004,
+    "name": "elementalenchantment",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2005,
+    "name": "mentaldefense",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2006,
+    "name": "thermalvision",
+    "profession": "engineer"
+  },
+  {
+    "id": 2008,
+    "name": "chillingvictory",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2009,
+    "name": "dangertime",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2011,
+    "name": "bloodreaction",
+    "profession": "warrior"
+  },
+  {
+    "id": 2013,
+    "name": "plaguesending",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2014,
+    "name": "speedofsynergy",
+    "profession": "engineer"
+  },
+  {
+    "id": 2015,
+    "name": "invigoratingtorrents",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2016,
+    "name": "cultivatedsynergy",
+    "profession": "ranger"
+  },
+  {
+    "id": 2017,
+    "name": "symbolicavenger",
+    "profession": "guardian"
+  },
+  {
+    "id": 2018,
+    "name": "coldshoulder",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2020,
+    "name": "chillingnova",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2021,
+    "name": "reapersonslaught",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2022,
+    "name": "seizethemoment",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2023,
+    "name": "escapistsfortitude",
+    "profession": "thief"
+  },
+  {
+    "id": 2025,
+    "name": "singularity",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2026,
+    "name": "relentlesspursuit",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2028,
+    "name": "soothingpower",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2030,
+    "name": "timesplitter",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2031,
+    "name": "decimatedefenses",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2032,
+    "name": "refinedtoxins",
+    "profession": "ranger"
+  },
+  {
+    "id": 2033,
+    "name": "lucidsingularity",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2035,
+    "name": "masteroffragmentation",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2036,
+    "name": "warhornproficiency",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2037,
+    "name": "huntersdetermination",
+    "profession": "guardian"
+  },
+  {
+    "id": 2038,
+    "name": "kingoffires",
+    "profession": "warrior"
+  },
+  {
+    "id": 2039,
+    "name": "lastblaze",
+    "profession": "warrior"
+  },
+  {
+    "id": 2042,
+    "name": "heatthesoul",
+    "profession": "warrior"
+  },
+  {
+    "id": 2043,
+    "name": "eternalchampion",
+    "profession": "warrior"
+  },
+  {
+    "id": 2046,
+    "name": "fatalfrenzy",
+    "profession": "warrior"
+  },
+  {
+    "id": 2047,
+    "name": "boundingdodger",
+    "profession": "thief"
+  },
+  {
+    "id": 2049,
+    "name": "smashbrawler",
+    "profession": "warrior"
+  },
+  {
+    "id": 2050,
+    "name": "shieldproficiency",
+    "profession": "revenant"
+  },
+  {
+    "id": 2052,
+    "name": "kineticaccelerators",
+    "profession": "engineer"
+  },
+  {
+    "id": 2053,
+    "name": "celestialshadow",
+    "profession": "ranger"
+  },
+  {
+    "id": 2055,
+    "name": "ancientseeds",
+    "profession": "ranger"
+  },
+  {
+    "id": 2056,
+    "name": "naturalstride",
+    "profession": "ranger"
+  },
+  {
+    "id": 2057,
+    "name": "graceoftheland",
+    "profession": "ranger"
+  },
+  {
+    "id": 2058,
+    "name": "lingeringlight",
+    "profession": "ranger"
+  },
+  {
+    "id": 2059,
+    "name": "desertempowerment",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2060,
+    "name": "magebanetether",
+    "profession": "warrior"
+  },
+  {
+    "id": 2061,
+    "name": "swiftrevenge",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2062,
+    "name": "swiftscholar",
+    "profession": "guardian"
+  },
+  {
+    "id": 2063,
+    "name": "weightyterms",
+    "profession": "guardian"
+  },
+  {
+    "id": 2064,
+    "name": "photonicblastingmodule",
+    "profession": "engineer"
+  },
+  {
+    "id": 2066,
+    "name": "thermalreleasevalve",
+    "profession": "engineer"
+  },
+  {
+    "id": 2067,
+    "name": "sadisticsearing",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2069,
+    "name": "nomadsendurance",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2070,
+    "name": "infinitehorizon",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2071,
+    "name": "livefast",
+    "profession": "ranger"
+  },
+  {
+    "id": 2072,
+    "name": "unstoppableunion",
+    "profession": "ranger"
+  },
+  {
+    "id": 2073,
+    "name": "axeproficiency",
+    "profession": "guardian"
+  },
+  {
+    "id": 2074,
+    "name": "fellbeacon",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2075,
+    "name": "unrelentingcriticism",
+    "profession": "guardian"
+  },
+  {
+    "id": 2076,
+    "name": "stalwartspeed",
+    "profession": "guardian"
+  },
+  {
+    "id": 2077,
+    "name": "elementalrefreshment",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2078,
+    "name": "payback",
+    "profession": "thief"
+  },
+  {
+    "id": 2079,
+    "name": "bloodfury",
+    "profession": "revenant"
+  },
+  {
+    "id": 2080,
+    "name": "feedfromcorruption",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2081,
+    "name": "elementalpolyphony",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2082,
+    "name": "renewingoasis",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2084,
+    "name": "ironsight",
+    "profession": "thief"
+  },
+  {
+    "id": 2085,
+    "name": "essenceofspeed",
+    "profession": "ranger"
+  },
+  {
+    "id": 2086,
+    "name": "archivistofwhispers",
+    "profession": "guardian"
+  },
+  {
+    "id": 2087,
+    "name": "axeproficiency",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2088,
+    "name": "daggerproficiency",
+    "profession": "ranger"
+  },
+  {
+    "id": 2089,
+    "name": "purityofword",
+    "profession": "guardian"
+  },
+  {
+    "id": 2090,
+    "name": "wovenstride",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2091,
+    "name": "crystalconfigurationzephyr",
+    "profession": "engineer"
+  },
+  {
+    "id": 2092,
+    "name": "heartpiercer",
+    "profession": "revenant"
+  },
+  {
+    "id": 2093,
+    "name": "bequickorbekilled",
+    "profession": "thief"
+  },
+  {
+    "id": 2094,
+    "name": "vindication",
+    "profession": "revenant"
+  },
+  {
+    "id": 2095,
+    "name": "sunandmoonstyle",
+    "profession": "warrior"
+  },
+  {
+    "id": 2096,
+    "name": "bloodassand",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2097,
+    "name": "slowcounter",
+    "profession": "warrior"
+  },
+  {
+    "id": 2098,
+    "name": "mirroredaxes",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2099,
+    "name": "shortbowproficiency",
+    "profession": "revenant"
+  },
+  {
+    "id": 2100,
+    "name": "lastinglegacy",
+    "profession": "revenant"
+  },
+  {
+    "id": 2101,
+    "name": "liberatorsvow",
+    "profession": "guardian"
+  },
+  {
+    "id": 2102,
+    "name": "nourishingashes",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2103,
+    "name": "crystalconfigurationstorm",
+    "profession": "engineer"
+  },
+  {
+    "id": 2105,
+    "name": "stoicdemeanor",
+    "profession": "guardian"
+  },
+  {
+    "id": 2106,
+    "name": "solarfocusinglens",
+    "profession": "engineer"
+  },
+  {
+    "id": 2107,
+    "name": "purestrike",
+    "profession": "warrior"
+  },
+  {
+    "id": 2108,
+    "name": "allforone",
+    "profession": "revenant"
+  },
+  {
+    "id": 2109,
+    "name": "weaver",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2110,
+    "name": "riddleofsand",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2111,
+    "name": "maleficentseven",
+    "profession": "thief"
+  },
+  {
+    "id": 2112,
+    "name": "sandsavant",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2113,
+    "name": "elusivemind",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2114,
+    "name": "lightdensityamplifier",
+    "profession": "engineer"
+  },
+  {
+    "id": 2115,
+    "name": "mastersfortitude",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2116,
+    "name": "legendarylore",
+    "profession": "guardian"
+  },
+  {
+    "id": 2117,
+    "name": "speedofsand",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2118,
+    "name": "silentscope",
+    "profession": "thief"
+  },
+  {
+    "id": 2119,
+    "name": "secondskin",
+    "profession": "ranger"
+  },
+  {
+    "id": 2120,
+    "name": "wroughtironwill",
+    "profession": "revenant"
+  },
+  {
+    "id": 2121,
+    "name": "sandsage",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2122,
+    "name": "lasersedge",
+    "profession": "engineer"
+  },
+  {
+    "id": 2123,
+    "name": "heraldofsorrow",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2124,
+    "name": "daggerproficiency",
+    "profession": "warrior"
+  },
+  {
+    "id": 2125,
+    "name": "swordproficiency",
+    "profession": "engineer"
+  },
+  {
+    "id": 2126,
+    "name": "lossaversion",
+    "profession": "warrior"
+  },
+  {
+    "id": 2127,
+    "name": "twiceasvicious",
+    "profession": "ranger"
+  },
+  {
+    "id": 2128,
+    "name": "leaderofthepack",
+    "profession": "ranger"
+  },
+  {
+    "id": 2129,
+    "name": "rifleproficiency",
+    "profession": "thief"
+  },
+  {
+    "id": 2130,
+    "name": "attackersinsight",
+    "profession": "warrior"
+  },
+  {
+    "id": 2131,
+    "name": "elementsofrage",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2133,
+    "name": "boldreversal",
+    "profession": "revenant"
+  },
+  {
+    "id": 2134,
+    "name": "freshreinforcement",
+    "profession": "ranger"
+  },
+  {
+    "id": 2135,
+    "name": "heattherapy",
+    "profession": "engineer"
+  },
+  {
+    "id": 2136,
+    "name": "oneinthechamber",
+    "profession": "thief"
+  },
+  {
+    "id": 2137,
+    "name": "enhancedcapacitystorageunit",
+    "profession": "engineer"
+  },
+  {
+    "id": 2138,
+    "name": "invigoratingstrikes",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2140,
+    "name": "noescape",
+    "profession": "warrior"
+  },
+  {
+    "id": 2141,
+    "name": "selfdeception",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2142,
+    "name": "brutalmomentum",
+    "profession": "revenant"
+  },
+  {
+    "id": 2143,
+    "name": "oppressivesuperiority",
+    "profession": "ranger"
+  },
+  {
+    "id": 2144,
+    "name": "torchproficiency",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2145,
+    "name": "maliciousintent",
+    "profession": "thief"
+  },
+  {
+    "id": 2146,
+    "name": "fireforeffect",
+    "profession": "thief"
+  },
+  {
+    "id": 2147,
+    "name": "mantleofsand",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2148,
+    "name": "imbuedhaste",
+    "profession": "guardian"
+  },
+  {
+    "id": 2149,
+    "name": "swordproficiency",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2150,
+    "name": "miragecloak",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2151,
+    "name": "elevatedbond",
+    "profession": "ranger"
+  },
+  {
+    "id": 2152,
+    "name": "crystalconfigurationeclipse",
+    "profession": "engineer"
+  },
+  {
+    "id": 2153,
+    "name": "guardcounter",
+    "profession": "warrior"
+  },
+  {
+    "id": 2154,
+    "name": "endlessenmity",
+    "profession": "revenant"
+  },
+  {
+    "id": 2155,
+    "name": "eternalbond",
+    "profession": "ranger"
+  },
+  {
+    "id": 2156,
+    "name": "furiousstrength",
+    "profession": "ranger"
+  },
+  {
+    "id": 2157,
+    "name": "prismaticconverter",
+    "profession": "engineer"
+  },
+  {
+    "id": 2158,
+    "name": "photonprojector",
+    "profession": "engineer"
+  },
+  {
+    "id": 2159,
+    "name": "loremaster",
+    "profession": "guardian"
+  },
+  {
+    "id": 2160,
+    "name": "premeditation",
+    "profession": "thief"
+  },
+  {
+    "id": 2161,
+    "name": "predatorscunning",
+    "profession": "ranger"
+  },
+  {
+    "id": 2162,
+    "name": "dispellingforce",
+    "profession": "warrior"
+  },
+  {
+    "id": 2163,
+    "name": "enchantmentcollapse",
+    "profession": "warrior"
+  },
+  {
+    "id": 2164,
+    "name": "demoniclore",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2165,
+    "name": "elementalpursuit",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2166,
+    "name": "ashendemeanor",
+    "profession": "revenant"
+  },
+  {
+    "id": 2167,
+    "name": "abrasivegrit",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2168,
+    "name": "revengecounter",
+    "profession": "warrior"
+  },
+  {
+    "id": 2169,
+    "name": "dunecloak",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2170,
+    "name": "bolsteredelements",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2171,
+    "name": "deadeyesgaze",
+    "profession": "thief"
+  },
+  {
+    "id": 2172,
+    "name": "renewinggaze",
+    "profession": "thief"
+  },
+  {
+    "id": 2173,
+    "name": "collateraldamage",
+    "profession": "thief"
+  },
+  {
+    "id": 2174,
+    "name": "miragemantle",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2175,
+    "name": "spellbreakersconviction",
+    "profession": "warrior"
+  },
+  {
+    "id": 2177,
+    "name": "superiorelements",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2178,
+    "name": "desertdistortion",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2179,
+    "name": "quickfire",
+    "profession": "guardian"
+  },
+  {
+    "id": 2180,
+    "name": "weaversprowess",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2181,
+    "name": "ambushcommander",
+    "profession": "revenant"
+  },
+  {
+    "id": 2182,
+    "name": "righteousrebel",
+    "profession": "revenant"
+  },
+  {
+    "id": 2183,
+    "profession": "necromancer"
+  },
+  {
+    "id": 2185,
+    "profession": "necromancer"
+  },
+  {
+    "id": 2186,
+    "name": "alchemicvigor",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2187,
+    "name": "conceitedcurate",
+    "profession": "guardian"
+  },
+  {
+    "id": 2188,
+    "profession": "necromancer"
+  },
+  {
+    "id": 2189,
+    "name": "lethaltempo",
+    "profession": "guardian"
+  },
+  {
+    "id": 2190,
+    "name": "powerforpower",
+    "profession": "guardian"
+  },
+  {
+    "id": 2191,
+    "name": "boonpact",
+    "profession": "guardian"
+  },
+  {
+    "id": 2192,
+    "name": "implacablefoe",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2193,
+    "name": "quietintensity",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2194,
+    "profession": "necromancer"
+  },
+  {
+    "id": 2195,
+    "name": "phoenixprotocol",
+    "profession": "guardian"
+  },
+  {
+    "id": 2196,
+    "name": "swordproficiency",
+    "profession": "guardian"
+  },
+  {
+    "id": 2197,
+    "name": "restorativevirtues",
+    "profession": "guardian"
+  },
+  {
+    "id": 2198,
+    "name": "deathlesscourage",
+    "profession": "guardian"
+  },
+  {
+    "id": 2199,
+    "name": "vanguardtactics",
+    "profession": "guardian"
+  },
+  {
+    "id": 2200,
+    "name": "willbendertraining",
+    "profession": "guardian"
+  },
+  {
+    "id": 2201,
+    "name": "tyrantsmomentum",
+    "profession": "guardian"
+  },
+  {
+    "id": 2202,
+    "name": "jaggedmind",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2203,
+    "name": "doomapproaches",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2204,
+    "name": "deadlyblades",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2205,
+    "name": "phantasmalblades",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2206,
+    "name": "infiniteforge",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2207,
+    "name": "sharpeningsorrow",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2208,
+    "name": "mentalfocus",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2209,
+    "name": "darkgunslinger",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2210,
+    "name": "holyreckoning",
+    "profession": "guardian"
+  },
+  {
+    "id": 2211,
+    "name": "psychicriposte",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2212,
+    "name": "bladeturnrefrain",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2213,
+    "name": "pistolproficiency",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2214,
+    "name": "daggerproficiency",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2215,
+    "name": "duelistsreversal",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2216,
+    "name": "psychicblades",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2217,
+    "name": "corruptedtalent",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2218,
+    "profession": "necromancer"
+  },
+  {
+    "id": 2219,
+    "profession": "necromancer"
+  },
+  {
+    "id": 2220,
+    "name": "twistedmedicine",
+    "profession": "necromancer"
+  },
+  {
+    "id": 2222,
+    "name": "righteoussprint",
+    "profession": "guardian"
+  },
+  {
+    "id": 2223,
+    "name": "bloodsong",
+    "profession": "mesmer"
+  },
+  {
+    "id": 2224,
+    "profession": "elementalist"
+  },
+  {
+    "id": 2225,
+    "name": "unseensword",
+    "profession": "warrior"
+  },
+  {
+    "id": 2226,
+    "name": "gunxsword",
+    "profession": "warrior"
+  },
+  {
+    "id": 2227,
+    "name": "depthofelements",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2228,
+    "name": "redemptorssermon",
+    "profession": "revenant"
+  },
+  {
+    "id": 2229,
+    "name": "empiredivided",
+    "profession": "revenant"
+  },
+  {
+    "id": 2230,
+    "profession": "elementalist"
+  },
+  {
+    "id": 2231,
+    "name": "elementalepitome",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2232,
+    "name": "vassalsoftheempire",
+    "profession": "revenant"
+  },
+  {
+    "id": 2233,
+    "name": "staunchauras",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2234,
+    "profession": "elementalist"
+  },
+  {
+    "id": 2235,
+    "name": "greatswordproficiency",
+    "profession": "revenant"
+  },
+  {
+    "id": 2236,
+    "name": "gunsandglory",
+    "profession": "warrior"
+  },
+  {
+    "id": 2237,
+    "name": "riversflow",
+    "profession": "warrior"
+  },
+  {
+    "id": 2238,
+    "name": "saintofzuheltzer",
+    "profession": "revenant"
+  },
+  {
+    "id": 2239,
+    "name": "unyieldingdragon",
+    "profession": "warrior"
+  },
+  {
+    "id": 2240,
+    "name": "lushforest",
+    "profession": "warrior"
+  },
+  {
+    "id": 2241,
+    "name": "empoweredempowerment",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2242,
+    "name": "dragonscaledefense",
+    "profession": "warrior"
+  },
+  {
+    "id": 2243,
+    "name": "angsiyanstrust",
+    "profession": "revenant"
+  },
+  {
+    "id": 2244,
+    "name": "fierceasfire",
+    "profession": "warrior"
+  },
+  {
+    "id": 2245,
+    "name": "daringdragon",
+    "profession": "warrior"
+  },
+  {
+    "id": 2246,
+    "name": "hammerproficiency",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2247,
+    "profession": "elementalist"
+  },
+  {
+    "id": 2248,
+    "name": "amnestyofshingjea",
+    "profession": "revenant"
+  },
+  {
+    "id": 2249,
+    "name": "evasiveempowerment",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2250,
+    "name": "elementalempowerment",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2251,
+    "name": "spherespecialist",
+    "profession": "elementalist"
+  },
+  {
+    "id": 2252,
+    "profession": "elementalist"
+  },
+  {
+    "id": 2253,
+    "name": "unshakablemountain",
+    "profession": "warrior"
+  },
+  {
+    "id": 2254,
+    "name": "balanceindiscord",
+    "profession": "revenant"
+  },
+  {
+    "id": 2255,
+    "name": "songofarboreum",
+    "profession": "revenant"
+  },
+  {
+    "id": 2256,
+    "name": "pistolproficiency",
+    "profession": "warrior"
+  },
+  {
+    "id": 2257,
+    "name": "forerunnerofdeath",
+    "profession": "revenant"
+  },
+  {
+    "id": 2258,
+    "name": "leviathanstrength",
+    "profession": "revenant"
+  },
+  {
+    "id": 2259,
+    "name": "reaverscurse",
+    "profession": "revenant"
+  },
+  {
+    "id": 2260,
+    "name": "swiftasthewind",
+    "profession": "warrior"
+  },
+  {
+    "id": 2261,
+    "name": "immortaldragon",
+    "profession": "warrior"
+  },
+  {
+    "id": 2262,
+    "name": "tenaciousruin",
+    "profession": "revenant"
+  }
+]

--- a/updateMappings.js
+++ b/updateMappings.js
@@ -43,7 +43,7 @@ function fetchSpecializations() {
         // write to disk
         fs.writeFile(
           `${MAPPINGS_PATH}specializations.json`,
-          JSON.stringify(specs),
+          JSON.stringify(specs, null, 2),
           { flag: 'w+' },
           (err) => {
             if (err) {
@@ -89,7 +89,7 @@ function fetchTraits() {
           // write to disk
           fs.writeFile(
             `${MAPPINGS_PATH}traits.json`,
-            JSON.stringify(traits),
+            JSON.stringify(traits, null, 2),
             { flag: 'w+' },
             (err) => {
               if (err) {
@@ -133,7 +133,7 @@ function fetchSkills() {
           // write to disk
           fs.writeFile(
             `${MAPPINGS_PATH}skills.json`,
-            JSON.stringify(skills),
+            JSON.stringify(skills, null, 2),
             { flag: 'w+' },
             (err) => {
               if (err) {
@@ -166,7 +166,7 @@ function fetchItemStats() {
         // write to disk
         fs.writeFile(
           `${MAPPINGS_PATH}itemstats.json`,
-          JSON.stringify(statsFinal),
+          JSON.stringify(statsFinal, null, 2),
           { flag: 'w+' },
           (err) => {
             if (err) {
@@ -271,7 +271,7 @@ function fetchItems() {
         });
 
       // write to disk
-      fs.writeFile(`${MAPPINGS_PATH}items.json`, JSON.stringify(items), { flag: 'w+' }, (err) => {
+      fs.writeFile(`${MAPPINGS_PATH}items.json`, JSON.stringify(items, null, 2), { flag: 'w+' }, (err) => {
         if (err) {
           console.error(err);
         } else {


### PR DESCRIPTION
This pretty-prints the JSON data generated by `yarn updateMappings`, which as far as I can tell should have no effect besides making the diffs cleaner and avoiding IDEs choking on the 150k-character single line. (It looks like Webpack minifies JSON into bundles, so the extra whitespace and newlines don't get included in the build.)