### PR TITLE
run testModifiers automatically

### DIFF
--- a/.github/workflows/test-modifiers.yml
+++ b/.github/workflows/test-modifiers.yml
@@ -2,6 +2,9 @@ name: Test Modifiers
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - src/assets/modifierdata/**
 
 env:
   NODE_VERSION: 16


### PR DESCRIPTION
This runs testModifers automatically on any PR that affects src/assets/modifierdata.

Not enabling this now, just storing it in case we want it at some point.