### PR TITLE
Fix test scripts for newer Node 16 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "eslint": "eslint --ignore-path .gitignore --max-warnings 0 . --ext .js,.jsx,ts,tsx",
     "updateMappings": "node updateMappings.js",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
-    "testModifiers": "node --experimental-json-modules ./src/assets/modifierdata/testModifiers.js",
-    "testPresets": "node --experimental-json-modules ./src/assets/presetdata/testPresets.js",
+    "testModifiers": "node ./src/assets/modifierdata/testModifiers.js",
+    "testPresets": "node ./src/assets/presetdata/testPresets.js",
     "extractLocale": "babel --config-file ./babel-extract.config.js 'src/**/*.{js,jsx,ts,tsx}' > /dev/null",
     "extractLocaleCMD": "babel --config-file ./babel-extract.config.js \"src/**/*.{js,jsx,ts,tsx}\" > NUL"
   },

--- a/src/assets/modifierdata/testModifiers.js
+++ b/src/assets/modifierdata/testModifiers.js
@@ -7,7 +7,7 @@ import fs from 'fs/promises';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import yaml from 'js-yaml';
 import path from 'path';
-import specializationData from '../../utils/mapping/specializations.json';
+// import specializationData from '../../utils/mapping/specializations.json' assert { type: 'json' };
 import {
   allAttributePercentKeys,
   allAttributePointKeys,
@@ -32,6 +32,9 @@ const gentleAssert = (condition, message) => {
 };
 
 const testModifiers = async () => {
+  const specializationDataJSON = await fs.readFile('./src/utils/mapping/specializations.json');
+  const specializationData = JSON.parse(specializationDataJSON);
+
   const files = (await fs.readdir(directory)).filter(
     (filename) => path.extname(filename) === '.yaml',
   );


### PR DESCRIPTION
Node 16's `--experimental-json-modules` option now requires `assert { type: 'json' }` after a JSON module import, but as this is experimental syntax still, this breaks ESLint unless we install a Babel plugin. Rather than bothering with this, I just used `fs.readFile` and `JSON.parse` to load the JSON. Too bad. Babel will support it eventually, I'm sure.