### PR TITLE
Fix: Use schema for assumedbuffs

### DIFF
--- a/src/assets/modifierdata/buffs.yaml
+++ b/src/assets/modifierdata/buffs.yaml
@@ -147,7 +147,7 @@
       type: Skill
       gw2id: 9093
 
-    - id: signetOfJudgment
+    - id: signetOfJudgement
       text: Signet of Judgement
       modifiers:
         damage:

--- a/src/assets/modifierdata/testModifiers.js
+++ b/src/assets/modifierdata/testModifiers.js
@@ -36,8 +36,8 @@ import {
 const schemaKeys = {
   'runes.yaml': runesDict,
   'sigils.yaml': sigilDict,
-  'food.yaml': enhancementDict,
-  'utility.yaml': nourishmentDict,
+  'food.yaml': nourishmentDict,
+  'utility.yaml': enhancementDict,
   'buffs.yaml': buffsDict,
 };
 

--- a/src/assets/modifierdata/testModifiers.js
+++ b/src/assets/modifierdata/testModifiers.js
@@ -7,6 +7,15 @@ import fs from 'fs/promises';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import yaml from 'js-yaml';
 import path from 'path';
+import {
+  buffsDict,
+  enhancementDict,
+  gearDict,
+  nourishmentDict,
+  runesDict,
+  sigilDict,
+} from '../../components/url-state/schema/SchemaDicts.js';
+import { Affix } from '../../utils/gw2-data.js';
 // import specializationData from '../../utils/mapping/specializations.json' assert { type: 'json' };
 import {
   allAttributeCoefficientKeys,
@@ -24,6 +33,14 @@ import {
   damageKeysBlacklist,
 } from './metadata.js';
 
+const schemaKeys = {
+  'runes.yaml': runesDict,
+  'sigils.yaml': sigilDict,
+  'food.yaml': enhancementDict,
+  'utility.yaml': nourishmentDict,
+  'buffs.yaml': buffsDict,
+};
+
 const directory = './src/assets/modifierdata/';
 
 // causes the script to fail if condition is false, but does not stop execution
@@ -35,6 +52,11 @@ const gentleAssert = (condition, message) => {
 };
 
 const testModifiers = async () => {
+  // not really modifiers, but, whatever
+  Object.keys(Affix).forEach((affix) =>
+    gentleAssert(gearDict.includes(affix), `err: gearDict doesn't include ${affix}!`),
+  );
+
   const specializationDataJSON = await fs.readFile('./src/utils/mapping/specializations.json');
   const specializationData = JSON.parse(specializationDataJSON);
 
@@ -108,6 +130,13 @@ const testModifiers = async () => {
           !Object.keys(otherKeys).length,
           `err: this script is missing validation for ${JSON.stringify(otherKeys)}`,
         );
+
+        if (schemaKeys[fileName]) {
+          gentleAssert(
+            schemaKeys[fileName].includes(id),
+            `err: schema for ${fileName} doesn't include ${id}!`,
+          );
+        }
 
         const checkNullRecursively = (obj) => {
           for (const value of Object.values(obj)) {

--- a/src/assets/modifierdata/testModifiers.js
+++ b/src/assets/modifierdata/testModifiers.js
@@ -10,12 +10,10 @@ import path from 'path';
 import {
   buffsDict,
   enhancementDict,
-  gearDict,
   nourishmentDict,
   runesDict,
   sigilDict,
 } from '../../components/url-state/schema/SchemaDicts.js';
-import { Affix } from '../../utils/gw2-data.js';
 // import specializationData from '../../utils/mapping/specializations.json' assert { type: 'json' };
 import {
   allAttributeCoefficientKeys,
@@ -52,11 +50,6 @@ const gentleAssert = (condition, message) => {
 };
 
 const testModifiers = async () => {
-  // not really modifiers, but, whatever
-  Object.keys(Affix).forEach((affix) =>
-    gentleAssert(gearDict.includes(affix), `err: gearDict doesn't include ${affix}!`),
-  );
-
   const specializationDataJSON = await fs.readFile('./src/utils/mapping/specializations.json');
   const specializationData = JSON.parse(specializationDataJSON);
 

--- a/src/components/sections/results/BuildShareModal/BuildShareModal.jsx
+++ b/src/components/sections/results/BuildShareModal/BuildShareModal.jsx
@@ -10,6 +10,7 @@ import { useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 import { changeCharacter } from '../../../../state/slices/buildPage';
 import { BuildPageSchema, version } from '../../../url-state/schema/BuildPageSchema_v2';
+import { buffsDict } from '../../../url-state/schema/SchemaDicts';
 import ModalContent from './ModalContent';
 
 const useStyles = makeStyles()((theme) => ({
@@ -72,7 +73,7 @@ const BuildShareModal = ({ children, title, character }) => {
 
     // create bit map for buffs
     const conv = (val) => (val ? 1 : 0);
-    const buffsInteger = Object.keys(buffs).reduce(
+    const buffsInteger = buffsDict.reduce(
       // eslint-disable-next-line no-bitwise
       (acc, curr) => (acc + conv(buffs[curr])) << 1,
       conv(buffs[0]),

--- a/src/components/url-state/schema/SchemaDicts.js
+++ b/src/components/url-state/schema/SchemaDicts.js
@@ -270,4 +270,6 @@ export const buffsDict = [
   'signetOfWrath',
   'exposed',
   'lightArmor',
+  'jade-bot-base',
+  'jade-bot-per-tier',
 ];

--- a/src/components/url-state/schema/SchemaDicts.js
+++ b/src/components/url-state/schema/SchemaDicts.js
@@ -247,3 +247,27 @@ export const nourishmentDict = [
   'meaty-rice-bowl',
   'block-of-tofu',
 ];
+
+export const buffsDict = [
+  'might',
+  'fury',
+  'protection',
+  'vulnerability',
+  'bannerOfStrength',
+  'bannerOfDiscipline',
+  'bannerOfTactics',
+  'bannerOfDefense',
+  'spotter',
+  'frostSpirit',
+  'empowerAllies',
+  'pinpointDistribution',
+  'assassinsPresence',
+  'riteDwarf',
+  'strengthInNumbers',
+  'baneSignet',
+  'signetOfJudgement',
+  'signetOfMercy',
+  'signetOfWrath',
+  'exposed',
+  'lightArmor',
+];

--- a/src/components/url-state/schema/SchemaDicts.js
+++ b/src/components/url-state/schema/SchemaDicts.js
@@ -246,6 +246,7 @@ export const nourishmentDict = [
   'meaty-asparagus-skewer',
   'meaty-rice-bowl',
   'block-of-tofu',
+  'dragons-revelry-starcake-bugged',
 ];
 
 export const buffsDict = [

--- a/src/components/url-state/schema/package.json
+++ b/src/components/url-state/schema/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/src/state/optimizer/sagas.js
+++ b/src/state/optimizer/sagas.js
@@ -9,7 +9,7 @@ import {
   parsePriority,
 } from '../../utils/usefulFunctions';
 import { getBuffsModifiers } from '../slices/buffs';
-import { changeBuildPage } from '../slices/buildPage';
+// import { changeBuildPage } from '../slices/buildPage';
 import {
   changeAll,
   changeControl,
@@ -381,6 +381,7 @@ function* watchImportState() {
   yield takeLeading('IMPORT_STATE', importState);
 }
 
+/*
 function* exportStateCharacter({ onSuccess }) {
   const reduxState = yield select();
 
@@ -433,9 +434,11 @@ function* importStateCharacter({ buildUrl: input, onSuccess, onError }) {
   }
 }
 
+
 function* watchImportStateCharacter() {
   yield takeLeading('IMPORT_STATE_CHARACTER', importStateCharacter);
 }
+*/
 
 export default function* rootSaga() {
   yield all([
@@ -443,7 +446,7 @@ export default function* rootSaga() {
     watchStart(),
     watchExportState(),
     watchImportState(),
-    watchExportStateCharacter(),
-    watchImportStateCharacter(),
+    // watchExportStateCharacter(),
+    // watchImportStateCharacter(),
   ]);
 }

--- a/src/state/slices/buildPage.js
+++ b/src/state/slices/buildPage.js
@@ -39,7 +39,9 @@ export const buildPageSlice = createSlice({
       const tempBits = action.payload.buffs.toString(2);
       // pad zeros
       const buffBits =
-        tempBits.length < 21 ? '0'.repeat(21 - tempBits.length) + tempBits : tempBits;
+        tempBits.length < buffsDict.length
+          ? '0'.repeat(buffsDict.length - tempBits.length) + tempBits
+          : tempBits;
       // force the same order during as it was during compression
       const buffsUnpacked = {};
       buffsDict.forEach((buff, index) => {

--- a/src/state/slices/buildPage.js
+++ b/src/state/slices/buildPage.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { buffModifiers } from '../../assets/modifierdata';
+import { buffsDict } from '../../components/url-state/schema/SchemaDicts';
 
 export const buildPageSlice = createSlice({
   name: 'buildPage',
@@ -42,13 +42,9 @@ export const buildPageSlice = createSlice({
         tempBits.length < 21 ? '0'.repeat(21 - tempBits.length) + tempBits : tempBits;
       // force the same order during as it was during compression
       const buffsUnpacked = {};
-      // grab the list of buffs like they are in buffs.yml and map it to get a list of ids.
-      buffModifiers
-        .flatMap((buff) => buff.items)
-        .map((buff) => buff.id)
-        .forEach((buff, index) => {
-          buffsUnpacked[buff] = buffBits[index] === '1';
-        });
+      buffsDict.forEach((buff, index) => {
+        buffsUnpacked[buff] = buffBits[index] === '1';
+      });
 
       // handle the case for when no infusions are present. Value must be undefined or else it wont get parsed correctly by the character component
       const infusions = action.payload.character.infusions

--- a/src/utils/package.json
+++ b/src/utils/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/src/utils/package.json
+++ b/src/utils/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
This adds a schema entry for buffs like we have for the other keys and uses it for buff encode/decode (although it is not currently the same system using the compression library), so that we can append new buffs onto the end of the list and old links will continue to work.
 
It adds a check to testModifiers that checks the schemas (not all of them unfortunately) to make sure we don't forget to update the schema when new modifier data is added, including buffs.

I had to add a dummy `package.json` to `src/components/url-state/schema/` to get node to import the schema in module mode; hopefully that doesn't break anything.