### PR TITLE
Feat: Add (manual) cache invalidation to gw2-ui cache

### DIFF
--- a/src/state/createStore.js
+++ b/src/state/createStore.js
@@ -1,5 +1,5 @@
 import { gw2UIReducer } from 'gw2-ui-bulk';
-import { persistReducer, persistStore } from 'redux-persist';
+import { persistReducer, persistStore, createMigrate } from 'redux-persist';
 
 import { applyMiddleware, combineReducers, compose, createStore as reduxCreateStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
@@ -34,10 +34,18 @@ const createNoopStorage = () => {
 
 const storage = typeof window === 'undefined' ? createNoopStorage() : createWebStorage('local');
 
+// bump this to cache invalidate the persisted state
+const CURRENT_VERSION = 1;
+
+const migrations = {
+  [CURRENT_VERSION]: (_state) => ({}),
+};
 const persistConfig = {
   key: 'root',
   whitelist: 'gw2UiStore',
   storage,
+  version: CURRENT_VERSION,
+  migrate: createMigrate(migrations),
 };
 
 const reducers = combineReducers({


### PR DESCRIPTION
I'm sure there's a better way to do this... you know, preferably automatically.

This adds a key we can manually bump to invalidate the persisted gw2-ui cache for game patches.