### PR TITLE
Parse and validate text boxes consistently

### DIFF
--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -28,6 +28,7 @@ import {
   getTextBoxes,
   coefficientsToPercents,
 } from '../../../state/slices/distribution';
+import { parseDistribution } from '../../../utils/usefulFunctions';
 
 const Attribute = React.memo(AttributeRaw);
 const Condition = React.memo(ConditionRaw);
@@ -176,19 +177,10 @@ const DamageDistribution = ({ classes }) => {
 
   const handleChangeTextNew = (key) => (e) => {
     const { value } = e.target;
-
-    if (!value) {
-      dispatch(changeDistributionNew({ index: key, value: 0 }));
-
-      // only update the value when the text entered is a valid number. The regex matches for integer or floats.
-    } else if (value.match('^[-+]?[0-9]*.?[0-9]+([eE][-+]?[0-9]+)?$')) {
-      const parsedValue = parseFloat(value);
-      if (!Number.isNaN(parsedValue)) {
-        dispatch(changeDistributionNew({ index: key, value: parsedValue }));
-      }
-    }
-
     dispatch(changeTextBoxes({ index: key, value }));
+
+    const parsedValue = parseDistribution(value).value;
+    dispatch(changeDistributionNew({ index: key, value: parsedValue }));
   };
   const SlidersNew = () => {
     return DISTRIBUTION_NAMES.map((dist, index) => (
@@ -220,7 +212,9 @@ const DamageDistribution = ({ classes }) => {
                   )}
                 </InputAdornment>
               }
+              error={parseDistribution(textBoxes[dist.name]).error}
               onChange={handleChangeTextNew(dist.name)}
+              autoComplete="off"
             />
           </FormControl>
         </Box>

--- a/src/components/sections/infusions/InfusionHelper.jsx
+++ b/src/components/sections/infusions/InfusionHelper.jsx
@@ -33,6 +33,7 @@ import {
 import { infusionIds } from '../../../utils/gw2-data';
 import CheckboxComponent from '../../baseComponents/CheckboxComponent';
 import TextDivider from '../../baseComponents/TextDivider';
+import { parseAr, parseInfusionCount } from '../../../utils/usefulFunctions';
 
 const Item = React.memo(ItemRaw);
 const CommonEffect = React.memo(CommonEffectRaw);
@@ -111,23 +112,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-// todo: import this from somewhere
-const parseTextNumber = (text, defaultValue) => {
-  const parsed = parseInt(text, 10);
-  if (Number.isNaN(parsed)) {
-    return defaultValue;
-  }
-  return Math.max(parsed, 0);
-};
-
 const InfusionHelper = () => {
   const dispatch = useDispatch();
   const classes = useStyles();
 
-  const arString = useSelector(getAR);
-  const ar = parseTextNumber(arString, 0);
-  const maxInfusionsString = useSelector(getMaxInfusions);
-  const maxInfusions = parseTextNumber(maxInfusionsString, 18);
+  const ar = parseAr(useSelector(getAR)).value;
+  const maxInfusions = parseInfusionCount(useSelector(getMaxInfusions)).value;
   const primaryInfusion = useSelector(getPrimaryInfusion);
   const secondaryInfusion = useSelector(getSecondaryInfusion);
   const { enabled, impedence, attunement, singularity, tear, slots, freeWvW, ownedMatrix } =

--- a/src/components/sections/infusions/Infusions.jsx
+++ b/src/components/sections/infusions/Infusions.jsx
@@ -26,7 +26,7 @@ import {
   changeOmnipotion,
   changeInfusion,
 } from '../../../state/slices/infusions';
-import { parseAr } from '../../../utils/usefulFunctions';
+import { parseAr, parseInfusionCount } from '../../../utils/usefulFunctions';
 import CheckboxComponent from '../../baseComponents/CheckboxComponent';
 import InfusionHelper from './InfusionHelper';
 import HelperIcon from '../../baseComponents/HelperIcon';
@@ -90,7 +90,7 @@ const Infusions = ({ classes }) => {
   };
 
   const input = (name, varName, value, className) => {
-    const { error } = parseAr(value);
+    const { error } = parseInfusionCount(value);
     return (
       <FormControl className={className}>
         <InputLabel htmlFor={`${varName}_input-with-icon-adornment`}>{name}</InputLabel>

--- a/src/components/sections/infusions/Infusions.jsx
+++ b/src/components/sections/infusions/Infusions.jsx
@@ -26,7 +26,7 @@ import {
   changeOmnipotion,
   changeInfusion,
 } from '../../../state/slices/infusions';
-import { parseAmount } from '../../../utils/usefulFunctions';
+import { parseAr } from '../../../utils/usefulFunctions';
 import CheckboxComponent from '../../baseComponents/CheckboxComponent';
 import InfusionHelper from './InfusionHelper';
 import HelperIcon from '../../baseComponents/HelperIcon';
@@ -57,7 +57,7 @@ const Infusions = ({ classes }) => {
 
   const handleARChange = React.useCallback((_e, value) => dispatch(changeAR(value)), [dispatch]);
 
-  const { error: arError } = parseAmount(ar);
+  const { error: arError } = parseAr(ar);
 
   const dropdown = (name, varName, infusion) => {
     return (
@@ -90,7 +90,7 @@ const Infusions = ({ classes }) => {
   };
 
   const input = (name, varName, value, className) => {
-    const { error } = parseAmount(value);
+    const { error } = parseAr(value);
     return (
       <FormControl className={className}>
         <InputLabel htmlFor={`${varName}_input-with-icon-adornment`}>{name}</InputLabel>

--- a/src/components/sections/priorities/Priorities.jsx
+++ b/src/components/sections/priorities/Priorities.jsx
@@ -138,6 +138,7 @@ const Priorities = ({ classes }) => {
               onChange={handleChange}
               name="minBoonDuration"
               error={parsePriority(minBoonDuration).error}
+              autoComplete="off"
             />
           </FormControl>
           <HelperIcon
@@ -155,6 +156,7 @@ const Priorities = ({ classes }) => {
               onChange={handleChange}
               name="minHealingPower"
               error={parsePriority(minHealingPower).error}
+              autoComplete="off"
             />
           </FormControl>
           <HelperIcon
@@ -174,6 +176,7 @@ const Priorities = ({ classes }) => {
               onChange={handleChange}
               name="minToughness"
               error={parsePriority(minToughness).error}
+              autoComplete="off"
             />
           </FormControl>
           <HelperIcon text={t('Only show results that fulfill a minimum amount of Toughness.')} />
@@ -189,6 +192,7 @@ const Priorities = ({ classes }) => {
               onChange={handleChange}
               name="maxToughness"
               error={parsePriority(maxToughness).error}
+              autoComplete="off"
             />
           </FormControl>
           <HelperIcon text={t('Only show results that fulfill a maximum amount of Toughness.')} />

--- a/src/components/sections/priorities/Priorities.jsx
+++ b/src/components/sections/priorities/Priorities.jsx
@@ -16,6 +16,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { changePriority, getPriority } from '../../../state/slices/priorities';
 import HelperIcon from '../../baseComponents/HelperIcon';
 import Affixes from '../Affixes';
+import { parsePriority } from '../../../utils/usefulFunctions';
 
 const styles = (theme) => ({
   text: {
@@ -136,6 +137,7 @@ const Priorities = ({ classes }) => {
               value={minBoonDuration}
               onChange={handleChange}
               name="minBoonDuration"
+              error={parsePriority(minBoonDuration).error}
             />
           </FormControl>
           <HelperIcon
@@ -152,6 +154,7 @@ const Priorities = ({ classes }) => {
               value={minHealingPower}
               onChange={handleChange}
               name="minHealingPower"
+              error={parsePriority(minHealingPower).error}
             />
           </FormControl>
           <HelperIcon
@@ -170,6 +173,7 @@ const Priorities = ({ classes }) => {
               value={minToughness}
               onChange={handleChange}
               name="minToughness"
+              error={parsePriority(minToughness).error}
             />
           </FormControl>
           <HelperIcon text={t('Only show results that fulfill a minimum amount of Toughness.')} />
@@ -184,6 +188,7 @@ const Priorities = ({ classes }) => {
               value={maxToughness}
               onChange={handleChange}
               name="maxToughness"
+              error={parsePriority(maxToughness).error}
             />
           </FormControl>
           <HelperIcon text={t('Only show results that fulfill a maximum amount of Toughness.')} />

--- a/src/components/sections/results/TemplateHelper.jsx
+++ b/src/components/sections/results/TemplateHelper.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Typography, TextField } from '@material-ui/core';
 import { useTranslation, Trans } from 'gatsby-plugin-react-i18next';
-import { parseAmount } from '../../../utils/usefulFunctions';
+import { parseDistribution } from '../../../utils/usefulFunctions';
 
 const initial = {
   Power: 0,
@@ -31,7 +31,7 @@ const TemplateHelper = ({ character }) => {
 
   const [input, setInput] = React.useState(initial);
   const data = Object.entries(input).map(([key, inputText]) => {
-    const { value, error } = parseAmount(inputText);
+    const { value, error } = parseDistribution(inputText);
     return { key, inputText, value, error };
   });
 

--- a/src/components/sections/traits/TraitAmount.jsx
+++ b/src/components/sections/traits/TraitAmount.jsx
@@ -4,8 +4,6 @@ import React from 'react';
 import { parseAmount } from '../../../utils/usefulFunctions';
 
 const TraitAmount = ({ amountData, handleAmountChange, value = '', disabled }) => {
-  // const parsedValue = Number(value);
-  // const isError = Number.isNaN(parsedValue) || parsedValue < 0;
   const { t } = useTranslation();
 
   const { error } = parseAmount(value);

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -968,10 +968,11 @@ function checkInvalid(character) {
   const { settings, attributes } = character;
 
   const invalid =
-    (settings.minBoonDuration && attributes['Boon Duration'] < settings.minBoonDuration / 100) ||
-    (settings.minHealingPower && attributes['Healing Power'] < settings.minHealingPower) ||
-    (settings.minToughness && attributes['Toughness'] < settings.minToughness) ||
-    (settings.maxToughness && attributes['Toughness'] > settings.maxToughness);
+    (settings.minBoonDuration !== null &&
+      attributes['Boon Duration'] < settings.minBoonDuration / 100) ||
+    (settings.minHealingPower !== null && attributes['Healing Power'] < settings.minHealingPower) ||
+    (settings.minToughness !== null && attributes['Toughness'] < settings.minToughness) ||
+    (settings.maxToughness !== null && attributes['Toughness'] > settings.maxToughness);
   if (invalid) {
     character.valid = false;
   }

--- a/src/state/optimizer/sagas.js
+++ b/src/state/optimizer/sagas.js
@@ -21,6 +21,8 @@ import { getTraitsModifiers, getCurrentSpecialization } from '../slices/traits';
 
 import { ERROR, SUCCESS, WAITING } from './status';
 
+import { parseInfusionCount } from '../../utils/usefulFunctions';
+
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function createInput(state, specialization, appliedModifiers, cachedFormState) {
@@ -48,17 +50,9 @@ function createInput(state, specialization, appliedModifiers, cachedFormState) {
     },
   } = state;
 
-  const parseTextNumber = (text, defaultValue) => {
-    const parsed = parseInt(text, 10);
-    if (Number.isNaN(parsed)) {
-      return defaultValue;
-    }
-    return Math.max(parsed, 0);
-  };
-
-  const maxInfusions = parseTextNumber(maxInfusionsInput, 18);
-  const primaryMaxInfusions = parseTextNumber(primaryMaxInfusionsInput, 18);
-  const secondaryMaxInfusions = parseTextNumber(secondaryMaxInfusionsInput, 18);
+  const maxInfusions = parseInfusionCount(maxInfusionsInput).value;
+  const primaryMaxInfusions = parseInfusionCount(primaryMaxInfusionsInput).value;
+  const secondaryMaxInfusions = parseInfusionCount(secondaryMaxInfusionsInput).value;
 
   const input = {
     tags: undefined,

--- a/src/state/optimizer/sagas.js
+++ b/src/state/optimizer/sagas.js
@@ -21,7 +21,7 @@ import { getTraitsModifiers, getCurrentSpecialization } from '../slices/traits';
 
 import { ERROR, SUCCESS, WAITING } from './status';
 
-import { parseInfusionCount } from '../../utils/usefulFunctions';
+import { parseInfusionCount, parsePriority } from '../../utils/usefulFunctions';
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -32,27 +32,32 @@ function createInput(state, specialization, appliedModifiers, cachedFormState) {
       infusions: {
         primaryInfusion,
         secondaryInfusion,
-        maxInfusions: maxInfusionsInput,
-        primaryMaxInfusions: primaryMaxInfusionsInput,
-        secondaryMaxInfusions: secondaryMaxInfusionsInput,
+        maxInfusions: maxInfusionsText,
+        primaryMaxInfusions: primaryMaxInfusionsText,
+        secondaryMaxInfusions: secondaryMaxInfusionsText,
       },
       forcedSlots: { slots },
       priorities: {
         optimizeFor,
         weaponType,
-        minBoonDuration,
-        minHealingPower,
-        minToughness,
-        maxToughness,
+        minBoonDuration: minBoonDurationText,
+        minHealingPower: minHealingPowerText,
+        minToughness: minToughnessText,
+        maxToughness: maxToughnessText,
         affixes,
       },
       distribution: { version, values1, values2 },
     },
   } = state;
 
-  const maxInfusions = parseInfusionCount(maxInfusionsInput).value;
-  const primaryMaxInfusions = parseInfusionCount(primaryMaxInfusionsInput).value;
-  const secondaryMaxInfusions = parseInfusionCount(secondaryMaxInfusionsInput).value;
+  const maxInfusions = parseInfusionCount(maxInfusionsText).value;
+  const primaryMaxInfusions = parseInfusionCount(primaryMaxInfusionsText).value;
+  const secondaryMaxInfusions = parseInfusionCount(secondaryMaxInfusionsText).value;
+
+  const minBoonDuration = parsePriority(minBoonDurationText).value;
+  const minHealingPower = parsePriority(minHealingPowerText).value;
+  const minToughness = parsePriority(minToughnessText).value;
+  const maxToughness = parsePriority(maxToughnessText).value;
 
   const input = {
     tags: undefined,

--- a/src/state/slices/infusions.js
+++ b/src/state/slices/infusions.js
@@ -1,6 +1,6 @@
 import { createSlice, createSelector } from '@reduxjs/toolkit';
 import { omnipotionModifiers, infusionIds } from '../../utils/gw2-data';
-import { parseAmount } from '../../utils/usefulFunctions';
+import { parseAmount, parseAr, parseInfusionCount } from '../../utils/usefulFunctions';
 import { changeAll } from './controlsSlice';
 
 export const infusionsSlice = createSlice({
@@ -143,15 +143,6 @@ const calcAgonyInfusions = (slots, ar) => {
   return { agonyCost, agonyText, agonyArray };
 };
 
-// todo: import this from somewhere
-const parseTextNumber = (text, defaultValue) => {
-  const parsed = parseInt(text, 10);
-  if (Number.isNaN(parsed)) {
-    return defaultValue;
-  }
-  return Math.max(parsed, 0);
-};
-
 export const getHelperResult = createSelector(
   getAR,
   getMaxInfusions,
@@ -169,8 +160,8 @@ export const getHelperResult = createSelector(
     secondaryMaxInfusions,
     helperData,
   ) => {
-    const ar = parseTextNumber(arString, 0);
-    const maxInfusions = parseTextNumber(maxInfusionsString, 18);
+    const ar = parseAr(arString).value;
+    const maxInfusions = parseInfusionCount(maxInfusionsString).value;
 
     const { impedence, attunement, singularity, tear, slots, freeWvW, ownedMatrix } = helperData;
 

--- a/src/utils/usefulFunctions.js
+++ b/src/utils/usefulFunctions.js
@@ -38,4 +38,5 @@ export const parseInfusionCount = (text) =>
   parseNumber(text, { defaultValue: 18, integerMode: true });
 export const parseDistribution = (text) =>
   parseNumber(text, { defaultValue: 0, integerMode: false });
-
+export const parsePriority = (text) =>
+  parseNumber(text, { defaultValue: null, integerMode: false });

--- a/src/utils/usefulFunctions.js
+++ b/src/utils/usefulFunctions.js
@@ -21,8 +21,12 @@ const parseNumber = (text, { defaultValue, integerMode }) => {
   if (text === '' || text === null || text === undefined) {
     return { value: defaultValue, error: false };
   }
-  const value = integerMode ? parseInt(text, 10) : Number(text);
-  if (Number.isNaN(value) || value < 0) {
+  const value = integerMode ? parseInt(text, 10) : parseFloat(text);
+
+  // this covers quirks like parseFloat('1hello') being 1
+  const isPlainNumber = value === Number(text);
+
+  if (!isPlainNumber || value < 0) {
     return { value: defaultValue, error: true };
   }
   return { value, error: false };

--- a/src/utils/usefulFunctions.js
+++ b/src/utils/usefulFunctions.js
@@ -36,3 +36,6 @@ export const parseAmount = (text) => parseNumber(text, { defaultValue: null, int
 export const parseAr = (text) => parseNumber(text, { defaultValue: 0, integerMode: true });
 export const parseInfusionCount = (text) =>
   parseNumber(text, { defaultValue: 18, integerMode: true });
+export const parseDistribution = (text) =>
+  parseNumber(text, { defaultValue: 0, integerMode: false });
+

--- a/src/utils/usefulFunctions.js
+++ b/src/utils/usefulFunctions.js
@@ -7,20 +7,28 @@ export function firstUppercase(text) {
 
 /**
  * Parses a string to a number, treating non-parsable strings like empty inputs but indicating an
- * error so text boxes can display the error validaton state
+ * error so text boxes can display the error validation state
  *
  * @param {*} text - the string to be parsed
+ * @param {object} settings
+ * @param {?number} settings.defaultValue - the value to return if the string is empty or unparsable
+ * @param {boolean} settings.integerMode - toggles parsing as integerMode instead of float
  * @returns {{ value: ?number, error: boolean}} result
  *   result.value - the resulting number, or null
  *   result.error - whether the input was invalid
  */
- export function parseAmount(text) {
+const parseNumber = (text, { defaultValue, integerMode }) => {
   if (text === '' || text === null || text === undefined) {
-    return { value: null, error: false };
+    return { value: defaultValue, error: false };
   }
-  const value = Number(text);
+  const value = integerMode ? parseInt(text, 10) : Number(text);
   if (Number.isNaN(value) || value < 0) {
-    return { value: null, error: true };
+    return { value: defaultValue, error: true };
   }
   return { value, error: false };
-}
+};
+
+export const parseAmount = (text) => parseNumber(text, { defaultValue: null, integerMode: false });
+export const parseAr = (text) => parseNumber(text, { defaultValue: 0, integerMode: true });
+export const parseInfusionCount = (text) =>
+  parseNumber(text, { defaultValue: 18, integerMode: true });


### PR DESCRIPTION
This makes the parseAmount function into a framework that can be used to create functions to parse any "please type a number" style text boxes in a consistent way and visually validate the text box input, and uses it for as many as I could find.

This should hopefully prevent any possible "invalid text results in stale input" bugs or "empty text box crashes the optimizer" bugs in the future.

I didn't use currying and partial application to create the derived functions from `parseNumber`, because I'm not brave enough (and also I think it would be hard to maintain if future contributors are not familiar with functional programming).