### PR TITLE
feat: rework share logic a bit

### DIFF
--- a/src/components/GearOptimizer.jsx
+++ b/src/components/GearOptimizer.jsx
@@ -17,6 +17,7 @@ import InfusionsSection from './sections/infusions/InfusionsSection';
 import PrioritiesSection from './sections/priorities/PrioritiesSection';
 import ResultDetails from './sections/results/ResultDetails';
 import ResultTable from './sections/results/table/ResultTable';
+import SharingSection from './sections/sharing/SharingSection';
 import SkillsSection from './sections/skills/SkillsSection';
 import TraitsSection from './sections/traits/TraitsSection';
 
@@ -98,6 +99,7 @@ const MainComponent = ({ data }) => {
           <Controls profession={profession} />
 
           <ResultTable />
+          <SharingSection />
           <Box m={3} />
           <ResultDetails data={data} />
         </div>

--- a/src/components/sections/controls/Controls.jsx
+++ b/src/components/sections/controls/Controls.jsx
@@ -111,7 +111,7 @@ const ControlsBox = ({ profession }) => {
             </Typography>
           </Button>
         </Box>
-        <Box>
+        <Box flexGrow={1}>
           <Button
             variant="outlined"
             color="primary"
@@ -124,9 +124,6 @@ const ControlsBox = ({ profession }) => {
               <Trans>Abort</Trans>
             </Typography>
           </Button>
-        </Box>
-        <Box flexGrow={1} alignSelf="center">
-          <URLStateExport />
         </Box>
 
         <Box alignSelf="center" display="flex" m={1} maxWidth={300}>

--- a/src/components/sections/controls/Controls.jsx
+++ b/src/components/sections/controls/Controls.jsx
@@ -18,7 +18,6 @@ import {
 } from '../../../state/slices/controlsSlice';
 import { getPriority } from '../../../state/slices/priorities';
 import ProgressIcon from '../../baseComponents/ProgressIcon';
-import URLStateExport from '../../url-state/URLStateExport';
 import ResultTableSettings from './ResultTableSettings';
 
 const useStyles = makeStyles()((theme) => ({

--- a/src/components/sections/results/BuildShareModal/BuildShareModal.jsx
+++ b/src/components/sections/results/BuildShareModal/BuildShareModal.jsx
@@ -1,6 +1,7 @@
 import CloseIcon from '@mui/icons-material/Close';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ShareIcon from '@mui/icons-material/Share';
 import { Box, Divider, IconButton, Typography } from '@mui/material';
-import Backdrop from '@mui/material/Backdrop';
 import Fade from '@mui/material/Fade';
 import Modal from '@mui/material/Modal';
 import { withPrefix } from 'gatsby';
@@ -10,8 +11,6 @@ import { makeStyles } from 'tss-react/mui';
 import { version } from '../../../url-state/schema/BuildPageSchema_v2';
 import generateLink from './generateLink';
 import ModalContent from './ModalContent';
-import ShareIcon from '@mui/icons-material/Share';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 const useStyles = makeStyles()((theme) => ({
   modal: {

--- a/src/components/sections/results/BuildShareModal/BuildShareModal.jsx
+++ b/src/components/sections/results/BuildShareModal/BuildShareModal.jsx
@@ -1,5 +1,5 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { Box, Divider, Typography } from '@mui/material';
+import { Box, Divider, IconButton, Typography } from '@mui/material';
 import Backdrop from '@mui/material/Backdrop';
 import Fade from '@mui/material/Fade';
 import Modal from '@mui/material/Modal';
@@ -10,6 +10,8 @@ import { makeStyles } from 'tss-react/mui';
 import { version } from '../../../url-state/schema/BuildPageSchema_v2';
 import generateLink from './generateLink';
 import ModalContent from './ModalContent';
+import ShareIcon from '@mui/icons-material/Share';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 const useStyles = makeStyles()((theme) => ({
   modal: {
@@ -65,10 +67,6 @@ const BuildShareModal = ({ children, title, character }) => {
         className={classes.modal}
         open={open}
         onClose={handleClose}
-        BackdropComponent={Backdrop}
-        BackdropProps={{
-          timeout: 1000,
-        }}
       >
         <Fade in={open}>
           <div className={classes.paper}>
@@ -80,12 +78,34 @@ const BuildShareModal = ({ children, title, character }) => {
               )}
 
               <Box alignSelf="center">
-                <CloseIcon className={classes.closeIcon} onClick={handleClose} />
+                <IconButton onClick={handleClose}>
+                  <CloseIcon className={classes.closeIcon} />
+                </IconButton>
               </Box>
             </Box>
             <Divider />
 
-            <ModalContent character={character} onClick={onClick} />
+            <ModalContent
+              character={character}
+              buttons={[
+                { label: 'Open build', onClick, icon: ShareIcon },
+                {
+                  label: 'Copy build',
+                  onClick: ({ profession, buffs, lines, selected, skills, weapons }) =>
+                    generateLink(
+                      { character, profession, buffs, lines, selected, skills, weapons },
+                      (result) => {
+                        navigator.clipboard.writeText(
+                          window.location.href.slice(0, window.location.href.length - 1) +
+                            withPrefix(`/build?v=${version}&data=${result}`),
+                        );
+                      },
+                      dispatch,
+                    ),
+                  icon: ContentCopyIcon,
+                },
+              ]}
+            />
           </div>
         </Fade>
       </Modal>

--- a/src/components/sections/results/BuildShareModal/ModalContent.jsx
+++ b/src/components/sections/results/BuildShareModal/ModalContent.jsx
@@ -1,5 +1,6 @@
 import { Error, Icon, Item, Progress } from '@discretize/gw2-ui-new';
 import { firstUppercase } from '@discretize/react-discretize-components';
+import DoneIcon from '@mui/icons-material/Done';
 import { Box, Button, ButtonGroup, MenuItem, Select, Typography } from '@mui/material';
 import axios from 'axios';
 import React from 'react';
@@ -36,6 +37,7 @@ export default function ModalContent({ character, buttons }) {
   const { buffs } = character.settings.cachedFormState.buffs;
 
   const [state, setState] = React.useState({ skills: undefined, error: undefined });
+  const [buttonState, setButtonState] = React.useState(new Array(buttons.length));
 
   const { profession } = character.settings;
   const { weapons: useableWeapons } = Classes[profession];
@@ -185,10 +187,22 @@ export default function ModalContent({ character, buttons }) {
       </Box>
 
       <ButtonGroup variant="contained" color="primary">
-        {buttons.map(({ label, icon: ButtonIcon, onClick }) => (
+        {buttons.map(({ label, icon: ButtonIcon, onClick }, index) => (
           <Button
-            startIcon={<ButtonIcon />}
-            onClick={() => onClick({ profession, buffs, lines, selected, skills, weapons })}
+            startIcon={buttonState[index] ? <DoneIcon /> : <ButtonIcon />}
+            disabled={buttonState[index]}
+            onClick={() => {
+              const newState = [...buttonState];
+              newState[index] = true;
+              setButtonState(newState);
+
+              setTimeout(() => {
+                const tmpState = [...buttonState];
+                tmpState[index] = false;
+                setButtonState(tmpState);
+              }, 5000);
+              onClick({ profession, buffs, lines, selected, skills, weapons });
+            }}
           >
             {label}
           </Button>

--- a/src/components/sections/results/BuildShareModal/ModalContent.jsx
+++ b/src/components/sections/results/BuildShareModal/ModalContent.jsx
@@ -1,18 +1,13 @@
-import { Icon, Item, Skill } from '@discretize/gw2-ui-new';
-import { firstUppercase, NoSelection } from '@discretize/react-discretize-components';
-import ShareIcon from '@mui/icons-material/Share';
-import { Box, Button, MenuItem, Select, Typography } from '@mui/material';
+import { Error, Icon, Item, Progress } from '@discretize/gw2-ui-new';
+import { firstUppercase } from '@discretize/react-discretize-components';
+import { Box, Button, ButtonGroup, MenuItem, Select, Typography } from '@mui/material';
 import axios from 'axios';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
-import {
-  changeSkill,
-  changeWeapon,
-  getSkills,
-  getWeapons,
-} from '../../../../state/slices/buildPage';
+import { changeWeapon, getSkills, getWeapons } from '../../../../state/slices/buildPage';
 import { Classes, WEAPONS } from '../../../../utils/gw2-data';
+import SkillSelect from './SkillSelect';
 
 const useStyles = makeStyles()((theme) => ({
   weaponItem: {
@@ -29,7 +24,7 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-export default function ModalContent({ character, onClick, label = 'Open Build' }) {
+export default function ModalContent({ character, buttons }) {
   const dispatch = useDispatch();
   const { classes } = useStyles();
   const weapons = useSelector(getWeapons);
@@ -40,7 +35,7 @@ export default function ModalContent({ character, onClick, label = 'Open Build' 
   const selected = character.settings.cachedFormState.traits.selectedTraits;
   const { buffs } = character.settings.cachedFormState.buffs;
 
-  const [apiSkills, setApiSkills] = React.useState(null);
+  const [state, setState] = React.useState({ skills: undefined, error: undefined });
 
   const { profession } = character.settings;
   const { weapons: useableWeapons } = Classes[profession];
@@ -56,10 +51,6 @@ export default function ModalContent({ character, onClick, label = 'Open Build' 
     dispatch(changeWeapon({ key: e.target.name, value: e.target.value }));
   };
 
-  const handleChangeSkill = (e) => {
-    dispatch(changeSkill({ key: e.target.name, value: e.target.value }));
-  };
-
   const getWeaponId = (weaponName) => {
     return WEAPONS[weaponName.toUpperCase().replace(' ', '')]?.gw2id;
   };
@@ -67,47 +58,15 @@ export default function ModalContent({ character, onClick, label = 'Open Build' 
   React.useEffect(() => {
     axios
       .get(`https://api.guildwars2.com/v2/professions/${firstUppercase(profession)}`)
-      .then((res) => setApiSkills(res.data.skills))
+      .then((res) => setState({ error: undefined, skills: res.data.skills }))
       .catch((e) => {
         console.error(e);
+        setState({ error: e.message });
         return null;
       });
   }, [profession]);
 
-  function SkillSelect(name, value, skillList) {
-    return (
-      <Select
-        variant="standard"
-        value={value}
-        name={name}
-        onChange={handleChangeSkill}
-        className={classes.skillSelect}
-        renderValue={(skill) =>
-          skill === '' ? (
-            <div style={{ fontSize: 60, lineHeight: 0 }}>
-              <NoSelection />
-            </div>
-          ) : (
-            <Skill id={skill} disableText style={{ fontSize: 60, lineHeight: 0 }} />
-          )
-        }
-        displayEmpty
-      >
-        {skillList.map((skill) => (
-          <MenuItem value={skill.id} key={skill.id}>
-            <Skill
-              id={skill.id}
-              disableLink
-              disableText
-              style={{ marginRight: 4, fontSize: '1.2rem' }}
-            />
-            <Skill id={skill.id} disableLink disableTooltip disableIcon />
-          </MenuItem>
-        ))}
-      </Select>
-    );
-  }
-
+  const isLoading = !state.error && !state.skills;
   return (
     <>
       <Typography>Select weapons:</Typography>
@@ -191,46 +150,50 @@ export default function ModalContent({ character, onClick, label = 'Open Build' 
 
       <Typography>Select skills:</Typography>
 
-      <Box mb={1}>
-        {apiSkills && (
+      <Box mb={2}>
+        {isLoading && <Progress />}
+        {state.error && <Error name="ERROR" message={state.error} />}
+        {state.skills && (
           <>
-            {SkillSelect(
-              'healId',
-              healId,
-              apiSkills.filter((skill) => skill.type === 'Heal'),
-            )}
-            {SkillSelect(
-              'utility1Id',
-              utility1Id,
-              apiSkills.filter((skill) => skill.type === 'Utility'),
-            )}
-            {SkillSelect(
-              'utility2Id',
-              utility2Id,
-              apiSkills.filter((skill) => skill.type === 'Utility'),
-            )}
-            {SkillSelect(
-              'utility3Id',
-              utility3Id,
-              apiSkills.filter((skill) => skill.type === 'Utility'),
-            )}
-            {SkillSelect(
-              'eliteId',
-              eliteId,
-              apiSkills.filter((skill) => skill.type === 'Elite'),
-            )}
+            <SkillSelect
+              name="healId"
+              value={healId}
+              skillList={state.skills.filter((skill) => skill.type === 'Heal')}
+            />
+            <SkillSelect
+              name="utility1Id"
+              value={utility1Id}
+              skillList={state.skills.filter((skill) => skill.type === 'Utility')}
+            />
+            <SkillSelect
+              name="utility2Id"
+              value={utility2Id}
+              skillList={state.skills.filter((skill) => skill.type === 'Utility')}
+            />
+            <SkillSelect
+              name="utility3Id"
+              value={utility3Id}
+              skillList={state.skills.filter((skill) => skill.type === 'Utility')}
+            />
+            <SkillSelect
+              name="eliteId"
+              value={eliteId}
+              skillList={state.skills.filter((skill) => skill.type === 'Elite')}
+            />
           </>
         )}
       </Box>
 
-      <Button
-        variant="contained"
-        color="primary"
-        startIcon={<ShareIcon />}
-        onClick={() => onClick({ profession, buffs, lines, selected, skills, weapons })}
-      >
-        {label}
-      </Button>
+      <ButtonGroup variant="contained" color="primary">
+        {buttons.map(({ label, icon: ButtonIcon, onClick }) => (
+          <Button
+            startIcon={<ButtonIcon />}
+            onClick={() => onClick({ profession, buffs, lines, selected, skills, weapons })}
+          >
+            {label}
+          </Button>
+        ))}
+      </ButtonGroup>
     </>
   );
 }

--- a/src/components/sections/results/BuildShareModal/SkillSelect.jsx
+++ b/src/components/sections/results/BuildShareModal/SkillSelect.jsx
@@ -1,0 +1,56 @@
+import { Skill } from '@discretize/gw2-ui-new';
+import { NoSelection } from '@discretize/react-discretize-components';
+import { MenuItem, Select } from '@mui/material';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { makeStyles } from 'tss-react/mui';
+import { changeSkill } from '../../../../state/slices/buildPage';
+
+const useStyles = makeStyles()((theme) => ({
+  skillSelect: {
+    width: 60,
+    height: 60,
+    marginRight: theme.spacing(0.5),
+  },
+}));
+
+export default function SkillSelect({ name, value, skillList }) {
+  const dispatch = useDispatch();
+  const { classes } = useStyles();
+
+  const handleChangeSkill = (e) => {
+    dispatch(changeSkill({ key: e.target.name, value: e.target.value }));
+  };
+
+  return (
+    <Select
+      variant="standard"
+      value={value}
+      name={name}
+      onChange={handleChangeSkill}
+      className={classes.skillSelect}
+      renderValue={(skill) =>
+        skill === '' ? (
+          <div style={{ fontSize: 60, lineHeight: 0 }}>
+            <NoSelection />
+          </div>
+        ) : (
+          <Skill id={skill} disableText style={{ fontSize: 60, lineHeight: 0 }} />
+        )
+      }
+      displayEmpty
+    >
+      {skillList.map((skill) => (
+        <MenuItem value={skill.id} key={skill.id}>
+          <Skill
+            id={skill.id}
+            disableLink
+            disableText
+            style={{ marginRight: 4, fontSize: '1.2rem' }}
+          />
+          <Skill id={skill.id} disableLink disableTooltip disableIcon />
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}

--- a/src/components/sections/results/BuildShareModal/generateLink.js
+++ b/src/components/sections/results/BuildShareModal/generateLink.js
@@ -1,0 +1,55 @@
+import { compress } from '@discretize/object-compression';
+import { changeCharacter } from '../../../../state/slices/buildPage';
+import { BuildPageSchema } from '../../../url-state/schema/BuildPageSchema_v2';
+import { buffsDict } from '../../../url-state/schema/SchemaDicts';
+
+export default function generateLink(
+  { character, profession, buffs, lines, selected, skills, weapons },
+  onSuccess,
+  dispatch,
+) {
+  const { attributes: allAttributes, gear, settings, infusions } = character;
+  const { specialization, weaponType, extrasCombination } = settings;
+
+  // filter out unnecessary attributes
+  const attributes = {};
+  Object.keys(BuildPageSchema.character.attributes).forEach((key) => {
+    attributes[key] = allAttributes[key];
+  });
+
+  // since we cant use the compression library for object where the layout of keys is unknown, we stringify it.
+  const minimalCharacter = {
+    attributes,
+    gear,
+    infusions: JSON.stringify(infusions) || '',
+    settings: {
+      extrasCombination,
+      profession,
+      specialization,
+      weaponType,
+    },
+  };
+  dispatch(changeCharacter(minimalCharacter));
+
+  // create bit map for buffs
+  const conv = (val) => (val ? 1 : 0);
+  const buffsInteger = buffsDict.reduce(
+    // eslint-disable-next-line no-bitwise
+    (acc, curr) => (acc + conv(buffs[curr])) << 1,
+    conv(buffs[0]),
+  );
+
+  const object = {
+    character: minimalCharacter,
+    skills,
+    traits: { lines, selected },
+    weapons,
+    buffs: buffsInteger,
+  };
+
+  compress({
+    object,
+    schema: BuildPageSchema,
+    onSuccess,
+  });
+}

--- a/src/components/sections/results/ResultDetails.jsx
+++ b/src/components/sections/results/ResultDetails.jsx
@@ -1,6 +1,5 @@
 import { TextDivider } from '@discretize/react-discretize-components';
-import ShareIcon from '@mui/icons-material/Share';
-import { Grid, IconButton } from '@mui/material';
+import { Grid } from '@mui/material';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -9,7 +8,6 @@ import { getSelectedCharacter } from '../../../state/slices/controlsSlice';
 import ErrorBoundary from '../../baseComponents/ErrorBoundary';
 import AffixesStats from './AffixesStats';
 import AppliedModifiers from './AppliedModifiers';
-import BuildShareModal from './BuildShareModal/BuildShareModal';
 import Indicators from './Indicators';
 import OutputDistribution from './OutputDistribution';
 import OutputInfusions from './OutputInfusions';
@@ -50,14 +48,7 @@ const ResultDetails = ({ data }) => {
   return (
     <ErrorBoundary location="ResultDetails" resetKeys={[character]}>
       <TextDivider text="Result Character" />
-      Click to generate a shareable link for this build
-      <BuildShareModal title="Build Share Settings" character={character}>
-        {(handleOpen) => (
-          <IconButton onClick={() => handleOpen()} style={{ display: 'inline-block' }}>
-            <ShareIcon />
-          </IconButton>
-        )}
-      </BuildShareModal>
+
       <ResultCharacter data={data} character={character} assumedBuffs={assumedBuffs} />
       <Grid container spacing={2}>
         <Grid item xs={12} sm={6} md={4}>

--- a/src/components/sections/results/TemplateHelperSections.jsx
+++ b/src/components/sections/results/TemplateHelperSections.jsx
@@ -1,5 +1,5 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ShareIcon from '@mui/icons-material/Share';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { Accordion, AccordionDetails, AccordionSummary, Grid, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'gatsby-plugin-react-i18next';
 import React from 'react';
@@ -105,7 +105,7 @@ const TemplateHelperSections = ({ character }) => {
                 content={
                   <ModalContent
                     character={character}
-                    buttons={[{ label: 'Copy Build to clipboard', onClick, icon: ShareIcon }]}
+                    buttons={[{ label: 'Copy Build to clipboard', onClick, icon: ContentCopyIcon }]}
                   />
                 }
               />

--- a/src/components/sections/results/TemplateHelperSections.jsx
+++ b/src/components/sections/results/TemplateHelperSections.jsx
@@ -1,4 +1,5 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ShareIcon from '@mui/icons-material/Share';
 import { Accordion, AccordionDetails, AccordionSummary, Grid, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'gatsby-plugin-react-i18next';
 import React from 'react';
@@ -104,8 +105,7 @@ const TemplateHelperSections = ({ character }) => {
                 content={
                   <ModalContent
                     character={character}
-                    onClick={onClick}
-                    label="Copy Build to clipboard"
+                    buttons={[{ label: 'Copy Build to clipboard', onClick, icon: ShareIcon }]}
                   />
                 }
               />

--- a/src/components/sections/results/table/ResultTable.jsx
+++ b/src/components/sections/results/table/ResultTable.jsx
@@ -175,7 +175,7 @@ const StickyHeadTable = () => {
       {saved.length ? (
         <>
           <TextDivider text={t('Saved Results')} />
-          <Box boxShadow={8}>
+          <Box boxShadow={8} mb={3}>
             <TableContainer className={classes.container}>
               <Table
                 stickyHeader

--- a/src/components/sections/sharing/SharingSection.jsx
+++ b/src/components/sections/sharing/SharingSection.jsx
@@ -12,6 +12,8 @@ const SharingSection = () => {
   const { t } = useTranslation();
   const character = useSelector(getSelectedCharacter);
 
+  if (!character) return null;
+
   return (
     <Section
       title={t('Share Builds')}

--- a/src/components/sections/sharing/SharingSection.jsx
+++ b/src/components/sections/sharing/SharingSection.jsx
@@ -1,0 +1,48 @@
+import ShareIcon from '@mui/icons-material/Share';
+import { IconButton, Typography } from '@mui/material';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { getSelectedCharacter } from '../../../state/slices/controlsSlice';
+import Section from '../../baseComponents/Section';
+import URLStateExport from '../../url-state/URLStateExport';
+import BuildShareModal from '../results/BuildShareModal/BuildShareModal';
+
+const SharingSection = () => {
+  const { t } = useTranslation();
+  const character = useSelector(getSelectedCharacter);
+
+  return (
+    <Section
+      title={t('Share Builds')}
+      helpText={t('Generate shareable links here!')}
+      content={
+        <>
+          <URLStateExport />{' '}
+          <Typography variant="body1" component="span">
+            Share settings.
+          </Typography>{' '}
+          <Typography variant="caption">
+            Includes the current selected options on this page only. Does not include result builds
+            in the table above
+          </Typography>
+          <br />
+          <BuildShareModal title="Build Share Settings" character={character}>
+            {(handleOpen) => (
+              <IconButton onClick={() => handleOpen()} size="large">
+                <ShareIcon />
+              </IconButton>
+            )}
+          </BuildShareModal>{' '}
+          <Typography variant="body1" component="span">
+            Share Character.{' '}
+          </Typography>
+          <Typography variant="caption"> Select weapons and skills as you please.</Typography>
+        </>
+      }
+      extraInfo={<></>}
+    />
+  );
+};
+
+export default SharingSection;


### PR DESCRIPTION
this pr shall rework the share logic. Multiple actions are being taken: 
- move all share buttons to a centralized section below the result table 
- provide clear instructions on how to use it
- add an option to copy builds instead of opening in new tab 
- extract the link generation logic 

TODO:

- [x] hide the share section when no character selected
- [x] add a visual indicator for a successful button action in the ModalContent