### PR TITLE
Feat: Include result list in share link (old code)

### DIFF
--- a/src/components/sections/results/ResultTable.jsx
+++ b/src/components/sections/results/ResultTable.jsx
@@ -22,9 +22,6 @@ const useStyles = makeStyles((theme) => ({
     borderColor: theme.palette.background.paper,
     border: '1px solid',
   },
-  pointer: {
-    cursor: 'pointer',
-  },
   tablehead: {
     backgroundColor: theme.palette.background.paper,
   },
@@ -88,7 +85,7 @@ const StickyHeadTable = () => {
                 rankBy={rankBy}
               />
             </TableHead>
-            <TableBody className={classes.pointer}>
+            <TableBody>
               {/* {saved.length
               ? saved.map((character, i) => {
                   return (

--- a/src/components/sections/results/ResultTableRow.jsx
+++ b/src/components/sections/results/ResultTableRow.jsx
@@ -34,6 +34,9 @@ const ResultTableRow = ({
   const dispatch = useDispatch();
   const classes = useStyles();
 
+  // disable selection if this is true (character data has been removed due to URL export limitations)
+  const { disableSelection } = character;
+
   const { value } = character.results;
   const comparisonValue = selectedValue ? value - selectedValue : 0;
 
@@ -46,21 +49,30 @@ const ResultTableRow = ({
       }`
     : '';
 
+  const style = {
+    ...(selected ? { backgroundColor: 'rgba(0, 204, 204, 0.2)' } : null),
+    ...(!disableSelection ? { cursor: 'pointer' } : { opacity: 0.7 }),
+  };
+
   return (
     <TableRow
       selected={selected}
-      style={selected ? { backgroundColor: 'rgba(0, 204, 204, 0.2)' } : null}
-      onClick={(e) => dispatch(changeSelectedCharacter(character))}
+      style={style}
+      onClick={disableSelection ? null : (e) => dispatch(changeSelectedCharacter(character))}
       hover
       className={underlineClass}
     >
       <TableCell scope="row" align="center" padding="none">
         <StarRoundedIcon
           className={saved ? classes.selectedStar : classes.unselectedStar}
-          onClick={(e) => {
-            dispatch(toggleSaved(character));
-            e.stopPropagation();
-          }}
+          onClick={
+            disableSelection
+              ? null
+              : (e) => {
+                  dispatch(toggleSaved(character));
+                  e.stopPropagation();
+                }
+          }
         />
       </TableCell>
       <TableCell scope="row">


### PR DESCRIPTION
This is some old code that I was working on to include the results list in the share link, by making way for "character" objects to not contain a full set of information, just enough to render a non-selectable table row.

Not a huge deal, but one problem with including table data in a serialized format was that multiple references to the same object stringify as different objects. Thus, even though the original variables are `===` equal, the new ones are not.

```js
let exportedData;
{
  const list = [{ some: 'information' }, { other: 'information' }];
  const selected = list[0];
  console.log(selected === list[0]); // true

  exportedData = JSON.stringify({ list, selected });
}
{
  const { list, selected } = JSON.parse(exportedData);
  console.log(selected === list[0]); // false
}
```
This breaks the currently selected character being highlighted in the result table/saved results, and breaks the connection between saved result entries and table entries, unless you do some processing on import to deduplicate the objects.

Anyway, this would need some changes now since table rows also display extras selections, which aren't included in this code. Also, you know, merge conflicts and etc.

PRing this so I don't lose it.