### PR TITLE
June 27: Update traits and skills

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -43,7 +43,7 @@
   "Copy build": "Copy build",
   "Copy from selected character": "Copy from selected character",
   "Copy selected sigils to both slots": "Copy selected sigils to both slots",
-  "Core game changes, preset coefficients, and trait selections are not fully updated for the June 27th game patch. Most gear results will be correctly optimized, but DPS estimates and comparisons may be wrong.<br/><br/>Templates not marked as Outdated are expected to be up to date.": "Core game changes, preset coefficients, and trait selections are not fully updated for the June 27th game patch. Most gear results will be correctly optimized, but DPS estimates and comparisons may be wrong.<br/><br/>Templates not marked as Outdated are expected to be up to date.",
+  "Core game changes are updated for the June 27th game patch, but preset coefficients and trait selections may not yet be completely updated. Most gear results will be correctly optimized, but DPS estimates and comparisons may be wrong.<br/><br/>Templates not marked as Outdated are up to date.": "Core game changes are updated for the June 27th game patch, but preset coefficients and trait selections may not yet be completely updated. Most gear results will be correctly optimized, but DPS estimates and comparisons may be wrong.<br/><br/>Templates not marked as Outdated are up to date.",
   "Create build templates that can be used for the gear optimizer.": "Create build templates that can be used for the gear optimizer.",
   "Create templates for the discretize.eu website. Please check the discretize-guides repo for more information.": "Create templates for the discretize.eu website. Please check the discretize-guides repo for more information.",
   "Ctrl+d": "Ctrl+d",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -817,6 +817,8 @@
   "skillSubText_100% uptime": "100% uptime",
   "skillSubText_Total Flat Pet Damage (no modifiers)": "Total Flat Pet Damage (no modifiers)",
   "skillSubText_damage buff only": "damage buff only",
+  "skillSubText_draconic echo passive": "draconic echo passive",
+  "skillSubText_draconic echo passive, 100% uptime": "draconic echo passive, 100% uptime",
   "skillSubText_no sic em": "no sic em",
   "skillSubText_no sic em, sharpened edges": "no sic em, sharpened edges",
   "skillSubText_passive": "passive",

--- a/src/assets/modifierdata/elementalist.yaml
+++ b/src/assets/modifierdata/elementalist.yaml
@@ -499,6 +499,19 @@
       gw2id: 1839
       defaultEnabled: true
 
+    - id: tempestuous-aria
+      text: Tempestuous Aria
+      amountData:
+        label: '% uptime'
+        default: 100
+        quantityEntered: 100
+      modifiers:
+        damage:
+          Strike Damage: [10%, unknown]
+          Condition Damage: [10%, unknown]
+      gw2id: 1891
+      defaultEnabled: true
+
 - section: Weaver
   id: 56
   items:

--- a/src/assets/modifierdata/elementalist.yaml
+++ b/src/assets/modifierdata/elementalist.yaml
@@ -508,7 +508,7 @@
       modifiers:
         damage:
           Strike Damage: [10%, unknown]
-          Condition Damage: [10%, unknown]
+          Condition Damage: [10%, add] # unconfirmed
       gw2id: 1891
       defaultEnabled: true
 

--- a/src/assets/modifierdata/engineer.yaml
+++ b/src/assets/modifierdata/engineer.yaml
@@ -333,6 +333,9 @@
       text: Kinetic Accelerators
       modifiers:
         conversion:
+          Concentration: {Power: 13%}
+      wvwModifiers:
+        conversion:
           Concentration: {Power: 10%}
       gw2id: 2052
       defaultEnabled: true

--- a/src/assets/modifierdata/necromancer.yaml
+++ b/src/assets/modifierdata/necromancer.yaml
@@ -418,7 +418,10 @@
         quantityEntered: 1
       modifiers:
         damage:
-          Condition Damage: [0.5%, add] # tested by ReMagic
+          Condition Damage: [0.25%, add] # tested by ReMagic
+      wvwModifiers:
+        damage:
+          Condition Damage: [0.5%, add]
       gw2id: 2185
       defaultEnabled: true
 

--- a/src/assets/modifierdata/ranger.yaml
+++ b/src/assets/modifierdata/ranger.yaml
@@ -129,6 +129,9 @@
       subText: melee, not accurate
       modifiers:
         damage:
+          Strike Damage: [10%, mult]
+      wvwModifiers:
+        damage:
           Strike Damage: [5%, mult]
       gw2id: 1000
       defaultEnabled: true
