### PR TITLE
Feat: Lifesteal food

### DIFF
--- a/src/assets/modifierdata/food.yaml
+++ b/src/assets/modifierdata/food.yaml
@@ -1,16 +1,34 @@
 - section: Power Food
   items:
 
+    - id: cilantro-lime-sous-vide-steak
+      text: Cilantro Lime Sous-Vide Steak
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Power: [100, converted]
+          Ferocity: [70, converted]
+      gw2id: 91805
+
     - id: sweet-and-spicy-butternut-squash-soup
-      text: Bowl of Sweet and Spicy Butternut Squash Soup / Sous-Vide Steak
+      text: Bowl of Sweet and Spicy Butternut Squash Soup
       modifiers:
         attributes:
           Power: [100, converted]
           Ferocity: [70, converted]
       gw2id: 41569
 
+    - id: plate-of-coq-au-vin-with-salsa
+      text: Plate of Coq Au Vin with Salsa
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Power: [100, converted]
+          Precision: [70, converted]
+      gw2id: 91709
+
     - id: truffle-steak
-      text: Plate of Truffle Steak / Coq Au Vin
+      text: Plate of Truffle Steak
       modifiers:
         attributes:
           Power: [100, converted]
@@ -83,16 +101,50 @@
           Concentration: [100, converted]
       gw2id: 68633
 
+    - id: slice-of-candied-dragon-roll
+      text: Slice of Candied Dragon Roll
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Precision: [70, converted]
+      gw2id: 43362
+
+    - id: slice-of-allspice-cake
+      text: Slice of Allspice Cake
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Power: [70, converted]
+      gw2id: 75126
+
 - section: Support Food
   items:
 
+    - id: plate-of-beef-carpaccio-with-salsa-garnish
+      text: Plate of Beef Carpaccio with Salsa Garnish
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Concentration: [100, converted]
+          Power: [70, converted]
+      gw2id: 91862
+
     - id: soul-pastry
-      text: Soul Pastry / Beef Carpaccio
+      text: Soul Pastry
       modifiers:
         attributes:
           Concentration: [100, converted]
           Power: [70, converted]
       gw2id: 89002
+
+    - id: salsa-eggs-benedict
+      text: Salsa Eggs Benedict
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Concentration: [100, converted]
+          Expertise: [70, converted]
+      gw2id: 91847
 
     - id: eggs-benedict
       text: Plate of Eggs Benedict
@@ -159,16 +211,34 @@
 - section: Condition Food
   items:
 
+    - id: salsa-topped-veggie-flatbread
+      text: Salsa-Topped Veggie Flatbread
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Expertise: [100, converted]
+          Condition Damage: [70, converted]
+      gw2id: 91876
+
     - id: rare-veggie-pizza
-      text: Rare Veggie Pizza / Veggie flatbread
+      text: Rare Veggie Pizza
       modifiers:
         attributes:
           Expertise: [100, converted]
           Condition Damage: [70, converted]
       gw2id: 12464
 
+    - id: cilantro-and-cured-meat-flatbread
+      text: Cilantro and Cured Meat Flatbread
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Condition Damage: [100, converted]
+          Expertise: [70, converted]
+      gw2id: 91878
+
     - id: beef-rendang
-      text: Plate of Beef Rendang / Cured Meat flatbread
+      text: Plate of Beef Rendang
       modifiers:
         attributes:
           Condition Damage: [100, converted]
@@ -283,13 +353,38 @@
 
     - id: prickly-pear-pie
       text: Prickly Pear Pie
+      hasLifesteal: true
       modifiers:
         attributes:
           Expertise: [100, converted]
       gw2id: 66538
 
+    - id: slice-of-allspice-cake-with-ice-cream
+      text: Slice of Allspice Cake with Ice Cream
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Condition Damage: [70, converted]
+      gw2id: 76359
+
 - section: Hybrid Food
   items:
