### PR TITLE
Attempt to fix mobile table

### DIFF
--- a/plugins/gatsby-plugin-top-layout/TopLayout.js
+++ b/plugins/gatsby-plugin-top-layout/TopLayout.js
@@ -1,10 +1,11 @@
-import { globals, muiTheme } from '@discretize/react-discretize-components';
+import { globals } from '@discretize/react-discretize-components';
 import { Global } from '@emotion/react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import muiTheme from '../../src/utils/placeholder-unused-theme';
 
 export default function TopLayout({ children }) {
   const title = 'Discretize - Gear Optimizer';

--- a/src/components/sections/results/table/ResultTable.jsx
+++ b/src/components/sections/results/table/ResultTable.jsx
@@ -35,6 +35,15 @@ const useStyles = makeStyles()((theme) => ({
   underline: {
     borderBottom: `5px solid ${theme.palette.divider}`,
   },
+  gearColumn: {
+    minWidth: '3em',
+  },
+  infusionColumn: {
+    minWidth: '1.8em',
+  },
+  extrasColumn: {
+    minWidth: '2.2em',
+  },
 }));
 
 // finds the most common element in an array

--- a/src/components/sections/results/table/ResultTableHeaderRow.jsx
+++ b/src/components/sections/results/table/ResultTableHeaderRow.jsx
@@ -2,6 +2,7 @@ import { ConsumableEffect, Item } from '@discretize/gw2-ui-new';
 import { HelperIcon } from '@discretize/react-discretize-components';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
+import classNames from 'classnames';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import React from 'react';
 import { extrasTypes } from '../../../../state/slices/extras';
@@ -42,12 +43,22 @@ const ResultTableHeaderRow = ({
         })}
       </TableCell>
       {Slots[weaponType].map((slot) => (
-        <TableCell className={classes.tablehead} key={slot.name} align="center" padding="none">
+        <TableCell
+          className={classNames(classes.tablehead, classes.gearColumn)}
+          key={slot.name}
+          align="center"
+          padding="none"
+        >
           {slot.short}
         </TableCell>
       ))}
       {Object.keys(infusions).map((type) => (
-        <TableCell className={classes.tablehead} key={type} align="center" padding="none">
+        <TableCell
+          className={classNames(classes.tablehead, classes.infusionColumn)}
+          key={type}
+          align="center"
+          padding="none"
+        >
           <Item id={INFUSION_IDS[type]} disableText disableLink />
         </TableCell>
       ))}
@@ -56,7 +67,7 @@ const ResultTableHeaderRow = ({
         .filter((type) => displayExtras[type])
         .map((type, index) => (
           <TableCell
-            className={classes.tablehead}
+            className={classNames(classes.tablehead, classes.extrasColumn)}
             // eslint-disable-next-line react/no-array-index-key
             key={`extras${index}`}
             align="center"

--- a/src/utils/placeholder-unused-theme.jsx
+++ b/src/utils/placeholder-unused-theme.jsx
@@ -17,6 +17,7 @@ const theme = createTheme({
     },
     background: {
       default: '#2f3136',
+      embossed: '#2a2c31',
       paper: '#26292e',
     },
     text: {
@@ -49,11 +50,40 @@ const theme = createTheme({
     },
   },
 });
+
 export default createTheme(theme, {
   components: {
+    MuiSvgIcon: {
+      styleOverrides: {
+        root: {
+          marginBottom: '-2px !important',
+        },
+      },
+    },
+    MuiTable: {
+      styleOverrides: {
+        root: {
+          marginBottom: theme.spacing(2),
+        },
+      },
+    },
+    // MuiTableHead: {
+    //   styleOverrides: {
+    //     root: {
+    //       [theme.breakpoints.down('md')]: {
+    //         display: 'block',
+    //         width: 'auto',
+    //       },
+    //     },
+    //   },
+    // },
     MuiTableBody: {
       styleOverrides: {
         root: {
+          // [theme.breakpoints.down('md')]: {
+          //   display: 'block',
+          //   width: 'auto',
+          // },
           '&> tr:last-child': {
             '&> th, td': {
               borderBottom: 'none',
@@ -62,10 +92,38 @@ export default createTheme(theme, {
         },
       },
     },
+    // MuiTableRow: {
+    //   styleOverrides: {
+    //     root: {
+    //       [theme.breakpoints.down('md')]: {
+    //         paddingTop: theme.spacing(1),
+    //         paddingBottom: theme.spacing(1),
+    //         display: 'block',
+    //         width: 'auto',
+    //         height: 'auto',
+    //         '&:not(:last-child)': {
+    //           borderBottom: `1px solid ${theme.palette.divider}`,
+    //         },
+    //       },
+    //     },
+    //     head: {
+    //       [theme.breakpoints.down('md')]: {
+    //         height: 'auto',
+    //         borderBottom: `1px solid ${theme.palette.divider}`,
+    //       },
+    //     },
+    //   },
+    // },
     MuiTableCell: {
       styleOverrides: {
         root: {
           borderBottom: `1px solid ${theme.palette.divider}`,
+          // [theme.breakpoints.down('md')]: {
+          //   display: 'block',
+          //   width: 'auto',
+          //   borderBottom: 'none',
+          //   padding: '4px 24px 4px 24px',
+          // },
           'th&': {
             fontWeight: 700,
           },
@@ -73,8 +131,30 @@ export default createTheme(theme, {
             marginBottom: 0,
           },
         },
+        head: {
+          fontSize: '0.8571428571428571rem',
+          color: theme.palette.text.secondary,
+          lineHeight: 'inherit',
+        },
       },
     },
+    MuiButton: {
+      styleOverrides: {
+        contained: {
+          fontWeight: 600,
+          transition: theme.transitions.create(
+            ['background-color', 'box-shadow', 'border', 'color'],
+            {
+              duration: theme.transitions.duration.short,
+            },
+          ),
+          '&:hover': {
+            color: 'white !important',
+          },
+        },
+      },
+    },
+    MuiButtonBase: { defaultProps: { disableRipple: true } },
     MuiGridList: {
       styleOverrides: {
         root: {
@@ -98,6 +178,30 @@ export default createTheme(theme, {
         },
       },
     },
+    MuiListItem: {
+      styleOverrides: {
+        root: {
+          paddingTop: '11px',
+          paddingBottom: '11px',
+          '& > *:first-child': {
+            paddingLeft: 0,
+          },
+        },
+        dense: {
+          paddingTop: '8px',
+          paddingBottom: '8px',
+        },
+      },
+    },
+    MuiListItemText: {
+      styleOverrides: {
+        root: {
+          marginTop: 0,
+          marginBottom: 0,
+          padding: '0 16px',
+        },
+      },
+    },
     MuiAccordion: {
       styleOverrides: {
         root: { background: theme.palette.background.paper },
@@ -106,6 +210,23 @@ export default createTheme(theme, {
     MuiMenu: {
       defaultProps: {
         elevation: 0,
+      },
+    },
+    MuiPaper: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: {
+          boxShadow: theme.shadows[1],
+        },
+      },
+    },
+    MuiDivider: {
+      styleOverrides: {
+        root: {
+          marginBottom: theme.spacing(2),
+        },
       },
     },
     MuiAutocomplete: {


### PR DESCRIPTION
yikes

not sure what we want to do about this - some of the styles on the optimizer table are shared with the (completely different) tables in the main site, but most aren't. I think it would make sense to have an object of the shared theme keys with no table overrides at all, then export a mainSiteTheme and an optimizerTheme object (or whatever) with the table keys separate for each; that way there doesn't have to be any overrides.