### PR TITLE
Chore: create cleanupLocale script

### DIFF
--- a/cleanupLocale.js
+++ b/cleanupLocale.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+// removes underscores and any text preceding them from translation values
+const regex = /.*_/;
+const path = 'locales/en/translation.json';
+
+const fileData = fs.readFileSync(path);
+const data = JSON.parse(fileData.toString());
+const fixedEntries = Object.entries(data).map(([key, value]) => [key, value.replace(regex, '')]);
+const fixedData = Object.fromEntries(fixedEntries);
+fs.writeFileSync(path, `${JSON.stringify(fixedData, null, 2)}\n`);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "testModifiers": "ts-node --esm --transpileOnly ./src/assets/modifierdata/testModifiers.ts",
     "testPresets": "ts-node --esm --transpileOnly ./src/assets/presetdata/testPresets.ts",
     "extractLocale": "babel --config-file ./babel-extract.config.js 'src/**/*.{js,jsx,ts,tsx}' > /dev/null",
-    "extractLocaleCMD": "babel --config-file ./babel-extract.config.js \"src/**/*.{js,jsx,ts,tsx}\" > NUL"
+    "extractLocaleCMD": "babel --config-file ./babel-extract.config.js \"src/**/*.{js,jsx,ts,tsx}\" > NUL",
+    "cleanupLocale": "node cleanupLocale.js"
   },
   "resolutions": {
     "@discretize/gw2-ui-new": "^0.0.13"


### PR DESCRIPTION
This creates a script that strips the beginning of the e.g. `affix_whatever` autogenerated values in the en locale file.

It's vanilla CJS because apparently using esm or typescript to write and run a (generously) 8 line script in 2022 without 45 characters of boilerplate is still fucking impossible.

~~PR since the package.json merge conflict will be easier to fix this way if we merge 437 - will wait for a decision on that.~~ actually whatever I can just merge