### PR TITLE
Fix: change table header when rankBy changes

### DIFF
--- a/src/components/sections/results/ResultTable.jsx
+++ b/src/components/sections/results/ResultTable.jsx
@@ -55,15 +55,21 @@ const StickyHeadTable = ({ classes }) => {
   }
 
   const firstCharacter = list[0];
-  const weaponType = firstCharacter?.settings?.weaponType || 'Two-handed';
-  const infusions = firstCharacter?.infusions || {};
+  const weaponType = firstCharacter?.settings?.weaponType;
+  const infusions = firstCharacter?.infusions;
+  const rankBy = firstCharacter?.settings?.rankby;
 
   return (
     <Box boxShadow={8}>
       <TableContainer className={classes.container}>
         <Table stickyHeader aria-label="sticky table" className={classes.tableCollapse}>
           <TableHead>
-            <ResultTableHeaderRow classes={classes} weaponType={weaponType} infusions={infusions} />
+            <ResultTableHeaderRow
+              classes={classes}
+              weaponType={weaponType}
+              infusions={infusions}
+              rankBy={rankBy}
+            />
           </TableHead>
           <TableBody className={classes.pointer}>
             {list.map((character, i) => {

--- a/src/components/sections/results/ResultTableHeaderRow.jsx
+++ b/src/components/sections/results/ResultTableHeaderRow.jsx
@@ -1,15 +1,24 @@
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
-import { Trans } from 'gatsby-plugin-react-i18next';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { Item } from 'gw2-ui-bulk';
 import React from 'react';
 import { Slots, INFUSION_IDS } from '../../../utils/gw2-data';
 
-const ResultTableHeaderRow = ({ classes, weaponType, infusions = {} }) => {
+const ResultTableHeaderRow = ({
+  classes,
+  weaponType = 'Two-handed',
+  infusions = {},
+  rankBy = 'Damage',
+}) => {
+  const { t } = useTranslation();
+
   return (
     <TableRow>
       <TableCell className={classes.tablehead}>
-        <Trans>Damage</Trans>
+        {t('priorityGoal', {
+          context: rankBy,
+        })}
       </TableCell>
       {Slots[weaponType].map((slot) => (
         <TableCell className={classes.tablehead} key={slot.name} align="center" padding="none">


### PR DESCRIPTION
Changes the leftmost table header cell to healing or survivability when that's the selected sort mode.

Am I using useTranslation correctly?