### PR TITLE
Feat: Extras multiselect, part 2

### DIFF
--- a/src/assets/presetdata/preset-extras.yaml
+++ b/src/assets/presetdata/preset-extras.yaml
@@ -4,590 +4,752 @@ list:
   - name: Power (Fractal)
     value: |-
       {
-        "Runes": ["scholar"],
-        "Sigil1": "force",
-        "Sigil2": "impact/night/slaying-both",
-        "Enhancement": ["slaying-potion"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["scholar"],
+          "Sigil1": ["force"],
+          "Sigil2": ["impact/night/slaying-both"],
+          "Enhancement": ["slaying-potion"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: Power (Raid)
     value: |-
       {
-        "Runes": ["scholar"],
-        "Sigil1": "force",
-        "Sigil2": "impact/night/slaying-only-3",
-        "Enhancement": ["superior-sharpening-stone"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["scholar"],
+          "Sigil1": ["force"],
+          "Sigil2": ["impact/night/slaying-only-3"],
+          "Enhancement": ["superior-sharpening-stone"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: Heal
     value: |-
       {
-        "Runes": ["monk"],
-        "Sigil1": "concentration",
-        "Sigil2": "transference",
-        "Enhancement": ["bountiful-maintenance-oil"],
-        "Nourishment": ["fruit-salad-mint-garnish"]
+        "extras": {
+          "Runes": ["monk"],
+          "Sigil1": ["concentration"],
+          "Sigil2": ["transference"],
+          "Enhancement": ["bountiful-maintenance-oil"],
+          "Nourishment": ["fruit-salad-mint-garnish"]
+        },
+        "amounts": {}
       }
 
   - name: Alacrity Mirage (Raid)
     profession: Mirage
     value: |-
       {
-        "Runes": ["nightmare"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-maintenance-oil"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["nightmare"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-maintenance-oil"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: DPS Mirage (Raid)
     profession: Mirage
     value: |-
       {
-        "Runes": ["nightmare"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["nightmare"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Chrono STM
     profession: Chronomancer
     value: |-
       {
-        "Runes": ["perplexity"],
-        "Sigil1": "bursting",
-        "Sigil2": "concentration",
-        "Enhancement": ["toxic-maintenance-oil"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["perplexity"],
+          "Sigil1": ["bursting"],
+          "Sigil2": ["concentration"],
+          "Enhancement": ["toxic-maintenance-oil"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Chrono DPS
     profession: Chronomancer
     value: |-
       {
-        "Runes": ["perplexity"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["perplexity"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta2] Virtuoso'
     profession: Virtuoso
     value: |-
       {
-        "Runes": ["scholar"],
-        "Sigil1": "force",
-        "Sigil2": "accuracy",
-        "Enhancement": ["superior-sharpening-stone"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["scholar"],
+          "Sigil1": ["force"],
+          "Sigil2": ["accuracy"],
+          "Enhancement": ["superior-sharpening-stone"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: DH Virtues (Fractal)
     profession: Dragonhunter
     value: |-
       {
-        "Runes": ["thief"],
-        "Sigil1": "force",
-        "Sigil2": "impact/night/slaying-both",
-        "Enhancement": ["slaying-potion"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["thief"],
+          "Sigil1": ["force"],
+          "Sigil2": ["impact/night/slaying-both"],
+          "Enhancement": ["slaying-potion"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] Power Willbender Virtues (Fractal)'
     profession: Willbender
     value: |-
       {
-        "Runes": ["thief"],
-        "Sigil1": "force",
-        "Sigil2": "impact/night/slaying-both",
-        "Enhancement": ["slaying-potion"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["thief"],
+          "Sigil1": ["force"],
+          "Sigil2": ["impact/night/slaying-both"],
+          "Enhancement": ["slaying-potion"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: DH Virtues (Raid)
     profession: Dragonhunter
     value: |-
       {
-        "Runes": ["thief"],
-        "Sigil1": "force",
-        "Sigil2": "accuracy",
-        "Enhancement": ["furious-sharpening-stone"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["thief"],
+          "Sigil1": ["force"],
+          "Sigil2": ["accuracy"],
+          "Enhancement": ["furious-sharpening-stone"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] Power Willbender Virtues (Raid)'
     profession: Willbender
     value: |-
       {
-        "Runes": ["thief"],
-        "Sigil1": "force",
-        "Sigil2": "accuracy",
-        "Enhancement": ["furious-sharpening-stone"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["thief"],
+          "Sigil1": ["force"],
+          "Sigil2": ["accuracy"],
+          "Enhancement": ["furious-sharpening-stone"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: CFB w/ Quickness (balthazar)
     profession: Firebrand
     value: |-
       {
-        "Runes": ["balthazar"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-maintenance-oil"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["balthazar"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-maintenance-oil"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: CFB w/ Quickness (renegade)
     profession: Firebrand
     value: |-
       {
-        "Runes": ["renegade"],
-        "Sigil1": "bursting",
-        "Sigil2": "smoldering",
-        "Enhancement": ["toxic-maintenance-oil"],
-        "Nourishment": ["fishy-rice-bowl"]
+        "extras": {
+          "Runes": ["renegade"],
+          "Sigil1": ["bursting"],
+          "Sigil2": ["smoldering"],
+          "Enhancement": ["toxic-maintenance-oil"],
+          "Nourishment": ["fishy-rice-bowl"]
+        },
+        "amounts": {}
       }
 
   - name: CFB DPS (balthazar)
     profession: Firebrand
     value: |-
       {
-        "Runes": ["balthazar"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["balthazar"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: CFB DPS (renegade)
     profession: Firebrand
     value: |-
       {
-        "Runes": ["renegade"],
-        "Sigil1": "bursting",
-        "Sigil2": "smoldering",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["fishy-rice-bowl"]
+        "extras": {
+          "Runes": ["renegade"],
+          "Sigil1": ["bursting"],
+          "Sigil2": ["smoldering"],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["fishy-rice-bowl"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta2] Condi Willbender'
     profession: Willbender
     value: |-
       {
-        "Runes": ["balthazar"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["balthazar"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Quickbrand 40%
     profession: Firebrand
     value: |-
       {
-        "Runes": ["firebrand"],
-        "Sigil1": "bursting",
-        "Sigil2": "smoldering",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["fishy-rice-bowl"]
+        "extras": {
+          "Runes": ["firebrand"],
+          "Sigil1": ["bursting"],
+          "Sigil2": ["smoldering"],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["fishy-rice-bowl"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Quickbrand 35%
     profession: Firebrand
     value: |-
       {
-        "Runes": ["balthazar"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-maintenance-oil"],
-        "Nourishment": ["dragon's-revelry-starcake"]
+        "extras": {
+          "Runes": ["balthazar"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-maintenance-oil"],
+          "Nourishment": ["dragon's-revelry-starcake"]
+        },
+        "amounts": {}
       }
 
   - name: Hybrid FB Traveler
     profession: Firebrand
     value: |-
       {
-        "Runes": ["traveler"],
-        "Sigil1": "bursting",
-        "Sigil2": "smoldering",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["traveler"],
+          "Sigil1": ["bursting"],
+          "Sigil2": ["smoldering"],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Bers
     profession: Berserker
     value: |-
       {
-        "Runes": ["renegade"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["renegade"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: Power Bers (Raid spotter)
     profession: Berserker
     value: |-
       {
-        "Runes": ["thief"],
-        "Sigil1": "force",
-        "Sigil2": "impact/night/slaying-only-3",
-        "Enhancement": ["superior-sharpening-stone"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["thief"],
+          "Sigil1": ["force"],
+          "Sigil2": ["impact/night/slaying-only-3"],
+          "Enhancement": ["superior-sharpening-stone"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: Flame Legion Power Weaver (Raid)
     profession: Weaver
     value: |-
       {
-        "Runes": ["flame-legion"],
-        "Sigil1": "force",
-        "Sigil2": "impact/night/slaying-only-3",
-        "Enhancement": ["superior-sharpening-stone"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["flame-legion"],
+          "Sigil1": ["force"],
+          "Sigil2": ["impact/night/slaying-only-3"],
+          "Enhancement": ["superior-sharpening-stone"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Weaver Sword
     profession: Weaver
     value: |-
       {
-        "Runes": ["elementalist"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["elementalist"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: Hybrid Weaver (Fractal)
     profession: Weaver
     value: |-
       {
-        "Runes": ["flame-legion"],
-        "Sigil1": "impact/night/slaying-both",
-        "Sigil2": "bursting",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["dragon's-revelry-starcake"]
+        "extras": {
+          "Runes": ["flame-legion"],
+          "Sigil1": ["impact/night/slaying-both"],
+          "Sigil2": ["bursting"],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["dragon's-revelry-starcake"]
+        },
+        "amounts": {}
       }
 
   - name: Hybrid Weaver (Raid)
     profession: Weaver
     value: |-
       {
-        "Runes": ["flame-legion"],
-        "Sigil1": "force",
-        "Sigil2": "bursting",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["dragon's-revelry-starcake"]
+        "extras": {
+          "Runes": ["flame-legion"],
+          "Sigil1": ["force"],
+          "Sigil2": ["bursting"],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["dragon's-revelry-starcake"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Tempest
     profession: Tempest
     value: |-
       {
-        "Runes": ["elementalist"],
-        "Sigil1": "bursting",
-        "Sigil2": "smoldering",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["elementalist"],
+          "Sigil1": ["bursting"],
+          "Sigil2": ["smoldering"],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: Power Tempest (Raid)
     profession: Tempest
     value: |-
       {
-        "Runes": ["scholar"],
-        "Sigil1": "force",
-        "Sigil2": "accuracy",
-        "Enhancement": ["superior-sharpening-stone"],
-        "Nourishment": ["truffle-steak"]
+        "extras": {
+          "Runes": ["scholar"],
+          "Sigil1": ["force"],
+          "Sigil2": ["accuracy"],
+          "Enhancement": ["superior-sharpening-stone"],
+          "Nourishment": ["truffle-steak"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] Condi Catalyst'
     profession: Catalyst
     value: |-
       {
-        "Runes": ["nightmare"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["nightmare"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: Power Slb Skirm (Raid)
     profession: Soulbeast
     value: |-
       {
-        "Runes": ["scholar"],
-        "Sigil1": "force",
-        "Sigil2": "impact/night/slaying-only-3",
-        "Enhancement": ["superior-sharpening-stone"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["scholar"],
+          "Sigil1": ["force"],
+          "Sigil2": ["impact/night/slaying-only-3"],
+          "Enhancement": ["superior-sharpening-stone"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Slb
     profession: Soulbeast
     value: |-
       {
-        "Runes": ["krait"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["krait"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Hybrid Slb
     profession: Soulbeast
     value: |-
       {
-        "Runes": ["krait"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["krait"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Pure Shortbow Slb BM
     profession: Soulbeast
     value: |-
       {
-        "Runes": ["krait"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["krait"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Druid
     profession: Druid
     value: |-
       {
-        "Runes": ["lich"],
-        "Sigil1": "malice",
-        "Sigil2": "",
-        "Enhancement": ["toxic-maintenance-oil"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["lich"],
+          "Sigil1": ["malice"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-maintenance-oil"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Holo
     profession: Holosmith
     value: |-
       {
-        "Runes": ["renegade"],
-        "Sigil1": "malice",
-        "Sigil2": "bursting",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["renegade"],
+          "Sigil1": ["malice"],
+          "Sigil2": ["bursting"],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Cele Ren (Fractal)
     profession: Renegade
     value: |-
       {
-        "Runes": ["leadership"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["toxic-maintenance-oil"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["leadership"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["toxic-maintenance-oil"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Cele Ren (Raid)
     profession: Renegade
     value: |-
       {
-        "Runes": ["leadership"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["writ-of-masterful-malice"],
-        "Nourishment": ["dragon's-revelry-starcake"]
+        "extras": {
+          "Runes": ["leadership"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["writ-of-masterful-malice"],
+          "Nourishment": ["dragon's-revelry-starcake"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Ren
     profession: Renegade
     value: |-
       {
-        "Runes": ["nightmare"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["nightmare"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Herald
     profession: Herald
     value: |-
       {
-        "Runes": ["nightmare"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["nightmare"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta2] Vindicator'
     profession: Vindicator
     value: |-
       {
-        "Runes": ["scholar"],
-        "Sigil1": "force",
-        "Sigil2": "",
-        "Enhancement": ["superior-sharpening-stone"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["scholar"],
+          "Sigil1": ["force"],
+          "Sigil2": [],
+          "Enhancement": ["superior-sharpening-stone"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] Condi Mechanist Thorns'
     profession: Mechanist
     value: |-
       {
-        "Runes": ["thorns"],
-        "Sigil1": "bursting",
-        "Sigil2": "malice",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["thorns"],
+          "Sigil1": ["bursting"],
+          "Sigil2": ["malice"],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] Condi Mechanist Renegade'
     profession: Mechanist
     value: |-
       {
-        "Runes": ["renegade"],
-        "Sigil1": "bursting",
-        "Sigil2": "malice",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["renegade"],
+          "Sigil1": ["bursting"],
+          "Sigil2": ["malice"],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] Condi Mechanist Elementalist'
     profession: Mechanist
     value: |-
       {
-        "Runes": ["elementalist"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["elementalist"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: DPS Scourge
     profession: Scourge
     value: |-
       {
-        "Runes": ["nightmare"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["nightmare"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Reaper
     profession: Reaper
     value: |-
       {
-        "Runes": ["krait"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["krait"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] DPS Harbinger'
     profession: Harbinger
     value: |-
       {
-        "Runes": ["tormenting"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["tormenting"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] Quickness Harbinger (Firebrand)'
     profession: Harbinger
     value: |-
       {
-        "Runes": ["firebrand"],
-        "Sigil1": "demons",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["firebrand"],
+          "Sigil1": ["demons"],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] Quickness Harbinger (Cele)'
     profession: Harbinger
     value: |-
       {
-        "Runes": ["tormenting"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["tormenting"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Deadeye
     profession: Deadeye
     value: |-
       {
-        "Runes": ["nightmare"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["nightmare"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Power Boon Daredevil
     profession: Daredevil
     value: |-
       {
-        "Runes": ["thief"],
-        "Sigil1": "force",
-        "Sigil2": "concentration",
-        "Enhancement": ["potent-lucent-oil"],
-        "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        "extras": {
+          "Runes": ["thief"],
+          "Sigil1": ["force"],
+          "Sigil2": ["concentration"],
+          "Enhancement": ["potent-lucent-oil"],
+          "Nourishment": ["sweet-and-spicy-butternut-squash-soup"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Daredevil
     profession: Daredevil
     value: |-
       {
-        "Runes": ["krait"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["krait"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: Condi Boon Daredevil
     profession: Daredevil
     value: |-
       {
-        "Runes": ["firebrand"],
-        "Sigil1": "concentration",
-        "Sigil2": "malice",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["rare-veggie-pizza"]
+        "extras": {
+          "Runes": ["firebrand"],
+          "Sigil1": ["concentration"],
+          "Sigil2": ["malice"],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["rare-veggie-pizza"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta2] DPS Specter'
     profession: Specter
     value: |-
       {
-        "Runes": ["tormenting"],
-        "Sigil1": "",
-        "Sigil2": "",
-        "Enhancement": ["master-tuning-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["tormenting"],
+          "Sigil1": [],
+          "Sigil2": [],
+          "Enhancement": ["master-tuning-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }
 
   - name: '[beta1] DPS Specter'
     profession: Specter
     value: |-
       {
-        "Runes": ["tormenting"],
-        "Sigil1": "bursting",
-        "Sigil2": "",
-        "Enhancement": ["toxic-focusing-crystal"],
-        "Nourishment": ["beef-rendang"]
+        "extras": {
+          "Runes": ["tormenting"],
+          "Sigil1": ["bursting"],
+          "Sigil2": [],
+          "Enhancement": ["toxic-focusing-crystal"],
+          "Nourishment": ["beef-rendang"]
+        },
+        "amounts": {}
       }

--- a/src/components/sections/extras/Extras.jsx
+++ b/src/components/sections/extras/Extras.jsx
@@ -4,24 +4,23 @@ import { useTranslation } from 'gatsby-plugin-react-i18next';
 import React from 'react';
 import { allExtrasModifiersById, extrasModifiers } from '../../../assets/modifierdata';
 import ExtrasMultiselect from '../../baseComponents/ExtrasMultiselect';
-import GW2Select from './GW2Select';
 
 const Extras = () => {
   const { t } = useTranslation();
   return (
     <>
       <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
-          <GW2Select
-            name="Sigil1"
+        <Grid item xs={12}>
+          <ExtrasMultiselect
+            type="Sigil1"
             label={<Item id={24615} disableLink disableTooltip text={t('Sigil 1')} />}
             modifierData={extrasModifiers.sigils}
             modifierDataById={allExtrasModifiersById}
           />
         </Grid>
-        <Grid item xs={12} md={6}>
-          <GW2Select
-            name="Sigil2"
+        <Grid item xs={12}>
+          <ExtrasMultiselect
+            type="Sigil2"
             label={<Item id={24868} disableLink disableTooltip text={t('Sigil 2')} />}
             modifierData={extrasModifiers.sigils}
             modifierDataById={allExtrasModifiersById}

--- a/src/components/sections/results/BuildShareModal/BuildShareModal.jsx
+++ b/src/components/sections/results/BuildShareModal/BuildShareModal.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 import { changeCharacter } from '../../../../state/slices/buildPage';
-import { BuildPageSchema, version } from '../../../url-state/schema/BuildPageSchema_v1';
+import { BuildPageSchema, version } from '../../../url-state/schema/BuildPageSchema_v2';
 import ModalContent from './ModalContent';
 
 const useStyles = makeStyles()((theme) => ({
@@ -64,11 +64,7 @@ const BuildShareModal = ({ children, title, character }) => {
       settings: {
         cachedFormState: {
           extras: {
-            Enhancement: cachedFormState.extras.Enhancement,
-            Nourishment: cachedFormState.extras.Nourishment,
-            Runes: cachedFormState.extras.Runes,
-            Sigil1: cachedFormState.extras.Sigil1,
-            Sigil2: cachedFormState.extras.Sigil2,
+            extras: cachedFormState.extras.extras,
           },
         },
         profession,

--- a/src/components/sections/results/ResultCharacter.jsx
+++ b/src/components/sections/results/ResultCharacter.jsx
@@ -10,7 +10,6 @@ import ErrorBoundary from '../../baseComponents/ErrorBoundary';
 
 export default function ResultCharacter({ data, character, weapons, skills, assumedBuffs }) {
   const { profession, specialization, weaponType, cachedFormState } = character.settings;
-  const { extras } = cachedFormState;
 
   const classData = Classes[profession].weapons;
 
@@ -39,7 +38,7 @@ export default function ResultCharacter({ data, character, weapons, skills, assu
     Enhancement: utility,
     Nourishment: food,
     Runes: runeStringId,
-  } = extras;
+  } = cachedFormState.extras.extras;
 
   const foodId = allExtrasModifiersById[food]?.gw2id;
   const utilityId = allExtrasModifiersById[utility]?.gw2id;

--- a/src/components/sections/results/ResultTable.jsx
+++ b/src/components/sections/results/ResultTable.jsx
@@ -71,6 +71,27 @@ const StickyHeadTable = () => {
 
   const selectedValue = selectedCharacter?.results?.value;
 
+  // display extra types if any displayed character has the flag set to true
+  const shouldDisplay = (type) =>
+    firstCharacter?.settings?.shouldDisplayExtras?.[type] ||
+    saved.some((character) => character?.settings?.shouldDisplayExtras?.[type]);
+
+  // this code looks awful but a working useMemo is very important here (rerendering every row = bad)
+  const displaySigils = shouldDisplay('Sigil1') || shouldDisplay('Sigil2');
+  const displayRunes = shouldDisplay('Runes');
+  const displayNourishment = shouldDisplay('Nourishment');
+  const displayEnhancement = shouldDisplay('Enhancement');
+  const displayExtras = React.useMemo(
+    () => ({
+      Sigil1: displaySigils,
+      Sigil2: displaySigils,
+      Runes: displayRunes,
+      Nourishment: displayNourishment,
+      Enhancement: displayEnhancement,
+    }),
+    [displaySigils, displayRunes, displayNourishment, displayEnhancement],
+  );
+
   return (
     <>
       <Box boxShadow={8} mb={3}>
@@ -82,6 +103,7 @@ const StickyHeadTable = () => {
                 weaponType={weaponType}
                 infusions={infusions}
                 rankBy={rankBy}
+                displayExtras={displayExtras}
               />
             </TableHead>
             <TableBody
@@ -121,6 +143,7 @@ const StickyHeadTable = () => {
                     underlineClass={underline ? classes.underline : null}
                     selectedValue={selectedValue}
                     compareByPercent={compareByPercent}
+                    displayExtras={displayExtras}
                   />
                 );
               })}
@@ -159,6 +182,7 @@ const StickyHeadTable = () => {
                     weaponType={weaponType}
                     infusions={infusions}
                     rankBy={rankBy}
+                    displayExtras={displayExtras}
                   />
                 </TableHead>
                 <TableBody
@@ -177,6 +201,7 @@ const StickyHeadTable = () => {
                         underlineClass={i === saved.length - 1 ? classes.bigUnderline : null}
                         selectedValue={selectedValue}
                         compareByPercent={compareByPercent}
+                        displayExtras={displayExtras}
                       />
                     );
                   })}

--- a/src/components/sections/results/ResultTableHeaderRow.jsx
+++ b/src/components/sections/results/ResultTableHeaderRow.jsx
@@ -4,13 +4,27 @@ import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import React from 'react';
+import { extrasTypes } from '../../../state/slices/extras';
 import { INFUSION_IDS, Slots } from '../../../utils/gw2-data';
+
+const extrasLabels = {
+  Sigil1: <Item id={24615} disableLink disableText disableTooltip style={{ fontSize: 18 }} />,
+  Sigil2: <Item id={24615} disableLink disableText disableTooltip style={{ fontSize: 18 }} />,
+  Runes: <Item id={24836} disableLink disableText disableTooltip style={{ fontSize: 18 }} />,
+  Nourishment: (
+    <ConsumableEffect disableLink disableText name="Nourishment" style={{ fontSize: 18 }} />
+  ),
+  Enhancement: (
+    <ConsumableEffect disableLink disableText name="Enhancement" style={{ fontSize: 18 }} />
+  ),
+};
 
 const ResultTableHeaderRow = ({
   classes,
   weaponType = 'Two-handed',
   infusions = {},
   rankBy = 'Damage',
+  displayExtras,
 }) => {
   const { t } = useTranslation();
 
@@ -38,15 +52,19 @@ const ResultTableHeaderRow = ({
         </TableCell>
       ))}
 
-      <TableCell className={classes.tablehead} align="center" padding="none">
-        <Item id={24836} disableLink disableText disableTooltip style={{ fontSize: 18 }} />
-      </TableCell>
-      <TableCell className={classes.tablehead} align="center" padding="none">
-        <ConsumableEffect disableLink disableText name="Nourishment" style={{ fontSize: 18 }} />
-      </TableCell>
-      <TableCell className={classes.tablehead} align="center" padding="none">
-        <ConsumableEffect disableLink disableText name="Enhancement" style={{ fontSize: 18 }} />
-      </TableCell>
+      {extrasTypes
+        .filter((type) => displayExtras[type])
+        .map((type, index) => (
+          <TableCell
+            className={classes.tablehead}
+            // eslint-disable-next-line react/no-array-index-key
+            key={`extras${index}`}
+            align="center"
+            padding="none"
+          >
+            {extrasLabels[type]}
+          </TableCell>
+        ))}
     </TableRow>
   );
 };

--- a/src/components/sections/results/ResultTableRow.jsx
+++ b/src/components/sections/results/ResultTableRow.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { allExtrasModifiersById } from '../../../assets/modifierdata';
 import { changeSelectedCharacter, toggleSaved } from '../../../state/slices/controlsSlice';
+import { extrasTypes } from '../../../state/slices/extras';
 
 const ResultTableRow = ({
   character,
@@ -16,6 +17,7 @@ const ResultTableRow = ({
   underlineClass,
   selectedValue,
   compareByPercent,
+  displayExtras,
 }) => {
   const dispatch = useDispatch();
 
@@ -90,22 +92,24 @@ const ResultTableRow = ({
             </TableCell>
           ))
         : null}
-      {['Runes', 'Nourishment', 'Enhancement'].map((key, index) => {
-        const extra = character.settings.cachedFormState.extras[key];
-        return (
-          // eslint-disable-next-line react/no-array-index-key
-          <TableCell align="center" key={`extras${index}`} padding="none">
-            {extra ? (
-              <Item
-                id={allExtrasModifiersById[extra]?.gw2id}
-                disableText
-                disableLink
-                style={{ fontSize: 18 }}
-              />
-            ) : null}
-          </TableCell>
-        );
-      })}
+      {extrasTypes
+        .filter((type) => displayExtras[type])
+        .map((key, index) => {
+          const extra = character.settings.cachedFormState.extras.extras[key];
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <TableCell align="center" key={`extras${index}`} padding="none">
+              {extra ? (
+                <Item
+                  id={allExtrasModifiersById[extra]?.gw2id}
+                  disableText
+                  disableLink
+                  style={{ fontSize: 18 }}
+                />
+              ) : null}
+            </TableCell>
+          );
+        })}
     </TableRow>
   );
 };

--- a/src/components/sections/results/TemplateHelper.jsx
+++ b/src/components/sections/results/TemplateHelper.jsx
@@ -35,7 +35,7 @@ const TemplateHelper = ({ character }) => {
     return { key, inputText, value, error };
   });
 
-  const { cachedFormState } = character.settings;
+  const { cachedFormState, realExtras } = character.settings;
   const { coefficientHelper } = character.results;
 
   // reverse engineer coefficient needed to reach target damage
@@ -156,7 +156,7 @@ const TemplateHelper = ({ character }) => {
       </Typography>
 
       <pre style={{ userSelect: 'all', overflowY: 'auto', maxHeight: '250px' }}>
-        {indent(JSON.stringify(cachedFormState?.extras, null, 2) || '', 6)}
+        {indent(JSON.stringify(realExtras, null, 2) || '', 6)}
       </pre>
     </>
   );

--- a/src/components/sections/results/TemplateHelperSections.jsx
+++ b/src/components/sections/results/TemplateHelperSections.jsx
@@ -27,7 +27,7 @@ const TemplateHelperSections = ({ character }) => {
       Enhancement: utility,
       Nourishment: food,
       Runes: runeStringId,
-    } = extras;
+    } = extras.extras;
 
     const foodId = allExtrasModifiersById[food]?.gw2id;
     const utilityId = allExtrasModifiersById[utility]?.gw2id;

--- a/src/components/url-state/schema/BuildPageSchema_v2.js
+++ b/src/components/url-state/schema/BuildPageSchema_v2.js
@@ -1,0 +1,71 @@
+import {
+  enhancementDict,
+  gearDict,
+  nourishmentDict,
+  professionDict,
+  runesDict,
+  sigilDict,
+  specializationDict,
+  weaponTypeDict,
+} from './SchemaDicts';
+
+export const version = 2;
+// eslint-disable-next-line import/prefer-default-export
+export const BuildPageSchema = {
+  character: {
+    attributes: {
+      Power: null,
+      Precision: null,
+      Toughness: null,
+      Vitality: null,
+      Ferocity: null,
+      'Condition Damage': null,
+      Expertise: null,
+      Concentration: null,
+      'Healing Power': null,
+      'Agony Resistance': null,
+      'Condition Duration': null,
+      'Boon Duration': null,
+      'Critical Chance': null,
+      'Critical Damage': null,
+      'Health': null,
+      'Armor': null,
+    },
+    gear: { type: 'array', dict: gearDict },
+    infusions: null,
+    settings: {
+      cachedFormState: {
+        extras: {
+          extras: {
+            Enhancement: { type: 'value', dict: enhancementDict },
+            Nourishment: { type: 'value', dict: nourishmentDict },
+            Runes: { type: 'value', dict: runesDict },
+            Sigil1: { type: 'value', dict: sigilDict },
+            Sigil2: { type: 'value', dict: sigilDict },
+          },
+        },
+      },
+      profession: { type: 'value', dict: professionDict },
+      specialization: { type: 'value', dict: specializationDict },
+      weaponType: { type: 'value', dict: weaponTypeDict },
+    },
+  },
+  skills: {
+    healId: null,
+    utility1Id: null,
+    utility2Id: null,
+    utility3Id: null,
+    eliteId: null,
+  },
+  traits: {
+    lines: null,
+    selected: null,
+  },
+  weapons: {
+    mainhand1: null,
+    mainhand2: null,
+    offhand1: null,
+    offhand2: null,
+  },
+  buffs: null,
+};

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -1257,6 +1257,7 @@ export function createOptimizerCore(input) {
     appliedModifiers,
     rankby,
     shouldDisplayExtras,
+    realExtras,
     // ...rest
   } = settings;
   // console.log(Object.keys(rest));
@@ -1270,6 +1271,7 @@ export function createOptimizerCore(input) {
     appliedModifiers,
     rankby,
     shouldDisplayExtras,
+    realExtras,
   };
 
   return new OptimizerCore(settings, minimalSettings);

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -98,6 +98,7 @@ let uniqueIDCounter = 0;
 
 class OptimizerCore {
   settings;
+  minimalSettings;
   applyInfusionsFunction;
   condiResultCache = new Map();
   worstScore;
@@ -105,8 +106,9 @@ class OptimizerCore {
   isChanged = true;
   randomId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 
-  constructor(settings) {
+  constructor(settings, minimalSettings) {
     this.settings = settings;
+    this.minimalSettings = minimalSettings;
   }
 
   /**
@@ -238,30 +240,9 @@ class OptimizerCore {
       return;
     }
 
-    const {
-      cachedFormState,
-      profession,
-      specialization,
-      weaponType,
-      appliedModifiers,
-      rankby,
-      // ...rest
-    } = settings;
-    // console.log(Object.keys(rest));
-
-    // only supply character with settings it uses to render
-    const minimalSettings = {
-      cachedFormState,
-      profession,
-      specialization,
-      weaponType,
-      appliedModifiers,
-      rankby,
-    };
-
     const character = {
       gear, // passed by reference
-      settings: minimalSettings, // passed by reference
+      settings: this.minimalSettings, // passed by reference
       gearStats, // passed by reference
       attributes: null,
       valid: true,
@@ -683,7 +664,10 @@ class OptimizerCore {
 
     // baseline for comparing adding/subtracting +5 infusions
     const baseline = this.clone(character);
-    const noRoundingCore = new OptimizerCore({ ...this.settings, noRounding: true });
+    const noRoundingCore = new OptimizerCore(
+      { ...this.settings, noRounding: true },
+      this.minimalSettings,
+    );
     noRoundingCore.updateAttributes(baseline);
 
     // effective gain from adding +5 infusions
@@ -1265,7 +1249,28 @@ export function createOptimizerCore(input) {
   //   return num / denom;
   // }
 
-  return new OptimizerCore(settings);
+  const {
+    cachedFormState,
+    profession,
+    specialization,
+    weaponType,
+    appliedModifiers,
+    rankby,
+    // ...rest
+  } = settings;
+  // console.log(Object.keys(rest));
+
+  // only supply character with settings it uses to render
+  const minimalSettings = {
+    cachedFormState,
+    profession,
+    specialization,
+    weaponType,
+    appliedModifiers,
+    rankby,
+  };
+
+  return new OptimizerCore(settings, minimalSettings);
 }
 
 // returns a positive value if B is better than A

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -1256,6 +1256,7 @@ export function createOptimizerCore(input) {
     weaponType,
     appliedModifiers,
     rankby,
+    shouldDisplayExtras,
     // ...rest
   } = settings;
   // console.log(Object.keys(rest));
@@ -1268,6 +1269,7 @@ export function createOptimizerCore(input) {
     weaponType,
     appliedModifiers,
     rankby,
+    shouldDisplayExtras,
   };
 
   return new OptimizerCore(settings, minimalSettings);

--- a/src/state/optimizer/sagas.js
+++ b/src/state/optimizer/sagas.js
@@ -37,6 +37,7 @@ function createInput(
   cachedFormState,
   customAffixData,
   shouldDisplayExtras,
+  realExtras,
 ) {
   const {
     control: { profession },
@@ -110,6 +111,7 @@ function createInput(
   input.cachedFormState = cachedFormState;
   input.customAffixData = customAffixData;
   input.shouldDisplayExtras = shouldDisplayExtras;
+  input.realExtras = realExtras;
 
   // temp: convert "poisoned" to "poison"
   const convertPoison = (distribution) =>
@@ -171,6 +173,9 @@ function* runCalc() {
         buffs: state.form.buffs, // buffs are also needed to share a build and display the assumed buffs for the result
       };
 
+      // insert real (with arrays of all options) extras data for the template helper
+      const realExtras = state.form.extras;
+
       // display extras in table if they have multiple options
       const shouldDisplayExtras = mapValues(
         state.form.extras.extras,
@@ -184,6 +189,7 @@ function* runCalc() {
         cachedFormState,
         customAffixData,
         shouldDisplayExtras,
+        realExtras,
       );
       console.log('Input option:', combination);
     }


### PR DESCRIPTION
This:
- Adds multiselection to the sigils as well
- Hides extras columns in the results table if they don't use the multiselect option
- Refactors the extras slice in order to add a section for extras data, and hopefully updates the schema stuff to continue to work with that change. This is the part I need confirmation that I did correctly.