### PR TITLE
Chore: Implement [no previews] PR body command

### DIFF
--- a/.github/workflows/previews-cf.yml
+++ b/.github/workflows/previews-cf.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       !contains(github.event.head_commit.message, 'skip ci') &&
-      !contains(github.event.head_commit.message, 'skip preview') &&
+      !contains(github.event.pull_request.body, '[no previews]') &&
       github.event.pull_request.draft == false
     timeout-minutes: 10
 


### PR DESCRIPTION
This allows you to write the command described in the description of a PR to disable cloudflare preview creation for any pushes to it.

~~Here is a test:~~

I have now removed the test.