### PR TITLE
Data: set every unconfirmed +outgoing cdmg mod to add

### DIFF
--- a/src/assets/modifierdata/elementalist.yaml
+++ b/src/assets/modifierdata/elementalist.yaml
@@ -48,7 +48,7 @@
       modifiers:
         damage:
           Strike Damage: [10%, unknown]
-          Condition Damage: [10%, unknown]
+          Condition Damage: [10%, add] #unconfirmed
       gw2id: 62758
 
     - id: crescent-wind
@@ -71,11 +71,11 @@
       modifiers:
         damage:
           Strike Damage: [10%, unknown]
-          Condition Damage: [10%, unknown]
+          Condition Damage: [10%, add] #unconfirmed
       wvwModifiers:
         damage:
           Strike Damage: [15%, unknown]
-          Condition Damage: [15%, unknown]
+          Condition Damage: [15%, add] #unconfirmed
       gw2id: 62965
 
     # - id: flame-axe
@@ -674,11 +674,11 @@
       modifiers:
         damage:
           Strike Damage: [3%, unknown]
-          Condition Damage: [3%, unknown]
+          Condition Damage: [3%, add] #unconfirmed
       wvwModifiers:
         damage:
           Strike Damage: [2%, unknown]
-          Condition Damage: [2%, unknown]
+          Condition Damage: [2%, add] #unconfirmed
       gw2id: 2247
       defaultEnabled: true
 

--- a/src/assets/modifierdata/engineer.yaml
+++ b/src/assets/modifierdata/engineer.yaml
@@ -35,7 +35,7 @@
       text: Superconducting Signet
       modifiers:
         damage:
-          Condition Damage: [10%, unknown]
+          Condition Damage: [10%, add] #unconfirmed
       gw2id: 63113
 
     - id: superconducting-signet-traited
@@ -43,7 +43,7 @@
       subText: traited
       modifiers:
         damage:
-          Condition Damage: [12%, unknown]
+          Condition Damage: [12%, add] #unconfirmed
       gw2id: 63113
 
 - section: Explosives

--- a/src/assets/modifierdata/mesmer.yaml
+++ b/src/assets/modifierdata/mesmer.yaml
@@ -383,7 +383,7 @@
       modifiers:
         damage:
           Strike Damage: [5%, unknown]
-          Condition Damage: [5%, unknown]
+          Condition Damage: [5%, add] #unconfirmed
       gw2id: 2204
       defaultEnabled: true
 

--- a/src/assets/modifierdata/revenant.yaml
+++ b/src/assets/modifierdata/revenant.yaml
@@ -21,10 +21,10 @@
         quantityEntered: 100
       modifiers:
         damage:
-          Condition Damage: [10%, unknown]
+          Condition Damage: [10%, add] #unconfirmed
       wvwModifiers:
         damage:
-          Condition Damage: [5%, unknown]
+          Condition Damage: [5%, add] #unconfirmed
       gw2id: 27014
 
     - id: facet-of-strength-draconic-echo

--- a/src/assets/modifierdata/testModifiers.js
+++ b/src/assets/modifierdata/testModifiers.js
@@ -320,6 +320,12 @@ function parseDamage(damage, id, amountData) {
         `set mode unknown for critical damage for now`,
       );
 
+      // so far (mid 2023), every +condition damage output bonus that's been tested has been additive
+      gentleAssert(
+        key !== 'Condition Damage' || mode !== 'unknown' || mode !== 'mult',
+        `set mode add for condition damage and comment that it's unconfirmed (remove this test if anyone finds a multiplicative one!)`,
+      );
+
       if (mode === 'target') {
         gentleAssert(damage['Phantasm Damage'] !== undefined, `${id} is missing phantasm damage`);
       }


### PR DESCRIPTION
As far as we know, every outgoing condition damage modifier in the game has been additive.

This adds a check to testModifiers enforcing this rule, which we should remove if at any point a multiplicative outgoing condition damage modifier is discovered.

Slightly messes up the power catalyst template, but like, whatever. Every template is dead anyway, making this a good time.

Resolves #522.