### PR TITLE
Feat: add amounts to extras

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -274,7 +274,7 @@
   "extraSection_Power Utilities": "Power Utilities",
   "extraSection_SAB Utilities": "SAB Utilities",
   "extraSection_Specific Condition Runes": "Specific Condition Runes",
-  "extraSection_Stacking Sigils (25x)": "Stacking Sigils (25x)",
+  "extraSection_Stacking Sigils": "Stacking Sigils",
   "extraSection_Support Food": "Support Food",
   "extraSection_Support Runes": "Support Runes",
   "extraSection_Support Sigils": "Support Sigils",

--- a/src/assets/modifierdata/food.yaml
+++ b/src/assets/modifierdata/food.yaml
@@ -36,10 +36,13 @@
 
     - id: seaweed-salad
       text: Bowl of Seaweed Salad
-      subText: (90% uptime)
+      amountData:
+        label: '% uptime'
+        default: 90
+        quantityEntered: 100
       modifiers:
         damage:
-          Strike Damage: [4.5%, mult]
+          Strike Damage: [5%, mult]
       gw2id: 12471
 
     - id: jerk-poultry

--- a/src/assets/modifierdata/sigils.yaml
+++ b/src/assets/modifierdata/sigils.yaml
@@ -136,6 +136,7 @@
         label: 'stacks'
         default: 25
         quantityEntered: 25
+        disableBlacklist: true
       modifiers:
         attributes:
           Precision: [250, converted]
@@ -169,6 +170,7 @@
         label: 'stacks'
         default: 25
         quantityEntered: 25
+        disableBlacklist: true
       modifiers:
         attributes:
           Concentration: [225, converted]
@@ -191,6 +193,7 @@
         label: 'stacks'
         default: 25
         quantityEntered: 25
+        disableBlacklist: true
       modifiers:
         attributes:
           Toughness: [125, converted]
@@ -202,6 +205,7 @@
         label: 'stacks'
         default: 25
         quantityEntered: 25
+        disableBlacklist: true
       modifiers:
         attributes:
           Power: [50, converted]

--- a/src/assets/modifierdata/sigils.yaml
+++ b/src/assets/modifierdata/sigils.yaml
@@ -105,11 +105,15 @@
           Torment Duration: 20%
       gw2id: 24583
 
-- section: Stacking Sigils (25x)
+- section: Stacking Sigils
   items:
 
     - id: bloodlust
       text: Superior Sigil of Bloodlust
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Power: [250, converted]
@@ -117,6 +121,10 @@
 
     - id: cruelty
       text: Superior Sigil of Cruelty
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Ferocity: [250, converted]
@@ -124,6 +132,10 @@
 
     - id: perception
       text: Superior Sigil of Perception
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Precision: [250, converted]
@@ -131,6 +143,10 @@
 
     - id: corruption
       text: Superior Sigil of Corruption
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Condition Damage: [250, converted]
@@ -138,6 +154,10 @@
 
     - id: life
       text: Superior Sigil of Life
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Healing Power: [250, converted]
@@ -145,6 +165,10 @@
 
     - id: bounty
       text: Superior Sigil of Bounty
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Concentration: [225, converted]
@@ -152,6 +176,10 @@
 
     - id: benevolence
       text: Superior Sigil of Benevolence
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Outgoing Healing: 12.5%
@@ -159,6 +187,10 @@
 
     - id: momentum
       text: Superior Sigil of Momentum
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Toughness: [125, converted]
@@ -166,6 +198,10 @@
 
     - id: stars
       text: Superior Sigil of the Stars
+      amountData:
+        label: 'stacks'
+        default: 25
+        quantityEntered: 25
       modifiers:
         attributes:
           Power: [50, converted]

--- a/src/assets/modifierdata/utility.yaml
+++ b/src/assets/modifierdata/utility.yaml
@@ -180,6 +180,7 @@
 
     - id: writ-of-masterful-accuracy
       text: Writ of Masterful Accuracy
+      subText: (100% uptime)
       modifiers:
         attributes:
           Precision: [200, converted]
@@ -187,6 +188,10 @@
 
     - id: writ-of-masterful-malice
       text: Writ of Masterful Malice
+      amountData:
+        label: '% uptime'
+        default: 100
+        quantityEntered: 100
       modifiers:
         attributes:
           Condition Damage: [200, converted]
@@ -194,6 +199,10 @@
 
     - id: writ-of-masterful-strength
       text: Writ of Masterful Strength
+      amountData:
+        label: '% uptime'
+        default: 100
+        quantityEntered: 100
       modifiers:
         attributes:
           Power: [200, converted]

--- a/src/assets/presetdata/preset-extras.yaml
+++ b/src/assets/presetdata/preset-extras.yaml
@@ -1,6 +1,16 @@
 GraphQL ID: presetExtras
 list:
 
