### PR TITLE
Use <Autocomplete> for AR

### DIFF
--- a/src/components/sections/infusions/Infusions.jsx
+++ b/src/components/sections/infusions/Infusions.jsx
@@ -144,7 +144,7 @@ const Infusions = ({ classes }) => {
               />
             )}
             id="ar_input-with-icon-adornment"
-            inputValue={ar}
+            value={ar}
             onInputChange={handleARChange}
           />
         </Grid>

--- a/src/components/sections/infusions/Infusions.jsx
+++ b/src/components/sections/infusions/Infusions.jsx
@@ -46,13 +46,7 @@ const Infusions = ({ classes }) => {
   const omnipotion = useSelector(getOmniPotion);
   const infusions = useSelector(getInfusions);
 
-  const handleARChange = React.useCallback(
-    (event, value) => {
-      console.log('ar changed to ', value);
-      dispatch(changeAR(value));
-    },
-    [dispatch],
-  );
+  const handleARChange = React.useCallback((_e, value) => dispatch(changeAR(value)), [dispatch]);
 
   const { error: arError } = parseAmount(ar);
 

--- a/src/components/sections/infusions/Infusions.jsx
+++ b/src/components/sections/infusions/Infusions.jsx
@@ -4,11 +4,13 @@ import {
   Input,
   InputLabel,
   InputAdornment,
+  TextField,
   MenuItem,
   Select,
   withStyles,
   Typography,
 } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
 import { Attribute, Item } from 'gw2-ui-bulk';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -45,8 +47,8 @@ const Infusions = ({ classes }) => {
   const infusions = useSelector(getInfusions);
 
   const handleARChange = React.useCallback(
-    (event) => {
-      const { value } = event.target;
+    (event, value) => {
+      console.log('ar changed to ', value);
       dispatch(changeAR(value));
     },
     [dispatch],
@@ -121,23 +123,30 @@ const Infusions = ({ classes }) => {
           />
         </Grid>
         <Grid item xs={12}>
-          <FormControl>
-            <InputLabel htmlFor="ar_input-with-icon-adornment">
-              <Trans>Agony Resistance</Trans>
-            </InputLabel>
-            <Input
-              id="ar_input-with-icon-adornment"
-              value={ar}
-              endAdornment={
-                <InputAdornment position="end">
-                  <Attribute name="Agony Resistance" disableLink disableText />
-                </InputAdornment>
-              }
-              onChange={handleARChange}
-              autoComplete="off"
-              error={arError}
-            />
-          </FormControl>
+          <Autocomplete
+            className={classes.formControl}
+            freeSolo
+            disableClearable
+            options={['150', '162', '222']}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                error={arError}
+                InputProps={{
+                  ...params.InputProps,
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <Attribute name="Agony Resistance" disableLink disableText />
+                    </InputAdornment>
+                  ),
+                }}
+                label={t('Agony Resistance')}
+              />
+            )}
+            id="ar_input-with-icon-adornment"
+            inputValue={ar}
+            onInputChange={handleARChange}
+          />
         </Grid>
       </Grid>
       <Grid


### PR DESCRIPTION
Yep, I'm PRing my own PR.

Cute QoL improvement on the AR box that adds a dropdown with presets but otherwise continues to act as a text box using the `freeSolo` mode of MUI's `Autocomplete` component.

- [x] Bug: This always calls onInputChange with an empty string as value on first render ("reason" is `reset`), so the initial state of `'162'` is discarded. 