### PR TITLE
Replace buildTemplateOutdated and context with outdated

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+  " (Outdated)": " (Outdated)",
   " duration": " duration",
   "% Outgoing Healing": "% Outgoing Healing",
   "(under construction)": "(under construction)",
@@ -407,8 +408,6 @@
   "buildTemplateName_Rifle Deadeye Premeditation": "Rifle Deadeye Premeditation",
   "buildTemplateName_Rifle Deadeye Silent Scope": "Rifle Deadeye Silent Scope",
   "buildTemplateName_[beta1] Condi Catalyst": "[beta1] Condi Catalyst",
-  "buildTemplateOutdated_false": "",
-  "buildTemplateOutdated_true": " (Outdated)",
   "copy raw data to clipboard": "copy raw data to clipboard",
   "extraSection_???": "???",
   "extraSection_Additional Condition Runes": "Additional Condition Runes",

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -258,8 +258,8 @@ const Navbar = () => {
                     <Profession
                       name={elem.specialization}
                       disableLink
-                      // i18next-extract-mark-context-next-line {{buildTemplateName}}
                       text={
+                        // i18next-extract-mark-context-next-line {{buildTemplateName}}
                         t('buildTemplateName', { context: elem.name }) +
                         (elem.outdated ? t(' (Outdated)') : '')
                       }

--- a/src/components/nav/NavBar.jsx
+++ b/src/components/nav/NavBar.jsx
@@ -261,8 +261,7 @@ const Navbar = () => {
                       // i18next-extract-mark-context-next-line {{buildTemplateName}}
                       text={
                         t('buildTemplateName', { context: elem.name }) +
-                        // i18next-extract-mark-context-next-line {{buildTemplateOutdated}}
-                        t('buildTemplateOutdated', { context: elem.outdated.toString() })
+                        (elem.outdated ? t(' (Outdated)') : '')
                       }
                     />
                   </MenuItem>
@@ -283,8 +282,7 @@ const Navbar = () => {
               text={
                 // i18next-extract-mark-context-next-line {{buildTemplateName}}
                 t('buildTemplateName', { context: selectedTemplateName }) +
-                // i18next-extract-mark-context-next-line {{buildTemplateOutdated}}
-                t('buildTemplateOutdated', { context: (!!selectedTemplate?.outdated).toString() })
+                (selectedTemplate?.outdated ? t(' (Outdated)') : '')
               }
               disableLink
             />


### PR DESCRIPTION
This is a more straightforwards solution that avoids potential issues with translation context extraction.

See also https://github.com/discretize/discretize-gear-optimizer/pull/600#issuecomment-1736332418