### PR TITLE
Fix: responsive breakpoint performance/simplicity

### DIFF
--- a/src/components/baseComponents/BackgroundImage.jsx
+++ b/src/components/baseComponents/BackgroundImage.jsx
@@ -1,8 +1,14 @@
+import { useMediaQuery, useTheme } from '@mui/material';
 import React from 'react';
 import fractalImg from '../../assets/images/background/fractals.jpg';
 import raidImg from '../../assets/images/background/raids.jpg';
 
 export default function BackgroundImage({ gameMode }) {
+  const theme = useTheme();
+  const showImage = useMediaQuery(theme.breakpoints.up('lg'));
+  // only show the image for larger screens
+  if (!showImage) return null;
+
   return (
     <img
       src={gameMode === 'fractals' ? fractalImg : raidImg}

--- a/src/components/baseComponents/BackgroundImage.jsx
+++ b/src/components/baseComponents/BackgroundImage.jsx
@@ -1,14 +1,8 @@
-import { useMediaQuery, useTheme } from '@mui/material';
 import React from 'react';
 import fractalImg from '../../assets/images/background/fractals.jpg';
 import raidImg from '../../assets/images/background/raids.jpg';
 
 export default function BackgroundImage({ gameMode }) {
-  const theme = useTheme();
-  const showImage = useMediaQuery(theme.breakpoints.up('lg'));
-  // only show the image for larger screens
-  if (!showImage) return null;
-
   return (
     <img
       src={gameMode === 'fractals' ? fractalImg : raidImg}

--- a/src/components/baseComponents/Layout.jsx
+++ b/src/components/baseComponents/Layout.jsx
@@ -1,0 +1,26 @@
+import { Box, Container, useMediaQuery, useTheme } from '@mui/material';
+import React from 'react';
+
+const Layout = ({ children, ContainerProps, disableContainer = false }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
+  return (
+    <>
+      {(!disableContainer && !isMobile && (
+        <Container maxWidth="lg" {...ContainerProps}>
+          <Box
+            sx={{
+              padding: 2,
+              backgroundColor: 'background.default',
+              boxShadow: 5,
+            }}
+          >
+            {children}
+          </Box>
+        </Container>
+      )) || <Box p={2}>{children}</Box>}
+    </>
+  );
+};
+
+export default Layout;

--- a/src/components/baseComponents/Layout.jsx
+++ b/src/components/baseComponents/Layout.jsx
@@ -1,13 +1,11 @@
-import { Box, Container, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Container } from '@mui/material';
 import React from 'react';
 
 const Layout = ({ children, ContainerProps, disableContainer = false }) => {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
   return (
     <>
-      {(!disableContainer && !isMobile && (
-        <Container maxWidth="lg" {...ContainerProps}>
+      {(!disableContainer && (
+        <Container disableGutters maxWidth="lg" {...ContainerProps}>
           <Box
             sx={{
               padding: 2,

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -5,16 +5,16 @@ import {
   AppBar,
   Box,
   Button,
-  debounce,
   IconButton,
   MenuItem,
   SwipeableDrawer,
   Toolbar,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
 import { bindHover, bindMenu, usePopupState } from 'material-ui-popup-state/es/hooks';
 import Menu from 'material-ui-popup-state/es/HoverMenu';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
@@ -57,8 +57,9 @@ const Navbar = () => {
   const isFractals = gamemode === 'fractals';
   const selectedGameModeText = isFractals ? t('Fractals') : t('Raids');
 
+  const mobileView = !useMediaQuery('(min-width:900px)');
+
   const [state, setState] = useState({
-    mobileView: typeof window !== 'undefined' ? window.innerWidth < 900 : false,
     drawerOpen: false,
     hover: [false, false, false, false, false, false, false, false, false],
     anchor: null,
@@ -66,23 +67,7 @@ const Navbar = () => {
   // state for the reapply dialog
   const [open, setOpen] = React.useState(false);
 
-  const { mobileView, drawerOpen } = state;
-
-  useEffect(() => {
-    const setResponsiveness = () => {
-      const mobileViewCurrent = window.innerWidth < 900;
-      if (mobileViewCurrent !== mobileView) {
-        setState((prevState) => ({ ...prevState, mobileView: mobileViewCurrent }));
-      }
-    };
-    const debouncedResponsive = debounce(setResponsiveness, 300);
-
-    window.addEventListener('resize', debouncedResponsive);
-
-    return () => {
-      window.removeEventListener('resize', debouncedResponsive);
-    };
-  }, [mobileView]);
+  const { drawerOpen } = state;
 
   const handleModeCycle = () => {
     const currentMode = gamemode;

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -58,6 +58,7 @@ const Navbar = () => {
   const selectedGameModeText = isFractals ? t('Fractals') : t('Raids');
 
   const mobileView = !useMediaQuery('(min-width:900px)');
+  const showSelectedTemplate = useMediaQuery('(min-width:960px)');
 
   const [state, setState] = useState({
     drawerOpen: false,
@@ -245,7 +246,7 @@ const Navbar = () => {
         ))}
       </Box>
 
-      {(selectedSpecialization || selectedTemplateName) && (
+      {showSelectedTemplate && (selectedSpecialization || selectedTemplateName) && (
         <Box flexGrow={1}>
           <Typography>
             <Trans>Selected</Trans>:{' '}

--- a/src/pages/index/index.jsx
+++ b/src/pages/index/index.jsx
@@ -1,5 +1,4 @@
 import { APILanguageProvider } from '@discretize/gw2-ui-new';
-import { Layout } from '@discretize/react-discretize-components';
 import CloseIcon from '@mui/icons-material/Close';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import { Collapse, IconButton, Link, Typography } from '@mui/material';
@@ -9,6 +8,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import BackgroundImage from '../../components/baseComponents/BackgroundImage';
 import ErrorBoundary from '../../components/baseComponents/ErrorBoundary';
+import Layout from '../../components/baseComponents/Layout';
 import GearOptimizer from '../../components/GearOptimizer';
 import URLStateImport from '../../components/url-state/URLStateImport';
 import SagaTypes from '../../state/sagas/sagaTypes';


### PR DESCRIPTION
This:
- Changes the behavior of the responsive <Layout> component to always return the same DOM structure, preventing a huge freeze when you resize the window past the 1200px boundary as the entire React tree gets rerendered. (could upstream to RDC?)
- Replaces our manual setResponsiveness implementation with an MUI useMediaQuery.