### PR TITLE
memoize Item and GatsbyImage in character

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-fast-compare": "^3.2.0",
     "react-i18next": "^11.12.0",
     "react-jss": "^10.7.1",
     "react-redux": "^7.2.0",

--- a/src/components/gw2/Armor.jsx
+++ b/src/components/gw2/Armor.jsx
@@ -1,7 +1,10 @@
 import { List, ListItem, ListItemText, withStyles } from '@material-ui/core';
-import { Item } from 'gw2-ui-bulk';
+import { Item as ItemRaw } from 'gw2-ui-bulk';
 import React from 'react';
+import equal from 'react-fast-compare';
 import { resolveArmor } from '../../utils/map-gw2-ids';
+
+const Item = React.memo(ItemRaw, equal);
 
 const styles = (theme) => ({
   listItem: {

--- a/src/components/gw2/BackAndTrinkets.jsx
+++ b/src/components/gw2/BackAndTrinkets.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { withStyles, Grid, Typography } from '@material-ui/core';
 import classNames from 'classnames';
-import { Item } from 'gw2-ui-bulk';
+import { Item as ItemRaw } from 'gw2-ui-bulk';
+import equal from 'react-fast-compare';
 import { resolveBackAndTrinkets } from '../../utils/map-gw2-ids';
+
+const Item = React.memo(ItemRaw, equal);
 
 const styles = (theme) => ({
   gridItem: {

--- a/src/components/gw2/Character.jsx
+++ b/src/components/gw2/Character.jsx
@@ -1,10 +1,12 @@
 import { Box, Paper, useMediaQuery, useTheme, withStyles } from '@material-ui/core';
-import { GatsbyImage } from 'gatsby-plugin-image';
+import { GatsbyImage as GatsbyImageRaw } from 'gatsby-plugin-image';
 import React from 'react';
 import Armor from './Armor';
 import Attributes from './Attributes';
 import BackAndTrinkets from './BackAndTrinkets';
 import Weapons from './Weapons';
+
+const GatsbyImage = React.memo(GatsbyImageRaw);
 
 const styles = (theme) => ({
   container: { maxHeight: '600px' },

--- a/src/components/gw2/Weapons.jsx
+++ b/src/components/gw2/Weapons.jsx
@@ -1,7 +1,10 @@
 import { Icon, List, ListItem, ListItemText, withStyles } from '@material-ui/core';
-import { Item } from 'gw2-ui-bulk';
+import { Item as ItemRaw } from 'gw2-ui-bulk';
 import React from 'react';
+import equal from 'react-fast-compare';
 import TextDivider from '../baseComponents/TextDivider';
+
+const Item = React.memo(ItemRaw, equal);
 
 const styles = (theme) => ({
   listItem: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10416,7 +10416,7 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-fast-compare@^3.1.1:
+react-fast-compare@^3.1.1, react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==


### PR DESCRIPTION
~Every gw2-ui component should be memoized imo, but if that's true, that should be added to gw2-ui, not this codebase.

However, this codebase currently passes arrays as props into `Item`s without memoizing the array generation, which would break the default React.memo implementation. I assume this will get refactored out at some point, but I'm not working on that rn, so this just puts a deep equality check on them.

Also memoized the GatsbyImage.