### PR TITLE
refactor: remove noui-slider dependency

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,7 @@
     "arrow-body-style": "off",
     "prefer-arrow-callback": "off",
 
-    "id-length": ["warn", { "exceptions": ["i", "j", "e", "t"] }],
+    "id-length": ["warn", { "exceptions": ["i", "j", "e", "t", "_"] }],
 
     "no-restricted-imports": [
       "error",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
     "material-ui-popup-state": "^1.9.0",
-    "nouislider-react": "^3.4.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-discretize-components": "^1.0.2",

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -75,7 +75,7 @@ const DamageDistribution = () => {
       for (let j = 0; j <= i; j++) {
         total += percentDistribution[j];
       }
-      return Math.min(total, 100);
+      return roundOne(Math.min(total, 100));
     });
   };
 

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -5,16 +5,13 @@ import {
   Input,
   InputAdornment,
   InputLabel,
+  makeStyles,
+  Slider,
   Typography,
-  withStyles,
 } from '@material-ui/core';
 import classNames from 'classnames';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { Attribute as AttributeRaw, Condition as ConditionRaw } from 'gw2-ui-bulk';
-import debounce from 'lodash.debounce';
-import Nouislider from 'nouislider-react';
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
-import 'nouislider/distribute/nouislider.css';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -32,7 +29,7 @@ import { parseDistribution } from '../../../utils/usefulFunctions';
 const Attribute = React.memo(AttributeRaw);
 const Condition = React.memo(ConditionRaw);
 
