### PR TITLE
Fix Virtuoso Quiet Intensity conversion

### DIFF
--- a/src/assets/modifierdata/mesmer.yaml
+++ b/src/assets/modifierdata/mesmer.yaml
@@ -364,7 +364,7 @@
       minor: true
       modifiers:
         conversion:
-          Ferocity: {Vitality: 7%}
+          Ferocity: {Vitality: 10%}
         attributes:
           Critical Chance: 10%
       gw2id: 2193


### PR DESCRIPTION
This fixes the Vitality to Ferocity conversion ratio in the Virtuoso Quiet Intensity trait. The conversion is 10% not 7%.