### PR TITLE
Fix: Parse distribution inputs correctly 

### DIFF
--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -173,9 +173,16 @@ const DamageDistribution = ({ classes }) => {
 
   const handleChangeTextNew = (key) => (e) => {
     const { value } = e.target;
-    if (value.match('^[-+]?[0-9]*.?[0-9]+([eE][-+]?[0-9]+)?$')) {
-      // only update the actual slider when the number entered is a valid string. The regex matches for integer or floats.
-      dispatch(changeDistributionNew({ index: key, value }));
+
+    if (!value) {
+      dispatch(changeDistributionNew({ index: key, value: 0 }));
+
+      // only update the value when the text entered is a valid number. The regex matches for integer or floats.
+    } else if (value.match('^[-+]?[0-9]*.?[0-9]+([eE][-+]?[0-9]+)?$')) {
+      const parsedValue = Number.parseInt(value, 10);
+      if (!Number.isNaN(parsedValue)) {
+        dispatch(changeDistributionNew({ index: key, value }));
+      }
     }
 
     dispatch(changeTextBoxes({ index: key, value }));

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -179,9 +179,9 @@ const DamageDistribution = ({ classes }) => {
 
       // only update the value when the text entered is a valid number. The regex matches for integer or floats.
     } else if (value.match('^[-+]?[0-9]*.?[0-9]+([eE][-+]?[0-9]+)?$')) {
-      const parsedValue = Number.parseInt(value, 10);
+      const parsedValue = Number.parseFloat(value);
       if (!Number.isNaN(parsedValue)) {
-        dispatch(changeDistributionNew({ index: key, value }));
+        dispatch(changeDistributionNew({ index: key, value: parsedValue }));
       }
     }
 

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -53,9 +53,9 @@ let isChanged = true;
  * @param {?number} input.primaryMaxInfusions - number of infusions, 0-18
  * @param {?number} input.secondaryMaxInfusions - number of infusions, 0-18
  * @param {?number} input.distributionVersion - version 1: old style (percentDistribution) - verison 2: new style (coeff / sec)
- * @param {?object.<number>} input.percentDistribution - old style distribution
+ * @param {?object.<string, number>} input.percentDistribution - old style distribution
  *                                   (sums to 100)
- * @param {?object.<number>} input.distribution - new style distribution
+ * @param {?object.<string, number>} input.distribution - new style distribution
  *                                   (coefficient * weaponstrength per second; average condition stacks)
  * @returns {object} settings - parsed settings object
  */

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -53,9 +53,9 @@ let isChanged = true;
  * @param {?number} input.primaryMaxInfusions - number of infusions, 0-18
  * @param {?number} input.secondaryMaxInfusions - number of infusions, 0-18
  * @param {?number} input.distributionVersion - version 1: old style (percentDistribution) - verison 2: new style (coeff / sec)
- * @param {?object.<string, number>} input.percentDistribution - old style distribution
+ * @param {?object.<number>} input.percentDistribution - old style distribution
  *                                   (sums to 100)
- * @param {?object.<string, number>} input.distribution - new style distribution
+ * @param {?object.<number>} input.distribution - new style distribution
  *                                   (coefficient * weaponstrength per second; average condition stacks)
  * @returns {object} settings - parsed settings object
  */


### PR DESCRIPTION
Previously, backspacing out the contents of a distribution text box would silently leave the old values selected. Additionally, distribution numbers were inconsistently passed as strings instead of numbers, messing up some core logic (hashtag things that would not happen if we used typescript :P)

