### PR TITLE
Experiment: make mode icon a button

### DIFF
--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -29,7 +29,7 @@ import {
   getSelectedTemplate,
   setBuildTemplate,
 } from '../../state/slices/controlsSlice';
-import { getExpertMode, getGameMode } from '../../state/slices/userSettings';
+import { getExpertMode, getGameMode, toggleGameMode } from '../../state/slices/userSettings';
 import data from '../../utils/data';
 import { PROFESSIONS } from '../../utils/gw2-data';
 import NavAccordion from './NavAccordion';
@@ -80,11 +80,13 @@ const Navbar = () => {
     return (
       <Box display="flex" alignItems="center" gap={1}>
         <Tooltip content={`${t('Selected Game Mode')}: ${isFractals ? t('Fractals') : t('Raids')}`}>
-          <img
-            style={{ width: '40px' }}
-            src={isFractals ? fractalImg : raidImg}
-            alt={isFractals ? t('Fractal') : t('Raid')}
-          />
+          <IconButton size="medium" onClick={() => alert('this needs to be in NavSettings rip')}>
+            <img
+              style={{ width: '40px' }}
+              src={isFractals ? fractalImg : raidImg}
+              alt={isFractals ? t('Fractal') : t('Raid')}
+            />
+          </IconButton>
         </Tooltip>
 
         <IconButton

--- a/src/state/slices/userSettings.js
+++ b/src/state/slices/userSettings.js
@@ -40,13 +40,20 @@ export const userSettingsSlice = createSlice({
     changeGameMode: (state, action) => {
       state.gameMode = action.payload;
     },
+    toggleGameMode: (state) => {
+      if (state.gameMode === 'fractals') {
+        state.gameMode = 'raids';
+      } else {
+        state.gameMode = 'fractals';
+      }
+    },
   },
 });
 
 export const getExpertMode = (state) => state.optimizer.userSettings.expertMode;
 export const getGameMode = (state) => state.optimizer.userSettings.gameMode;
 
-export const { changeAllUserSettings, changeExpertMode, changeGameMode } =
+export const { changeAllUserSettings, changeExpertMode, changeGameMode, toggleGameMode } =
   userSettingsSlice.actions;
 
 export default userSettingsSlice.reducer;


### PR DESCRIPTION
I figured it might be kinda cute if the raid/fractal mode icon toggled the mode when clicked, but the code to do that is inside NavSettings and I can't be bothered to look into whether there's an elegant way to extract it or not (possibly not, actually - dialog boxes in react are weird).