### PR TITLE
Implement increased critical damage traits as mult

### DIFF
--- a/src/assets/modifierdata/mesmer.yaml
+++ b/src/assets/modifierdata/mesmer.yaml
@@ -155,7 +155,7 @@
       subText: base
       modifiers:
         damage:
-          Outgoing Critical Damage: [15%, unknown]
+          Outgoing Critical Damage: [15%, mult]
       gw2id: 692
       defaultEnabled: true
 
@@ -168,7 +168,8 @@
         quantityEntered: 100
       modifiers:
         damage:
-          Outgoing Critical Damage: [10%, unknown]
+          # increases base version to 25%: 1.25/1.15 = 1.08695652174
+          Outgoing Critical Damage: [8.695652174%, mult]
       gw2id: 692
       defaultEnabled: true
 

--- a/src/assets/modifierdata/mesmer.yaml
+++ b/src/assets/modifierdata/mesmer.yaml
@@ -168,7 +168,7 @@
         quantityEntered: 100
       modifiers:
         damage:
-          # increases base version to 25%: 1.25/1.15 = 1.08695652174
+          # increases base version to 25%: 1.25/1.15 = 1.08695652174. see GitHub PR #612.
           Outgoing Critical Damage: [8.695652174%, mult]
       gw2id: 692
       defaultEnabled: true

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -552,11 +552,11 @@
         quantityEntered: 100
       modifiers:
         damage:
-          # increases base version to 15%: 1.15/1.075 = 1.06976744186
+          # increases base version to 15%: 1.15/1.075 = 1.06976744186. see GitHub PR #612.
           Outgoing Critical Damage: [6.976744186%, mult]
       wvwModifiers:
         damage:
-          # increases base version to 14%: 1.14/1.07 = 1.06542056075
+          # increases base version to 14%: 1.14/1.07 = 1.06542056075. see GitHub PR #612.
           Outgoing Critical Damage: [6.542056075%, mult]
       gw2id: 2107
       defaultEnabled: true

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -536,10 +536,10 @@
       subText: base
       modifiers:
         damage:
-          Outgoing Critical Damage: [7.5%, unknown]
+          Outgoing Critical Damage: [7.5%, mult]
       wvwModifiers:
         damage:
-          Outgoing Critical Damage: [7%, unknown]
+          Outgoing Critical Damage: [7%, mult]
       gw2id: 2107
       defaultEnabled: true
 
@@ -552,10 +552,12 @@
         quantityEntered: 100
       modifiers:
         damage:
-          Outgoing Critical Damage: [7.5%, unknown]
+          # increases base version to 15%: 1.15/1.075 = 1.06976744186
+          Outgoing Critical Damage: [6.976744186%, mult]
       wvwModifiers:
         damage:
-          Outgoing Critical Damage: [7%, unknown]
+          # increases base version to 14%: 1.14/1.07 = 1.06542056075
+          Outgoing Critical Damage: [6.542056075%, mult]
       gw2id: 2107
       defaultEnabled: true
 

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -324,7 +324,7 @@ function parseDamage(damage, id, amountData) {
       gentleAssert(allDamageModes.includes(mode), `invalid val ${allPairs} for ${key} in ${id}`);
       gentleAssert(
         key !== 'Outgoing Critical Damage' || mode !== 'add',
-        `set mode mult for critical damage and calculate additive mods manually`,
+        `if ${id} is an additive increase of a single bonus, use mode mult and calculate the addition; see GitHub PR #612. (change this to a warning if an additive critical damage bonus is found!)`,
       );
 
       // so far (mid 2023), every +condition damage output bonus that's been tested has been additive

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -323,8 +323,8 @@ function parseDamage(damage, id, amountData) {
       parsePercent(amount, key, id);
       gentleAssert(allDamageModes.includes(mode), `invalid val ${allPairs} for ${key} in ${id}`);
       gentleAssert(
-        key !== 'Outgoing Critical Damage' || mode === 'unknown',
-        `set mode unknown for critical damage for now`,
+        key !== 'Outgoing Critical Damage' || mode !== 'add',
+        `set mode mult for critical damage and calculate additive mods manually`,
       );
 
       // so far (mid 2023), every +condition damage output bonus that's been tested has been additive


### PR DESCRIPTION
Superiority Complex and Pure Strike are traits with critical damage bonuses that additively increase under certain conditions. We implement these bonuses as a second, separate trait bonus entry, which in theory should be additive with the first bonus, but not with a different critical damage bonus.

In practice, there are only two of these traits and they cannot be simultaneously enabled, as they are on different classes. Thus, simply marking these as additive should give accurate results.

Instead, though, to ensure that it is impossible to run into accuracy issues at a later date (e.g. if we do more testing and determine that some critical damage bonuses actually are additive with each other), this PR implements the bonus values as multiplicative using arithmetic, as suggested by REMagic here: [discord.com/channels/380901000200060929/384171360219430913/1014304525579976776](https://discord.com/channels/380901000200060929/384171360219430913/1014304525579976776)

Resolves #496.

