### PR TITLE
Correctly set Alac tempest's average boon number

### DIFF
--- a/src/assets/presetdata/preset-distribution.yaml
+++ b/src/assets/presetdata/preset-distribution.yaml
@@ -426,7 +426,7 @@ list:
     profession: Tempest
     value: >-
       {
-        "values2": { "Power": 3118, "Power2": 0, "Burning": 10.84, "Bleeding": 12.23, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
+        "values2": { "Power": 3094, "Power2": 0, "Burning": 10.83, "Bleeding": 12.22, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
     credit:
       - author: 'Dánmander'

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -3346,7 +3346,7 @@ list:
               "amount": ""
             },
             "bountiful-power": {
-              "amount": ""
+              "amount": "10.6"
             }
           },
           {


### PR DESCRIPTION
Available in EI's json under statsAll -> boonAvg for the next time I start looking at the individual boon graph and counting stability sections.