### PR TITLE
Fix: Reuse workers

### DIFF
--- a/src/state/optimizer-parallel/calculate.ts
+++ b/src/state/optimizer-parallel/calculate.ts
@@ -17,6 +17,8 @@ export interface WorkerWrapper {
   worker: globalThis.Worker;
 }
 
+let workers: WorkerWrapper[] = [];
+
 // fuck typing redux
 export default function calculate(reduxState: any, dispatch: Dispatch<any>): WorkerWrapper[] {
   const selectedMaxThreads = reduxState.optimizer.control.hwThreads;
@@ -34,13 +36,14 @@ export default function calculate(reduxState: any, dispatch: Dispatch<any>): Wor
 
   console.log(`Creating ${selectedMaxThreads} threads`);
   // create all threads. later on we may or may not use them depending on the presented problem
-  const workers: WorkerWrapper[] = [...Array(selectedMaxThreads)].map((_, index) => {
-    return {
-      status: 'created',
-      workerId: index,
-      worker: new Worker(new URL('./worker/worker.ts', import.meta.url), { type: 'module' }),
-    };
-  });
+  workers = [...Array(selectedMaxThreads)].map(
+    (_, index) =>
+      workers[index] ?? {
+        status: 'created',
+        workerId: index,
+        worker: new Worker(new URL('./worker/worker.ts', import.meta.url), { type: 'module' }),
+      },
+  );
 
   // select calculation mode - at the moment there are only two modes
   if (withHeuristics) {

--- a/src/state/optimizer-parallel/calculate.ts
+++ b/src/state/optimizer-parallel/calculate.ts
@@ -17,7 +17,7 @@ export interface WorkerWrapper {
   worker: globalThis.Worker;
 }
 
-let workers: WorkerWrapper[] = [];
+const createdWorkers: globalThis.Worker[] = [];
 
 // fuck typing redux
 export default function calculate(reduxState: any, dispatch: Dispatch<any>): WorkerWrapper[] {
@@ -36,14 +36,16 @@ export default function calculate(reduxState: any, dispatch: Dispatch<any>): Wor
 
   console.log(`Creating ${selectedMaxThreads} threads`);
   // create all threads. later on we may or may not use them depending on the presented problem
-  workers = [...Array(selectedMaxThreads)].map(
-    (_, index) =>
-      workers[index] ?? {
-        status: 'created',
-        workerId: index,
-        worker: new Worker(new URL('./worker/worker.ts', import.meta.url), { type: 'module' }),
-      },
-  );
+  const workers: WorkerWrapper[] = [...Array(selectedMaxThreads)].map((_, index) => {
+    createdWorkers[index] ??= new Worker(new URL('./worker/worker.ts', import.meta.url), {
+      type: 'module',
+    });
+    return {
+      status: 'created',
+      workerId: index,
+      worker: createdWorkers[index],
+    };
+  });
 
   // select calculation mode - at the moment there are only two modes
   if (withHeuristics) {


### PR DESCRIPTION
Reuses already-instantiated workers when running more than one calculation in Rust mode. Should fix the "if I press calculate a few times I run out of memory" problem.