### PR TITLE
fix webpack resolve configuration

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,5 @@
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
-    // for some reason the modules option is required, else the css breaks entirely.
     resolve: { symlinks: false },
   });
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,11 +1,7 @@
-// eslint-disable-next-line no-unused-vars
-const webpack = require(`webpack`);
-const path = require('path');
-
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
     // for some reason the modules option is required, else the css breaks entirely.
-    resolve: { symlinks: false, modules: [path.resolve('./node_modules')] },
+    resolve: { symlinks: false },
   });
 };
 


### PR DESCRIPTION
The configuration `resolve.modules: [path.resolve('./node_modules')]` is a potentially harmful. It will make webpack module resolution behave differently from what node/npm/yarn does.        
In particular, the result of `path.resolve('./node_modules')` is an **absolute path**. According to [webpack configuration document](https://webpack.js.org/configuration/resolve/#resolvemodules), this will make webpack **only** search for dependencies in the **root** `node_modules` directory instead of in the **nested** `node_modules` directories first. However sometimes nested dependencies have version confliction which is why there may be nested `node_modules` directories (to allow different versions of packages to exist) in the first place. Forcing webpack to only search in the root `node_modules` directory can lead to severe problems, such as api broken in older/newer versions.     
    
Now go back to **why there was problem (css broken) without it** . That's because when we **locally** test the `react-discretize-components`, we had an instance of `react` in `react-discretize-components` project (as a "devdependency" when in development). Webpack bundled this instance **along with** the **root** `react` instance and the css material-ui components use are stored in the context of `react` which causes conflict.  
However this is not true when the package is properly published. Because at that time, `devdependencies` are just ignored and react is only declared as a peer dependency which won't cause duplicate instances. There will only be one `react` in the root `node_modules`.   

What should we do when test it locally then? I recommend the following workflow:
1. build the required dependency
2. properly add it as a dependency (preferably with `yarn add link:xx`) to the project we use to test (and properly configure the bundlers like webpack in the project to use symlinks if there is one)
3. remove the `node_modules` directory in the required dependency and run `npm/yarn install` in the project which will make npm/yarn properly add packages to node_modules according to their own resolution algorithm. Alternatively the whole step can probably be replaced with `npm/yarn install --force` but it will take longer.
4. everything is fine and just proceed from here.