@@ -137,6 +140,9 @@
       text: Farsighted
       subText: ranged, not accurate
       modifiers:
+        damage:
+          Strike Damage: [25%, mult]
+      wvwModifiers:
         damage:
           Strike Damage: [15%, mult]
       gw2id: 1000

--- a/src/assets/modifierdata/ranger.yaml
+++ b/src/assets/modifierdata/ranger.yaml
@@ -229,6 +229,24 @@
       gw2id: 1888
       defaultEnabled: true
 
+    - id: striders-strength
+      text: Strider's Strength
+      subText: base
+      modifiers:
+        attributes:
+          Power: [120, buff] # buff unconfirmed
+      gw2id: 1700
+      defaultEnabled: true
+
+    - id: striders-strength-sword
+      text: Strider's Strength
+      subText: with sword
+      modifiers:
+        attributes:
+          Power: [120, buff] # buff unconfirmed
+      gw2id: 1700
+      defaultEnabled: true
+
 - section: Wilderness Survival
   id: 33
   items:

--- a/src/assets/modifierdata/revenant.yaml
+++ b/src/assets/modifierdata/revenant.yaml
@@ -1,5 +1,55 @@
 - section: Skills
   items:
+    - id: facet-of-darkness-draconic-echo
+      text: Facet of Darkness
+      subText: draconic echo passive, 100% uptime
+      modifiers:
+        attributes:
+          Critical Chance: 5%
+      gw2id: 28379
+      defaultEnabled: false
+
+    - id: facet-of-elements-draconic-echo
+      text: Facet of Elements
+      subText: draconic echo passive
+      amountData:
+        label: '% uptime'
+        default: 20
+        quantityEntered: 100
+      modifiers:
+        damage:
+          Condition Damage: [5%, unknown]
+      gw2id: 27014
+
+    - id: facet-of-strength-draconic-echo
+      text: Facet of Strength
+      subText: draconic echo passive
+      amountData:
+        label: '% uptime'
+        default: 20
+        quantityEntered: 100
+      modifiers:
+        damage:
+          Strike Damage: [5%, unknown]
+      gw2id: 26644
+
+    - id: facet-of-chaos-draconic-echo
+      text: Facet of Chaos (Draconic Echo)
+      subText: draconic echo passive, 100% uptime
+      modifiers:
+        damage:
+          Damage Reduction: [5%, unknown]
+      gw2id: 27760
+      defaultEnabled: false
+
+    - id: facet-of-nature-draconic-echo
+      text: Facet of Nature (Draconic Echo)
+      subText: draconic echo passive, 100% uptime
+      modifiers:
+        attributes:
+          Concentration: [75, buff] # unconfirmed
+      gw2id: 29371
+      defaultEnabled: false
 
     - id: burst-of-strength
       text: Burst of Strength

--- a/src/assets/modifierdata/revenant.yaml
+++ b/src/assets/modifierdata/revenant.yaml
@@ -5,6 +5,9 @@
       subText: draconic echo passive, 100% uptime
       modifiers:
         attributes:
+          Critical Chance: 10%
+      wvwModifiers:
+        attributes:
           Critical Chance: 5%
       gw2id: 28379
       defaultEnabled: false
@@ -18,6 +21,9 @@
         quantityEntered: 100
       modifiers:
         damage:
+          Condition Damage: [10%, unknown]
+      wvwModifiers:
+        damage:
           Condition Damage: [5%, unknown]
       gw2id: 27014
 
@@ -30,6 +36,9 @@
         quantityEntered: 100
       modifiers:
         damage:
+          Strike Damage: [10%, unknown]
+      wvwModifiers:
+        damage:
           Strike Damage: [5%, unknown]
       gw2id: 26644
 
@@ -37,6 +46,9 @@
       text: Facet of Chaos (Draconic Echo)
       subText: draconic echo passive, 100% uptime
       modifiers:
+        damage:
+          Damage Reduction: [10%, unknown]
+      wvwModifiers:
         damage:
           Damage Reduction: [5%, unknown]
       gw2id: 27760
@@ -47,7 +59,10 @@
       subText: draconic echo passive, 100% uptime
       modifiers:
         attributes:
-          Concentration: [75, buff] # unconfirmed
+          Boon Duration: 10%
+      wvwModifiers:
+        attributes:
+          Boon Duration: 5%
       gw2id: 29371
       defaultEnabled: false
 

