### PR TITLE
Fix autocomplete

### DIFF
--- a/src/components/baseComponents/Presets.jsx
+++ b/src/components/baseComponents/Presets.jsx
@@ -40,15 +40,10 @@ const Presets = ({ className, data, handleClick }) => {
               t(preset.name)
             )
           }
-          onSelect={(event) => {
-            const clickedIndex = data.indexOf(
-              data.find((preset) => preset.name === event.target.defaultValue),
-            );
-            handleClick(clickedIndex)(event);
-          }}
+          onChange={(event, value) => handleClick(value)}
         />
       ) : (
-        data.map((preset, index) => (
+        data.map((preset) => (
           <Chip
             id={preset.name}
             key={preset.name}
@@ -63,7 +58,7 @@ const Presets = ({ className, data, handleClick }) => {
               )
             }
             variant="outlined"
-            onClick={handleClick(index)}
+            onClick={handleClick(preset)}
             className={classes.templateChip}
           />
         ))

--- a/src/components/baseComponents/Presets.jsx
+++ b/src/components/baseComponents/Presets.jsx
@@ -3,7 +3,9 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
 import classNames from 'classnames';
 import { Profession } from 'gw2-ui-bulk';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
+import { getProfession } from '../../state/controlsSlice';
 import { firstUppercase } from '../../utils/usefulFunctions';
 
 const useStyles = makeStyles((theme) => ({
@@ -21,11 +23,13 @@ const MAX_CHIPS = 6;
 const Presets = ({ className, data, handleClick }) => {
   const classes = useStyles();
   const { t } = useTranslation();
+  const profession = useSelector(getProfession);
 
   return (
     <div className={classNames(className, classes.root)}>
       {data.length > MAX_CHIPS ? (
         <Autocomplete
+          key={`${profession}-presets`}
           id="presets"
           options={data}
           getOptionLabel={(preset) => preset.name}

--- a/src/components/baseComponents/Presets.jsx
+++ b/src/components/baseComponents/Presets.jsx
@@ -5,7 +5,7 @@ import { Profession } from 'gw2-ui-bulk';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
-import { getProfession } from '../../state/controlsSlice';
+import { getProfession, getControl } from '../../state/controlsSlice';
 import { firstUppercase } from '../../utils/usefulFunctions';
 
 const useStyles = makeStyles((theme) => ({
@@ -24,12 +24,13 @@ const Presets = ({ className, data, handleClick }) => {
   const classes = useStyles();
   const { t } = useTranslation();
   const profession = useSelector(getProfession);
+  const selectedTemplateName = useSelector(getControl('selectedTemplate'));
 
   return (
     <div className={classNames(className, classes.root)}>
       {data.length > MAX_CHIPS ? (
         <Autocomplete
-          key={`${profession}-presets`}
+          key={`${selectedTemplateName || profession}-presets`}
           id="presets"
           options={data}
           getOptionLabel={(preset) => preset.name}

--- a/src/components/baseComponents/Presets.jsx
+++ b/src/components/baseComponents/Presets.jsx
@@ -40,6 +40,9 @@ const Presets = ({ className, data, handleClick }) => {
               t(preset.name)
             )
           }
+          blurOnSelect
+          disableClearable
+          clearOnBlur={false}
           onChange={(event, value) => handleClick(value)}
         />
       ) : (

--- a/src/components/sections/buffs/BuffsSection.jsx
+++ b/src/components/sections/buffs/BuffsSection.jsx
@@ -11,11 +11,13 @@ const BuffsSection = ({ data }) => {
   const { t } = useTranslation();
 
   const handleTemplateClickBuffs = React.useCallback(
-    (index) => (event) => {
-      const state = JSON.parse(data.presetBuffs.list[index].value);
+    (value) => {
+      if (value === null) return;
+
+      const state = JSON.parse(value.value);
       dispatch(replaceBuffs(state));
     },
-    [data.presetBuffs.list, dispatch],
+    [dispatch],
   );
 
   return (

--- a/src/components/sections/distribution/DistributionSection.jsx
+++ b/src/components/sections/distribution/DistributionSection.jsx
@@ -35,19 +35,16 @@ const DistributionSection = ({ profession, data }) => {
   }
 
   const onTemplateClickDistribution = React.useCallback(
-    (index) => (event) => {
-      if (index < 0) {
-        dispatch(resetDistributions());
-        return;
-      }
+    (value) => {
+      if (value === null) return;
 
-      const state = JSON.parse(distributionPresets[index].value);
+      const state = JSON.parse(value.value);
 
       dispatch(changeAllDistributionsOld(state.values1));
       dispatch(changeAllDistributionsNew(state.values2));
       dispatch(changeAllTextBoxes(state.values2));
     },
-    [dispatch, distributionPresets],
+    [dispatch],
   );
 
   return (

--- a/src/components/sections/extras/ExtrasSection.jsx
+++ b/src/components/sections/extras/ExtrasSection.jsx
@@ -27,13 +27,13 @@ const ExtrasSection = ({ profession, data }) => {
   }
 
   const onTemplateClickExtras = React.useCallback(
-    (index) => (event) => {
-      if (index < 0) return;
+    (value) => {
+      if (value === null) return;
 
-      const newExtras = JSON.parse(extrasPresets[index].value);
+      const newExtras = JSON.parse(value.value);
       dispatch(changeExtras(newExtras));
     },
-    [dispatch, extrasPresets],
+    [dispatch],
   );
 
   return (

--- a/src/components/sections/infusions/InfusionsSection.jsx
+++ b/src/components/sections/infusions/InfusionsSection.jsx
@@ -13,13 +13,13 @@ const InfusionsSection = ({ data }) => {
   const infusionPresets = data.presetInfusions.list;
 
   const onTemplateClickInfusions = React.useCallback(
-    (index) => (event) => {
-      if (index < 0) return;
+    (value) => {
+      if (value === null) return;
 
-      const newInfusions = JSON.parse(infusionPresets[index].value);
+      const newInfusions = JSON.parse(value.value);
       dispatch(changeInfusions(newInfusions));
     },
-    [dispatch, infusionPresets],
+    [dispatch],
   );
 
   return (

--- a/src/components/sections/priorities/PrioritiesSection.jsx
+++ b/src/components/sections/priorities/PrioritiesSection.jsx
@@ -11,11 +11,12 @@ const PrioritiesSection = ({ data }) => {
   const { t } = useTranslation();
 
   const handleTemplateClickPriorities = React.useCallback(
-    (index) => (event) => {
-      const state = JSON.parse(data.presetAffixes.list[index].value);
+    (value) => {
+      if (value === null) return;
+      const state = JSON.parse(value.value);
       Object.keys(state).forEach((key) => dispatch(changePriority({ key, value: state[key] })));
     },
-    [data.presetAffixes.list, dispatch],
+    [dispatch],
   );
 
   return (

--- a/src/components/sections/traits/TraitsSection.jsx
+++ b/src/components/sections/traits/TraitsSection.jsx
@@ -30,16 +30,16 @@ const TraitsSection = ({ profession, data }) => {
   }
 
   const onTemplateClickTraits = React.useCallback(
-    (index) => (event) => {
-      if (index < 0) return;
+    (value) => {
+      if (value === null) return;
 
-      const newTraits = JSON.parse(traitsPresets[index].traits);
+      const newTraits = JSON.parse(value.traits);
       dispatch(changeTraits(newTraits));
 
-      const newSkills = JSON.parse(traitsPresets[index].skills);
+      const newSkills = JSON.parse(value.skills);
       dispatch(changeSkills(newSkills));
     },
-    [dispatch, traitsPresets],
+    [dispatch],
   );
 
   return (


### PR DESCRIPTION
This fixes up the MUI autocomplete component used for presets when there are a lot of them. It changes the onSelect callback to an onChange callback to fix its inconsistency firing the update, changes the <Preset> callback API to do this more cleanly, and also fixes the problem where when you switch professions or templates, the old text was still in the autocomplete, a mismatch compared to the actual state.