+
+    - id: spherified-cilantro-oyster-soup
+      text: Spherified Cilantro Oyster Soup
+      hasLifesteal: true
+      modifiers:
+        attributes:
+          Power: [45, converted]
+          Precision: [45, converted]
+          Toughness: [45, converted]
+          Vitality: [45, converted]
+          Concentration: [45, converted]
+          Condition Damage: [45, converted]
+          Expertise: [45, converted]
+          Ferocity: [45, converted]
+          Healing Power: [45, converted]
+      gw2id: 91804
 
     - id: dragon's-revelry-starcake
       text: Oyster Soup

--- a/src/assets/modifierdata/metadata.js
+++ b/src/assets/modifierdata/metadata.js
@@ -56,6 +56,7 @@ const coefficients = [
   'Power Coefficient',
   ...damagingConditions.map((condition) => `${condition} Coefficient`),
   'Flat DPS',
+  'Siphon Base Coefficient',
 ];
 
 export const allDamageKeys = [

--- a/src/assets/modifierdata/testModifiers.js
+++ b/src/assets/modifierdata/testModifiers.js
@@ -116,6 +116,8 @@ const testModifiers = async () => {
           minor,
           amountData,
           defaultEnabled,
+          // eslint-disable-next-line no-unused-vars
+          hasLifesteal,
           ...otherKeys
         } = item;
 

--- a/src/assets/presetdata/preset-extras.yaml
+++ b/src/assets/presetdata/preset-extras.yaml
@@ -18,7 +18,7 @@ list:
             "slaying-potion": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -40,7 +40,7 @@ list:
             "superior-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -83,7 +83,7 @@ list:
             "toxic-maintenance-oil": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -104,7 +104,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -126,7 +126,7 @@ list:
             "perplexity": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           },
           "Enhancement": {
             "toxic-focusing-crystal": {}
@@ -151,7 +151,7 @@ list:
             "perplexity": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           },
           "Enhancement": {
             "toxic-focusing-crystal": {}
@@ -204,7 +204,7 @@ list:
             "superior-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -227,7 +227,7 @@ list:
             "slaying-potion": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -250,7 +250,7 @@ list:
             "slaying-potion": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -273,7 +273,7 @@ list:
             "furious-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -296,7 +296,7 @@ list:
             "furious-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -343,7 +343,7 @@ list:
             "toxic-maintenance-oil": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -389,7 +389,7 @@ list:
             "toxic-focusing-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -412,7 +412,7 @@ list:
             "toxic-focusing-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -480,7 +480,7 @@ list:
   #           "toxic-maintenance-oil": {}
   #       },
   #       "Nourishment": {
-  #           "dragon's-revelry-starcake": {}
+  #           "spherified-cilantro-oyster-soup": {}
   #       }
   #     }
 
@@ -502,7 +502,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -521,7 +521,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           }
         }
       }
@@ -544,7 +544,7 @@ list:
             "superior-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -567,7 +567,7 @@ list:
             "superior-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -587,7 +587,7 @@ list:
             "scholar": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           },
           "Enhancement": {
             "superior-sharpening-stone": {}
@@ -613,7 +613,7 @@ list:
             "superior-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -632,7 +632,7 @@ list:
             "toxic-focusing-crystal": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           }
         }
       }
@@ -652,7 +652,7 @@ list:
             "elementalist": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           },
           "Enhancement": {
             "toxic-focusing-crystal": {}
@@ -678,7 +678,7 @@ list:
             "toxic-focusing-crystal": {}
           },
           "Nourishment": {
-            "dragon's-revelry-starcake": {}
+            "spherified-cilantro-oyster-soup": {}
           }
         }
       }
@@ -701,7 +701,7 @@ list:
             "toxic-focusing-crystal": {}
           },
           "Nourishment": {
-            "dragon's-revelry-starcake": {}
+            "spherified-cilantro-oyster-soup": {}
           }
         }
       }
@@ -724,7 +724,7 @@ list:
             "toxic-focusing-crystal": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           }
         }
       }
