### PR TITLE
Update WvW Roiling Mists

### DIFF
--- a/src/assets/modifierdata/revenant.yaml
+++ b/src/assets/modifierdata/revenant.yaml
@@ -172,6 +172,9 @@
       modifiers:
         attributes:
           Critical Chance: 25%
+      wvwModifiers:
+        attributes:
+          Critical Chance: 20%
       gw2id: 1719
       defaultEnabled: true
 


### PR DESCRIPTION
Hi, realized about the new split in Roiling Mists in a past patch now that we were trying to optimize a revenant build. 
Will probably open a new PR later if I spot any other WvW modifier that is not up to date.

Thank you!