-const styles = (theme) => ({
+const useStyles = makeStyles((theme) => ({
   textbox: {
     maxWidth: 195,
     marginBottom: theme.spacing(2),
@@ -44,42 +41,7 @@ const styles = (theme) => ({
       marginLeft: theme.spacing(5),
     },
   },
-
-  sliderOld: {
-    marginBottom: theme.spacing(7),
-    '& div': {
-      '& .noUi-connects': {
-        '& .noUi-connect:nth-child(1)': {
-          background: '#b1b1b5 !important',
-        },
-        '& .noUi-connect:nth-child(2)': {
-          background: '#e25822 !important',
-        },
-        '& .noUi-connect:nth-child(3)': {
-          background: '#d2351e !important',
-        },
-        '& .noUi-connect:nth-child(4)': {
-          background: '#48631f !important',
-        },
-        '& .noUi-connect:nth-child(5)': {
-          background: 'orange !important',
-        },
-        '& .noUi-connect:nth-child(6)': {
-          background: '#a25aca !important',
-        },
-      },
-    },
-  },
-  sliderNew: {
-    '& div': {
-      '& .noUi-connects': {
-        '& .noUi-connect': {
-          background: '#00cccc !important',
-        },
-      },
-    },
-  },
-});
+}));
 
 const DISTRIBUTION_NAMES = [
   { name: 'Power', min: 0, max: 6000, step: 10, color: '#b1b1b5' },
@@ -90,7 +52,9 @@ const DISTRIBUTION_NAMES = [
   { name: 'Confusion', min: 0, max: 60, step: 0.1 },
 ];
 
-const DamageDistribution = ({ classes }) => {
+const DamageDistribution = () => {
+  const classes = useStyles();
+
   const dispatch = useDispatch();
   const version = useSelector(getDistributionVersion);
   const distributionOld = useSelector(getDistributionOld); // actual real selected damage distribution at any time
@@ -100,8 +64,19 @@ const DamageDistribution = ({ classes }) => {
   // locally displayed in the text boxes. Text boxes might contain a string that is not a real number (yet), so we need to store those separately
   const textBoxes = useSelector(getTextBoxes);
 
-  // eslint-disable-next-line no-unused-vars
-  const onUpdateOld = (render, handle, value, un, percent) => {
+  // const initialPercentDistribution = Object.values(coefficientsToPercents(distributionNew, true));
+  const percentToState = (percentDistribution) => {
+    return [0, 1, 2, 3, 4].map((i) => {
+      let total = 0;
+      for (let j = 0; j <= i; j++) {
+        total += percentDistribution[j];
+      }
+      return Math.min(total, 100);
+    });
+  };
+
+  // eslint-disable-next-line id-length
+  const onUpdateOld = (_, value) => {
     const distributionRecalc = [];
     let prev = 0;
     for (let i = 0; i < value.length; i++) {
@@ -117,37 +92,22 @@ const DamageDistribution = ({ classes }) => {
       Torment: distributionRecalc[4],
       Confusion: distributionRecalc[5],
     };
+
     dispatch(changeAllDistributionsOld(percentDistribution));
   };
-
-  const initialPercentDistribution = Object.values(coefficientsToPercents(distributionNew, true));
-  const initialPercentValue = [0, 1, 2, 3, 4].map((i) => {
-    let total = 0;
-    for (let j = 0; j <= i; j++) {
-      total += initialPercentDistribution[j];
-    }
-    return Math.min(total, 100);
-  });
 
   const SliderOld = () => {
     return (
       <>
         <div className={classes.sliderWrapper}>
-          <Nouislider
-            className={classNames(classes.sliderOld)}
-            start={initialPercentValue}
-            connect={[true, true, true, true, true, true]}
-            range={{
-              min: [0],
-              max: [100],
-            }}
-            step={1}
-            pips={{
-              mode: 'values',
-              values: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
-              density: 5,
-            }}
-            onSlide={onUpdateOld}
+          <Slider
+            value={percentToState(Object.values(distributionOld))}
+            onChange={onUpdateOld}
+            valueLabelDisplay="auto"
+            aria-labelledby="range-slider"
+            marks={[...Array(11).keys()]
+              .map((v) => v * 10)
+              .map((value) => ({ value, label: `${value}` }))}
           />
         </div>
         <Grid container spacing={2}>
@@ -168,8 +128,8 @@ const DamageDistribution = ({ classes }) => {
     );
   };
 
-  // eslint-disable-next-line no-unused-vars
-  const onUpdateNew = (key) => (render, handle, value, un, percent) => {
+  // eslint-disable-next-line id-length
+  const onUpdateNew = (key) => (_, value) => {
     dispatch(changeTextBoxes({ index: key, value: Math.round(value * 100) / 100 }));
     dispatch(changeDistributionNew({ index: key, value: Math.round(value * 100) / 100 }));
   };
@@ -217,17 +177,20 @@ const DamageDistribution = ({ classes }) => {
             />
           </FormControl>
         </Box>
-        <Box flexGrow={1}>
-          <Nouislider
-            className={classNames(classes.sliderNew, classes.slider)}
-            start={distributionNew[dist.name]}
-            connect={[true, false]}
-            range={{
-              min: [dist.min],
-              max: [dist.max],
-            }}
+        <Box flexGrow={1} alignSelf="center" ml={2}>
+          <Slider
+            value={distributionNew[dist.name]}
             step={dist.step}
-            onSlide={debounce(onUpdateNew(dist.name), 50)}
+            marks={[...Array(7).keys()]
+              .map((value) => value * ((dist.max - dist.min) / 6))
+              .map((value) => ({
+                value,
+                label: `${value}`,
+              }))}
+            min={dist.min}
+            max={dist.max}
+            onChange={onUpdateNew(dist.name)}
+            valueLabelDisplay="auto"
           />
         </Box>
       </Box>
@@ -237,4 +200,4 @@ const DamageDistribution = ({ classes }) => {
   return version === 1 ? SliderOld() : SlidersNew();
 };
 
-export default withStyles(styles)(DamageDistribution);
+export default DamageDistribution;

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -28,6 +28,8 @@ import { parseDistribution } from '../../../utils/usefulFunctions';
 const Attribute = React.memo(AttributeRaw);
 const Condition = React.memo(ConditionRaw);
 
+const roundOne = (num) => Math.round(num * 10) / 10;
+
 const useStyles = makeStyles((theme) => ({
   textbox: {
     maxWidth: 195,
@@ -118,7 +120,7 @@ const DamageDistribution = () => {
                 ) : (
                   <Condition name={dist.name} disableLink style={{ whiteSpace: 'nowrap' }} />
                 )}{' '}
-                {distributionOld[dist.name]}%
+                {roundOne(distributionOld[dist.name])}%
               </Typography>
             </Grid>
           ))}

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -6,6 +6,7 @@ import {
   InputAdornment,
   InputLabel,
   makeStyles,
+  Slider,
   Typography,
 } from '@material-ui/core';
 import classNames from 'classnames';

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -18,7 +18,6 @@ import {
   changeAllDistributionsOld,
   changeDistributionNew,
   changeTextBoxes,
-  coefficientsToPercents,
   getDistributionNew,
   getDistributionOld,
   getDistributionVersion,
@@ -106,7 +105,7 @@ const DamageDistribution = () => {
             valueLabelDisplay="auto"
             aria-labelledby="range-slider"
             marks={[...Array(11).keys()]
-              .map((v) => v * 10)
+              .map((value) => value * 10)
               .map((value) => ({ value, label: `${value}` }))}
           />
         </div>

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -42,6 +42,9 @@ const useStyles = makeStyles((theme) => ({
       marginLeft: theme.spacing(5),
     },
   },
+  percentSliderRail: {
+    opacity: 1,
+  },
 }));
 
 const DISTRIBUTION_NAMES = [
@@ -102,9 +105,11 @@ const DamageDistribution = () => {
       <>
         <div className={classes.sliderWrapper}>
           <Slider
+            classes={{ rail: classes.percentSliderRail }}
             value={percentToState(Object.values(distributionOld))}
             onChange={onUpdateOld}
             valueLabelDisplay="auto"
+            track={false}
             aria-labelledby="range-slider"
             marks={[...Array(11).keys()]
               .map((value) => value * 10)

--- a/src/components/sections/distribution/DamageDistribution.jsx
+++ b/src/components/sections/distribution/DamageDistribution.jsx
@@ -79,7 +79,6 @@ const DamageDistribution = () => {
     });
   };
 
-  // eslint-disable-next-line id-length
   const onUpdateOld = (_, value) => {
     const distributionRecalc = [];
     let prev = 0;
@@ -134,7 +133,6 @@ const DamageDistribution = () => {
     );
   };
 
-  // eslint-disable-next-line id-length
   const onUpdateNew = (key) => (_, value) => {
     dispatch(changeTextBoxes({ index: key, value: Math.round(value * 100) / 100 }));
     dispatch(changeDistributionNew({ index: key, value: Math.round(value * 100) / 100 }));

--- a/src/state/slices/distribution.js
+++ b/src/state/slices/distribution.js
@@ -92,6 +92,11 @@ export const distributionSlice = createSlice({
     },
     changeDistributionVersion: (state, action) => {
       state.version = action.payload;
+
+      // update percentage distribution from coefficients if switching in that direction
+      if (action.payload === 1) {
+        state.values1 = coefficientsToPercents(state.values2, true);
+      }
     },
     changeDistributionNew: (state, action) => {
       return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9291,18 +9291,6 @@ normalize-url@^6.0.1, normalize-url@^6.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
-nouislider-react@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/nouislider-react/-/nouislider-react-3.4.1.tgz#cb0fc3d77ed8f7818cf52b614f0d67f3e16275d4"
-  integrity sha512-ryVbcApz6sELqPPiWwEOq5pkwhHYoNSxmGpP/HXHptpB6A6XedMrM/BP5W/rHRtBBaFK7vJTCTTma6gKviEiNg==
-  dependencies:
-    nouislider "^14.6.3"
-
-nouislider@^14.6.3:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/nouislider/-/nouislider-14.7.0.tgz#a71db0587c92567b6da1df57d251d3696d942362"
-  integrity sha512-4RtQ1+LHJKesDCNJrXkQcwXAWCrC2aggdLYMstS/G5fEWL+fXZbUA9pwVNHFghMGuFGRATlDLNInRaPeRKzpFQ==
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"


### PR DESCRIPTION
This PR removes the noUI-slider dependency and instead makes use of the mui ones. One minor issue that arises is that the legacy slider is less pretty now due to it being impossible to color parts between sliders. I think thats acceptable in exchange for consistent styling and one less dependency we need to worry about. 

Please properly check my changes to the legacy (old) slider! I did test it but I'm not entirely sure the conversions I did are correct. 