### PR TITLE
en of line unification

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,9 @@
 # editorconfig.org
 root = true
 
+[*]
+end_of_line = lf
+
 [*.html]
 indent_style = space
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
unify end of line configuration among git, editorconfig and prettier (which detects .editorconfig so no need to specify in .prettierrc) to all use lf
without the unification inconsistency may occur with different user configurations of git and the default behavior of editorconfig and prettier 
best to run `git reset --hard` (remember to first stash uncommited changes, if any) or something alike to update indexes on local repositories after applying this change