### PR TITLE
Add disclaimer for July 18th patch

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -43,7 +43,7 @@
   "Copy build": "Copy build",
   "Copy from selected character": "Copy from selected character",
   "Copy selected sigils to both slots": "Copy selected sigils to both slots",
-  "Core game changes are updated for the June 27th game patch, but preset coefficients and trait selections may not yet be completely updated. Most gear results will be correctly optimized, but DPS estimates and comparisons may be wrong.<br/><br/>Templates not marked as Outdated are up to date.": "Core game changes are updated for the June 27th game patch, but preset coefficients and trait selections may not yet be completely updated. Most gear results will be correctly optimized, but DPS estimates and comparisons may be wrong.<br/><br/>Templates not marked as Outdated are up to date.",
+  "Core game changes, preset coefficients, and trait selections are not fully updated for the July 18th game patch. Most gear results will be correctly optimized, but DPS estimates and comparisons may be wrong.<br/><br/>Templates not marked as Outdated are up to date.": "Core game changes, preset coefficients, and trait selections are not fully updated for the July 18th game patch. Most gear results will be correctly optimized, but DPS estimates and comparisons may be wrong.<br/><br/>Templates not marked as Outdated are up to date.",
   "Create build templates that can be used for the gear optimizer.": "Create build templates that can be used for the gear optimizer.",
   "Create templates for the discretize.eu website. Please check the discretize-guides repo for more information.": "Create templates for the discretize.eu website. Please check the discretize-guides repo for more information.",
   "Ctrl+d": "Ctrl+d",

--- a/src/pages/index/index.jsx
+++ b/src/pages/index/index.jsx
@@ -24,9 +24,9 @@ const IndexPage = () => {
 
   const ALERTS = [
     <Trans>
-      Core game changes are updated for the June 27th game patch, but preset coefficients and trait
-      selections may not yet be completely updated. Most gear results will be correctly optimized,
-      but DPS estimates and comparisons may be wrong.
+      Core game changes, preset coefficients, and trait selections are not fully updated for the
+      July 18th game patch. Most gear results will be correctly optimized, but DPS estimates and
+      comparisons may be wrong.
       <br />
       <br />
       Templates not marked as Outdated are expected to be up to date.


### PR DESCRIPTION
I'm likely to be busy Tuesday/Wednesday so my original plan of "just update the few traits they're reworking" is out the window.
Expected trait changes with numbers impact are Scourge and Specter but one of the Specter changes is missing a number