--- a/src/assets/modifierdata/thief.yaml
+++ b/src/assets/modifierdata/thief.yaml
@@ -207,15 +207,16 @@
   id: 54
   items:
 
-    - id: endless-stamina
-      text: Endless Stamina
+    - id: fluid-strikes
+      text: Fluid Strikes
       minor: true
+      amountData:
+        label: '% uptime'
+        default: 100
+        quantityEntered: 100
       modifiers:
-        attributes:
-          Concentration: [240, buff]
-      wvwModifiers:
-        attributes:
-          Concentration: [60, buff]
+        damage:
+          Strike Damage: [10%, unknown]
       gw2id: 1242
       defaultEnabled: true
 

--- a/src/assets/modifierdata/thief.yaml
+++ b/src/assets/modifierdata/thief.yaml
@@ -430,7 +430,7 @@
         conversion:
           Healing Power: {Condition Damage: 7%}
         attributes:
-          Healing Power: [60, unknown]
+          Condition Damage: [90, unknown]
       gw2id: 2284
       defaultEnabled: true
 
@@ -443,7 +443,7 @@
         quantityEntered: 100
       modifiers:
         attributes:
-          Healing Power: [60, unknown]
+          Condition Damage: [90, unknown]
       gw2id: 2284
       defaultEnabled: true
 

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -436,7 +436,8 @@
       subText: base
       modifiers:
         conversion:
-          Ferocity: {Precision: 7%}
+          Ferocity: {Precision: 10%}
+          Condition Damage: {Power: 10%}
       gw2id: 2011
       defaultEnabled: true
 
@@ -449,7 +450,8 @@
         quantityEntered: 100
       modifiers:
         conversion:
-          Ferocity: {Precision: 7%}
+          Ferocity: {Precision: 10%}
+          Condition Damage: {Power: 10%}
       gw2id: 2011
       defaultEnabled: true
 

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -500,7 +500,7 @@
         quantityEntered: 100
       modifiers:
         damage:
-          Strike Damage: [25%, mult]
+          Strike Damage: [20%, mult]
       wvwModifiers:
         damage:
           Strike Damage: [10%, mult]

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -360,6 +360,9 @@
       modifiers:
         damage:
           Strike Damage: [25%, mult]
+      wvwModifiers:
+        damage:
+          Strike Damage: [7%, mult]
       gw2id: 1486
       defaultEnabled: true
 

--- a/src/pages/index/index.jsx
+++ b/src/pages/index/index.jsx
@@ -24,9 +24,9 @@ const IndexPage = () => {
 
   const ALERTS = [
     <Trans>
-      Core game changes, preset coefficients, and trait selections are not fully updated for the
-      June 27th game patch. Most gear results will be correctly optimized, but DPS estimates and
-      comparisons may be wrong.
+      Core game changes are updated for the June 27th game patch, but preset coefficients and trait
+      selections may not yet be completely updated. Most gear results will be correctly optimized,
+      but DPS estimates and comparisons may be wrong.
       <br />
       <br />
       Templates not marked as Outdated are expected to be up to date.


### PR DESCRIPTION
https://wiki.guildwars2.com/wiki/Game_updates/2023-06-27

Not too happy with the big block of herald facet passives, ideas for improvement welcome

 - [x] Tempestous Aria:
  10% all damage needs uptime

 - [x] Kinetic Accelerators:
  10% -> 13% power to conc conversion in pve only

 - [x] Septic Corruption:
  0.5% -> 0.25% in pve only

 - [x] Farsighted:
  Increased the minimum damage bonus from 5% to 10% and increased
  the maximum damage bonus from 10% to 15% in PvE only.

 - [x] Strider's Strength:
  Gain power, gain additional power when wielding a sword
  120, 120, pet also gains it

 - [x] Herald facet buff changes

 - [x] Endless Stamina -> Fluid Strikes
  10% strike damage with uptime

 - [x] Second Opinion:
  Grants condition damage when equipped and while wielding a cepter
  90, +90, 7% condi convert to healing power

 - [x] Warrior's Cunning:
  Reduced the damage increase against high-health foes from 25% to
  7% and the damage increase vs. foes with barrier from 50% to 10%
  in WvW only.

 - [x] Blood Reaction:
  Increased the base precision-to-ferocity conversion to 10%. This
  trait now converts 10% of power to condition damage. These bonuses
  are still doubled in berserk mode.

 - [x] Bloody Roar:
  25% -> 20% in PvE only