### PR TITLE
Feat: Disable URL shortener in preview

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -19,6 +19,7 @@
   "Click the star icon to save a result for comparison.": "Click the star icon to save a result for comparison.",
   "Compare by percentage": "Compare by percentage",
   "Copied link to clipboard!": "Copied link to clipboard!",
+  "Copied link to clipboard! (Link shortener disabled in preview builds.)": "Copied link to clipboard! (Link shortener disabled in preview builds.)",
   "Copy build": "Copy build",
   "Copy from selected character": "Copy from selected character",
   "Copy sharable link to clipboard (note: results are not currently included)": "Copy sharable link to clipboard (note: results are not currently included)",

--- a/src/components/url-state/URLStateExport.jsx
+++ b/src/components/url-state/URLStateExport.jsx
@@ -47,6 +47,19 @@ const URLStateExport = ({ type }) => {
       }
       console.log(`Exported long URL (${longUrl.length} characters):`, longUrl);
 
+      // skip link shortener if build in staging/preview/local development
+      // (prevents sharing short links that redirect to an invalid location)
+      if (!longUrl.includes('optimizer.discretize.eu')) {
+        setSnackbarState((state) => ({
+          ...state,
+          open: true,
+          success: true,
+          message: t('Copied link to clipboard! (Link shortener disabled in preview builds.)'),
+        }));
+        navigator.clipboard.writeText(longUrl);
+        return;
+      }
+
       // get request to create a new short-url
       // this url points to a cloudflare worker, which acts as a url shortener
       // Source for the shortener: https://gist.github.com/gw2princeps/dc88d11e6b2378db35bcb2dd3726c7c6


### PR DESCRIPTION
This skips using the link shortener in staging/preview/local development builds, to prevent people sharing short links that redirect to an invalid location.