@@ -747,7 +747,7 @@ list:
             "superior-sharpening-stone": {}
           },
           "Nourishment": {
-            "truffle-steak": {}
+            "plate-of-coq-au-vin-with-salsa": {}
           }
         }
       }
@@ -768,7 +768,7 @@ list:
             "toxic-focusing-crystal": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           }
         }
       }
@@ -791,7 +791,7 @@ list:
             "superior-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -811,7 +811,7 @@ list:
             "krait": {}
           },
           "Nourishment": {
-            "beef-rendang": {},
+            "cilantro-and-cured-meat-flatbread": {},
             "bowl-of-kimchi-tofu-stew": {}
           },
           "Enhancement": {
@@ -833,7 +833,7 @@ list:
             "krait": {}
           },
           "Nourishment": {
-            "beef-rendang": {},
+            "cilantro-and-cured-meat-flatbread": {},
             "plate-of-kimchi-pancakes": {}
           },
           "Enhancement": {
@@ -857,7 +857,7 @@ list:
             "krait": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           },
           "Enhancement": {
             "toxic-focusing-crystal": {}
@@ -881,7 +881,7 @@ list:
             "toxic-maintenance-oil": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           }
         }
       }
@@ -904,7 +904,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -921,9 +921,9 @@ list:
           },
           "Nourishment": {
             "meaty-asparagus-skewer": {},
-            "eggs-benedict": {},
-            "dragon's-revelry-starcake": {},
-            "beef-rendang": {}
+            "salsa-eggs-benedict": {},
+            "spherified-cilantro-oyster-soup": {},
+            "cilantro-and-cured-meat-flatbread": {}
           },
           "Enhancement": {
             "toxic-maintenance-oil": {}
@@ -942,7 +942,7 @@ list:
             "nightmare": {}
           },
           "Nourishment": {
-            "beef-rendang": {},
+            "cilantro-and-cured-meat-flatbread": {},
             "meaty-asparagus-skewer": {}
           },
           "Enhancement": {
@@ -965,7 +965,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           }
         }
       }
@@ -986,7 +986,7 @@ list:
             "superior-sharpening-stone": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -1009,7 +1009,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -1032,7 +1032,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -1053,7 +1053,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -1074,7 +1074,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -1093,7 +1093,7 @@ list:
             "toxic-focusing-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -1132,7 +1132,7 @@ list:
             "tormenting": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           },
           "Enhancement": {
             "master-tuning-crystal": {}
@@ -1156,7 +1156,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           }
         }
       }
@@ -1177,7 +1177,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "beef-rendang": {}
+            "cilantro-and-cured-meat-flatbread": {}
           }
         }
       }
@@ -1200,7 +1200,7 @@ list:
             "potent-lucent-oil": {}
           },
           "Nourishment": {
-            "sweet-and-spicy-butternut-squash-soup": {}
+            "cilantro-lime-sous-vide-steak": {}
           }
         }
       }
@@ -1221,7 +1221,7 @@ list:
             "krait-no-elite": {}
           },
           "Nourishment": {
-            "beef-rendang": {},
+            "cilantro-and-cured-meat-flatbread": {},
             "plate-of-kimchi-pancakes": {},
             "bowl-of-kimchi-tofu-stew": {}
           },
@@ -1250,7 +1250,7 @@ list:
             "master-tuning-crystal": {}
           },
           "Nourishment": {
-            "rare-veggie-pizza": {}
+            "salsa-topped-veggie-flatbread": {}
           }
         }
       }
