### PR TITLE
Fix Ranger Taste for Danger conversion

### DIFF
--- a/src/assets/modifierdata/ranger.yaml
+++ b/src/assets/modifierdata/ranger.yaml
@@ -110,6 +110,7 @@
       modifiers:
         attributes:
           Vitality: [120, buff]
+          Expertise: [8, buff] # conversion of own 120 vitality
         conversion:
           Expertise: {Vitality: 7%}
       gw2id: 1099


### PR DESCRIPTION
Added Expertise conversion of own 120 Vitality bonus for [Taste of Danger](https://wiki.guildwars2.com/wiki/Taste_for_Danger).

I noticed a discrepancy between ingame stats & the optimizer for Expertise on Condi Soulbeast.
Ingame (no Expertise from Food):
![Gw2-64_trRXlRL4Av](https://user-images.githubusercontent.com/19844016/157553996-505dac24-e174-4551-aa6b-ee098a674ec8.png)
Optimizer (no Expertise from Food):
![ga8BPh21jP](https://user-images.githubusercontent.com/19844016/157554142-6ebdd4b3-09d1-4ad8-9782-84169c823120.png)
Seems like the game includes the 120 Vitality gained for the Expertise conversion, which is exactly 8 Expertise. Other conversions seem to be unaffected by the gained Vitality (tested with [Magnanimous Sharpening Stone](https://wiki.guildwars2.com/wiki/Magnanimous_Sharpening_Stone)).