### PR TITLE
Move affixes data

### DIFF
--- a/src/components/sections/Affixes.jsx
+++ b/src/components/sections/Affixes.jsx
@@ -6,6 +6,9 @@ import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { changePriority, getPriority } from '../../state/slices/priorities';
 import { firstUppercase } from '../../utils/usefulFunctions';
+import { Affix } from '../../utils/gw2-data';
+
+const AFFIXES = Object.keys(Affix).map((entry) => entry.toUpperCase());
 
 const styles = (theme) => ({
   text: {
@@ -15,55 +18,6 @@ const styles = (theme) => ({
     minWidth: 180,
   },
 });
-
-export const AFFIXES = [
-  'BERSERKER',
-  'ZEALOT',
-  'SOLDIER',
-  // 'FORSAKEN',  exotic
-  'VALKYRIE',
-  'HARRIER',
-  // 'PALADIN', PVP
-  'COMMANDER',
-  // 'DEMOLISHER', PVP
-  // 'SWASHBUCKLER', PVP
-  'MARAUDER',
-  // 'AVATAR', PVP
-  // 'DESTROYER', PVP
-  'VIGILANT',
-  'CRUSADER',
-  'WANDERER',
-  'DIVINER',
-  // 'WIZARD', PVP
-  'VIPER',
-  'GRIEVING',
-  // 'SAGE', PVP
-  'MARSHAL',
-  // 'CAPTAIN', exotic
-  'RAMPAGER',
-  'ASSASSIN',
-  'SERAPH',
-  'KNIGHT',
-  'CAVALIER',
-  'NOMAD',
-  'SETTLER',
-  'GIVER',
-  'TRAILBLAZER',
-  'MINSTREL',
-  'SENTINEL',
-  'SHAMAN',
-  'SINISTER',
-  'CARRION',
-  'RABID',
-  'DIRE',
-  // 'APOSTATE', exotic
-  'PLAGUEDOCTOR',
-  'BRINGER',
-  'CLERIC',
-  'MAGI',
-  'APOTHECARY',
-  'CELESTIAL',
-];
 
 const Affixes = ({ classes }) => {
   const dispatch = useDispatch();

--- a/src/components/sections/Affixes.jsx
+++ b/src/components/sections/Affixes.jsx
@@ -8,7 +8,7 @@ import { changePriority, getPriority } from '../../state/slices/priorities';
 import { firstUppercase } from '../../utils/usefulFunctions';
 import { Affix } from '../../utils/gw2-data';
 
-const AFFIXES = Object.keys(Affix).map((entry) => entry.toUpperCase());
+const AFFIXES = Object.keys(Affix);
 
 const styles = (theme) => ({
   text: {

--- a/src/components/sections/forcedslots/ForcedSlots.jsx
+++ b/src/components/sections/forcedslots/ForcedSlots.jsx
@@ -5,9 +5,10 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { changeForcedSlot, getForcedSlots } from '../../../state/slices/forcedSlots';
 import { getPriority } from '../../../state/slices/priorities';
-import { GEAR_SLOTS } from '../../../utils/gw2-data';
+import { GEAR_SLOTS, Affix } from '../../../utils/gw2-data';
 import { firstUppercase } from '../../../utils/usefulFunctions';
-import { AFFIXES } from '../Affixes';
+
+const AFFIXES = Object.keys(Affix).map((entry) => entry.toUpperCase());
 
 const styles = (theme) => ({
   textField: { marginTop: 0, marginBottom: 0 },

--- a/src/components/sections/forcedslots/ForcedSlots.jsx
+++ b/src/components/sections/forcedslots/ForcedSlots.jsx
@@ -8,7 +8,7 @@ import { getPriority } from '../../../state/slices/priorities';
 import { GEAR_SLOTS, Affix } from '../../../utils/gw2-data';
 import { firstUppercase } from '../../../utils/usefulFunctions';
 
-const AFFIXES = Object.keys(Affix).map((entry) => entry.toUpperCase());
+const AFFIXES = Object.keys(Affix);
 
 const styles = (theme) => ({
   textField: { marginTop: 0, marginBottom: 0 },

--- a/src/utils/gw2-data.js
+++ b/src/utils/gw2-data.js
@@ -182,13 +182,6 @@ export const Affix = {
       minor: ['Power', 'Ferocity'],
     },
   },
-  'Berserker+Valkyrie': {
-    type: 'bervalk',
-    bonuses: {
-      major: ['Power'],
-      minor: ['Vitality', 'Ferocity'],
-    },
-  },
   Celestial: {
     type: 'celestial',
     bonuses: {


### PR DESCRIPTION
Uses affixes data directly from gw2-data.js instead of having a separate copy in Affixes.jsx  and changes the affixes in the UI to `Startcase`.