@@ -1298,7 +1298,7 @@ list:
             "renegade": {}
           },
           "Nourishment": {
-            "eggs-benedict": {},
+            "salsa-eggs-benedict": {},
             "meaty-asparagus-skewer": {}
           },
           "Enhancement": {

--- a/src/components/url-state/schema/SchemaDicts.js
+++ b/src/components/url-state/schema/SchemaDicts.js
@@ -264,6 +264,16 @@ export const nourishmentDict = [
   'meaty-rice-bowl',
   'block-of-tofu',
   'dragons-revelry-starcake-bugged',
+  'cilantro-lime-sous-vide-steak',
+  'plate-of-coq-au-vin-with-salsa',
+  'plate-of-beef-carpaccio-with-salsa-garnish',
+  'salsa-eggs-benedict',
+  'salsa-topped-veggie-flatbread',
+  'cilantro-and-cured-meat-flatbread',
+  'spherified-cilantro-oyster-soup',
+  'slice-of-candied-dragon-roll',
+  'slice-of-allspice-cake',
+  'slice-of-allspice-cake-with-ice-cream',
 ];
 
 export const buffsDict = [

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -589,10 +589,15 @@ export class OptimizerCore {
       attributes['Power'] * (1 + critChance * (critDmg - 1)) * damageMultiplier['Strike Damage'];
 
     // 2597: standard enemy armor value, also used for ingame damage tooltips
-    const damage = ((attributes['Power Coefficient'] || 0) / 2597) * attributes['Effective Power'];
-    attributes['Power DPS'] = damage;
+    const powerDamage =
+      ((attributes['Power Coefficient'] || 0) / 2597) * attributes['Effective Power'];
+    attributes['Power DPS'] = powerDamage;
 
-    return damage;
+    const siphonDamage =
+      (character.attributes['Siphon Base Coefficient'] || 0) * damageMultiplier['Siphon Damage'];
+    attributes['Siphon DPS'] = powerDamage;
+
+    return powerDamage + siphonDamage;
   }
 
   conditionDamageTick = (condition, cdmg, mult) =>
@@ -884,7 +889,7 @@ export function inputToSettings(input) {
   const initialMultipliers = {
     'Strike Damage': 1,
     'Condition Damage': 1,
-    'Lifesteal Damage': 1,
+    'Siphon Damage': 1,
     'Damage Taken': 1,
     'Critical Damage': 1,
     'Bleeding Damage': 1,
@@ -976,7 +981,7 @@ export function inputToSettings(input) {
           case 'All Damage':
             dmgBuff('Strike Damage', scaledAmount, addOrMult);
             dmgBuff('Condition Damage', scaledAmount, addOrMult);
-            dmgBuff('Lifesteal Damage', scaledAmount, addOrMult);
+            dmgBuff('Siphon Damage', scaledAmount, addOrMult);
             break;
           case 'Damage Reduction':
             const negativeAmount = -scaledAmount;

--- a/src/state/optimizer/optimizerCore.js
+++ b/src/state/optimizer/optimizerCore.js
@@ -6,6 +6,7 @@
 
 import {
   allAttributeCoefficientKeys,
+  allAttributePercentKeys,
   allAttributePointKeys,
   allConversionAfterBuffsSourceKeys,
 } from '../../assets/modifierdata/metadata';
@@ -1025,7 +1026,7 @@ export function inputToSettings(input) {
         const scaledAmount = scaleValue(value, amountInput, amountData);
         settings.baseAttributes[attribute] =
           (settings.baseAttributes[attribute] || 0) + scaledAmount;
-      } else {
+      } else if (allAttributePercentKeys.includes(attribute)) {
         // percent, i.e.
         //   Torment Duration: 15%
 
@@ -1040,6 +1041,8 @@ export function inputToSettings(input) {
           settings.baseAttributes[attribute] =
             (settings.baseAttributes[attribute] || 0) + scaledAmount;
         }
+      } else {
+        alert(`invalid attribute ${attribute}`);
       }
     }
 


### PR DESCRIPTION
Fully support all-damage modifiers like those on renegade buffing the lifesteal effect.

I may actually wind up doing this differently, as some of the possibilities for dual sigils involve having a more integrated way to have separate effects in one extra selection. Works for now, though.

The default 4.3 proc/10sec frequency (2.33s interval) for these is fairly arbitrary, but it's what I used for earth sigil and it's reasonably within the range of a couple benchmarks done with lifesteal food, idk.