### PR TITLE
Fix: Language fallback

### DIFF
--- a/src/pages/build/index.jsx
+++ b/src/pages/build/index.jsx
@@ -27,8 +27,8 @@ const IndexPage = ({ data }) => {
   );
 };
 export const query = graphql`
-  query ($language: String!) {
-    locales: allLocale(filter: { language: { eq: $language } }) {
+  query {
+    locales: allLocale {
       edges {
         node {
           ns

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -58,8 +58,8 @@ const IndexPage = () => {
   );
 };
 export const query = graphql`
-  query ($language: String!) {
-    locales: allLocale(filter: { language: { eq: $language } }) {
+  query {
+    locales: allLocale {
       edges {
         node {
           ns


### PR DESCRIPTION
This should let the non-english localization fall back to the english strings as desired.

Not sure if there is any drawback to this?