### PR TITLE
Demo: Enable profiling in production

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -15,4 +15,10 @@ export default defineConfig({
     },
   },
   plugins: [react(), yamlImporter()],
+  resolve: {
+    alias: {
+      'react-dom': 'react-dom/profiling',
+      'scheduler/tracing': 'scheduler/tracing-profiling',
+    },
+  },
 });


### PR DESCRIPTION
To do: figure out how to load vite config entries conditionally based on a flag and use this to recreate the `yarn profile` script.