### PR TITLE
Fix: extractLocale broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.7",
     "@reduxjs/toolkit": "^1.7.1",
+    "babel-preset-gatsby": "^2.4.0",
     "classnames": "^2.3.1",
     "gatsby": "^4.4.0",
     "gatsby-plugin-image": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "axios": "^0.21.4",
     "babel-eslint": "^10.0.0",
     "babel-plugin-i18next-extract": "^0.8.3",
+    "babel-preset-gatsby": "^2.4.0",
     "eslint": "^7.5.0",
     "eslint-config-airbnb": "18.2.1",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.7",
     "@reduxjs/toolkit": "^1.7.1",
-    "babel-preset-gatsby": "^2.4.0",
     "classnames": "^2.3.1",
     "gatsby": "^4.4.0",
     "gatsby-plugin-image": "^2.4.0",


### PR DESCRIPTION
ExtractLocale appears to have been broken, presumably by the move to Gatsby v4 or something related to it.

I don't understand what exactly this does and so I don't see why it would work, but it seems to? Also, the script seems to work slightly differently now?