### PR TITLE
Add Burst of Strength's PvE condi mod; Split out WvW Burst of Strength

### DIFF
--- a/src/assets/modifierdata/revenant.yaml
+++ b/src/assets/modifierdata/revenant.yaml
@@ -76,6 +76,10 @@
       modifiers:
         damage:
           Outgoing Strike Damage: [15%, add]
+          Outgoing Condition Damage: [15%, add] #unconfirmed
+      wvwModifiers:
+        damage:
+          Outgoing Strike Damage: [7%, add]
       gw2id: 28113
 
     - id: vengeful-hammers


### PR DESCRIPTION
https://wiki.guildwars2.com/wiki/Burst_of_Strength

Doesn't mark any templates as out of date since all templates are baseline out of date.

I'm planning on starting back on the template data entry after the balance patch on the 26th (though I might be driven to do things before then out of boredom, like #588 would be pretty cool)