+  - name: TEMP PRESET TO TEST THE THINGY
+    value: |-
+      {
+        "Runes": "",
+        "Sigil1": "momentum",
+        "Sigil2": "life",
+        "Enhancement": "writ-of-masterful-malice",
+        "Nourishment": "seaweed-salad"
+      }
+
   - name: Power (Fractal)
     value: |-
       {

--- a/src/components/sections/extras/Extras.jsx
+++ b/src/components/sections/extras/Extras.jsx
@@ -1,4 +1,3 @@
-import { Grid } from '@material-ui/core';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { ConsumableEffect, Item } from 'gw2-ui-bulk';
 import React from 'react';
@@ -9,49 +8,42 @@ const Extras = () => {
   const { t } = useTranslation();
 
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={12} md={6}>
-        <GW2Select
-          name="Sigil1"
-          label={<Item id={24615} disableLink disableTooltip text={t('Sigil 1')} />}
-          modifierData={extrasModifiers.sigils}
-          modifierDataById={extrasModifiersById}
-        />
-      </Grid>
-      <Grid item xs={12} md={6}>
-        <GW2Select
-          name="Sigil2"
-          label={<Item id={24868} disableLink disableTooltip text={t('Sigil 2')} />}
-          modifierData={extrasModifiers.sigils}
-          modifierDataById={extrasModifiersById}
-        />
-      </Grid>
-      <Grid item xs={12} md={6}>
-        <GW2Select
-          name="Runes"
-          label={<Item id={24836} disableLink disableTooltip text={t('Rune')} />}
-          modifierData={extrasModifiers.runes}
-          modifierDataById={extrasModifiersById}
-        />
-      </Grid>
-      <Grid item md={6} />
-      <Grid item xs={12} md={6}>
-        <GW2Select
-          name="Nourishment"
-          label={<ConsumableEffect text={t('Nourishment')} name="Nourishment" />}
-          modifierData={extrasModifiers.food}
-          modifierDataById={extrasModifiersById}
-        />
-      </Grid>
-      <Grid item xs={12} md={6}>
-        <GW2Select
-          name="Enhancement"
-          label={<ConsumableEffect text={t('Enhancement')} name="Enhancement" />}
-          modifierData={extrasModifiers.utility}
-          modifierDataById={extrasModifiersById}
-        />
-      </Grid>
-    </Grid>
+    <>
+      <GW2Select
+        name="Sigil1"
+        label={<Item id={24615} disableLink disableTooltip text={t('Sigil 1')} />}
+        modifierData={extrasModifiers.sigils}
+        modifierDataById={extrasModifiersById}
+      />
+
+      <GW2Select
+        name="Sigil2"
+        label={<Item id={24868} disableLink disableTooltip text={t('Sigil 2')} />}
+        modifierData={extrasModifiers.sigils}
+        modifierDataById={extrasModifiersById}
+      />
+
+      <GW2Select
+        name="Runes"
+        label={<Item id={24836} disableLink disableTooltip text={t('Rune')} />}
+        modifierData={extrasModifiers.runes}
+        modifierDataById={extrasModifiersById}
+      />
+
+      <GW2Select
+        name="Nourishment"
+        label={<ConsumableEffect text={t('Nourishment')} name="Nourishment" />}
+        modifierData={extrasModifiers.food}
+        modifierDataById={extrasModifiersById}
+      />
+
+      <GW2Select
+        name="Enhancement"
+        label={<ConsumableEffect text={t('Enhancement')} name="Enhancement" />}
+        modifierData={extrasModifiers.utility}
+        modifierDataById={extrasModifiersById}
+      />
+    </>
   );
 };
 

--- a/src/components/sections/extras/GW2Select.jsx
+++ b/src/components/sections/extras/GW2Select.jsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   FormControl,
   Input,
   InputLabel,
@@ -14,6 +15,7 @@ import { Item } from 'gw2-ui-bulk';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { changeExtra, getExtra } from '../../../state/slices/extras';
+import AmountInput from '../../baseComponents/AmountInput';
 
 const styles = (theme) => ({
   formControl: {
@@ -38,6 +40,8 @@ const GW2Select = ({ classes, name, label, modifierData, modifierDataById }) => 
   const dispatch = useDispatch();
   const bigValue = useSelector(getExtra(name));
 
+  const { amountData } = modifierDataById[bigValue] || {};
+
   const { t } = useTranslation();
 
   const handleChange = (event) => {
@@ -50,65 +54,81 @@ const GW2Select = ({ classes, name, label, modifierData, modifierDataById }) => 
   // return an array in the select: https://github.com/mui-org/material-ui/issues/16181
   // Fragments are not supported as children!
   return (
-    <FormControl className={classes.formControl}>
-      <InputLabel htmlFor={name}>{label}</InputLabel>
-      <Select
-        value={bigValue || ''}
-        input={<Input name={name} id={name} />}
-        onChange={handleChange}
-        renderValue={(selected) => {
-          const item = modifierDataById[selected];
-          return (
-            <Item
-              id={item.gw2id}
-              disableLink
-              {...(!isChinese && { text: item.text.replace('Superior ', '') })}
-              className={classes.item}
-            />
-          );
-        }}
-      >
-        [
-        <MenuItem value="">
-          <em>
-            <Trans>None</Trans>
-          </em>
-        </MenuItem>
-        ,
-        {modifierData.map((category) => {
-          return [
-            <ListSubheader disableSticky>
-              {
-                // i18next-extract-mark-context-next-line {{extraSection}}
-                t('extraSection', { context: category.section })
-              }
-            </ListSubheader>,
-            category.items.map((item) => (
-              <MenuItem key={item.id} value={item.id} className={classes.menuItem}>
-                <ListItemText
-                  primary={
-                    <Item
-                      id={item.gw2id}
-                      disableLink
-                      {...(!isChinese && { text: item.text.replace('Superior ', '') })}
-                    />
-                  }
-                  secondary={
-                    <Typography className={classes.subText}>
-                      {
-                        // i18next-extract-mark-context-next-line {{extraSubText}}
-                        t('extraSubText', { context: item.subText })
-                      }
-                    </Typography>
-                  }
+    <Box justifyContent="space-between" display="flex" maxWidth="648px" mb={2}>
+      <Box>
+        <FormControl className={classes.formControl}>
+          <InputLabel htmlFor={name}>{label}</InputLabel>
+          <Select
+            value={bigValue || ''}
+            input={<Input name={name} id={name} />}
+            onChange={handleChange}
+            renderValue={(selected) => {
+              const item = modifierDataById[selected];
+              return (
+                <Item
+                  id={item.gw2id}
+                  disableLink
+                  {...(!isChinese && { text: item.text.replace('Superior ', '') })}
+                  className={classes.item}
                 />
-              </MenuItem>
-            )),
-          ];
-        })}
-        ]
-      </Select>
-    </FormControl>
+              );
+            }}
+          >
+            [
+            <MenuItem value="">
+              <em>
+                <Trans>None</Trans>
+              </em>
+            </MenuItem>
+            ,
+            {modifierData.map((category) => {
+              return [
+                <ListSubheader disableSticky>
+                  {
+                    // i18next-extract-mark-context-next-line {{extraSection}}
+                    t('extraSection', { context: category.section })
+                  }
+                </ListSubheader>,
+                category.items.map((item) => (
+                  <MenuItem key={item.id} value={item.id} className={classes.menuItem}>
+                    <ListItemText
+                      primary={
+                        <Item
+                          id={item.gw2id}
+                          disableLink
+                          {...(!isChinese && { text: item.text.replace('Superior ', '') })}
+                        />
+                      }
+                      secondary={
+                        <Typography className={classes.subText}>
+                          {
+                            // i18next-extract-mark-context-next-line {{extraSubText}}
+                            t('extraSubText', { context: item.subText })
+                          }
+                        </Typography>
+                      }
+                    />
+                  </MenuItem>
+                )),
+              ];
+            })}
+            ]
+          </Select>
+        </FormControl>
+      </Box>
+      <Box>
+        {amountData ? (
+          <AmountInput
+            placeholder={amountData.default}
+            // i18next-extract-mark-context-next-line {{amountLabel}}
+            endLabel={t('amountLabel', { context: amountData.label })}
+            // handleAmountChange={handleAmountChange(id)}
+            // value={amount}
+            maxWidth={32}
+          />
+        ) : null}
+      </Box>
+    </Box>
   );
 };
 export default withStyles(styles)(GW2Select);

--- a/src/components/sections/extras/GW2Select.jsx
+++ b/src/components/sections/extras/GW2Select.jsx
@@ -8,7 +8,7 @@ import {
   MenuItem,
   Select,
   Typography,
-  withStyles,
+  withStyles
 } from '@material-ui/core';
 import { Trans, useTranslation } from 'gatsby-plugin-react-i18next';
 import { Item } from 'gw2-ui-bulk';


### PR DESCRIPTION
this is primarily progress towards stuff like geomancy sigil (and thought should be put into how to do 2 different on swap slash on crit sigils)

I realized though that my yaml "amount" system doesn't support uptimes on runes or on kill food because it scales both the flat bonuses and the uptime bonuses, so... I'm stupid

- [ ] actually hook up the amount inputs
- [ ] layout