### PR TITLE
Use cloudflare direct deployment

### DIFF
--- a/.github/workflows/previews-cf.yml
+++ b/.github/workflows/previews-cf.yml
@@ -5,26 +5,49 @@ on:
   
 env:
   PAGES_PROJECT_NAME: discretize-optimizer
+  NODE_VERSION: 18
+  APIKEY: ${{ secrets.CF_GLOBAL_APIKEY }}
   
 jobs:
   deployment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     if: >
+      env.APIKEY != null &&
       !contains(github.event.head_commit.message, 'skip ci') &&
       !contains(github.event.pull_request.body, '[no previews]') &&
       (contains(github.event.pull_request.body, '[draft previews]') || github.event.pull_request.draft == false)
     timeout-minutes: 15
 
     steps:
-      - name: Generate preview
-        env:
-          APIKEY: ${{ secrets.CF_GLOBAL_APIKEY }}
-        if: env.APIKEY != null
-        uses: tomjschuster/cloudflare-pages-deploy-action@v0
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
         with:
-          account-id: '${{ secrets.CF_ACCOUNT_ID }}'
-          project-name: '${{ env.PAGES_PROJECT_NAME }}'
-          api-key: '${{ secrets.CF_GLOBAL_APIKEY }}'
-          email: '${{ secrets.CF_EMAIL }}'
-          preview: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+      - name: Cache dependencies
+        id: node-modules-cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      - name: Compile WASM
+        run: yarn wasm
+      - name: Build
+        run: yarn build
+
+      - name: Publish
+        uses: cloudflare/pages-action@1
+        with:
+          apiToken: ${{ secrets.CF_GLOBAL_APIKEY }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          projectName: ${{ env.PAGES_PROJECT_NAME }}
+          directory: dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/previews-cf.yml
+++ b/.github/workflows/previews-cf.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       deployments: write
     if: >
-      env.APIKEY != null &&
+      env.APIKEY &&
       !contains(github.event.head_commit.message, 'skip ci') &&
       !contains(github.event.pull_request.body, '[no previews]') &&
       (contains(github.event.pull_request.body, '[draft previews]') || github.event.pull_request.draft == false)

--- a/.github/workflows/previews-cf.yml
+++ b/.github/workflows/previews-cf.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       deployments: write
     if: >
-      env.APIKEY &&
+      env.APIKEY != null &&
       !contains(github.event.head_commit.message, 'skip ci') &&
       !contains(github.event.pull_request.body, '[no previews]') &&
       (contains(github.event.pull_request.body, '[draft previews]') || github.event.pull_request.draft == false)

--- a/.github/workflows/staging-cf.yml
+++ b/.github/workflows/staging-cf.yml
@@ -8,20 +8,44 @@ on:
   
 env:
   PAGES_PROJECT_NAME: discretize-optimizer
+  NODE_VERSION: 18
   
 jobs:
   deployment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     timeout-minutes: 15
 
     steps:
-      - name: Deploy staging
-        uses: tomjschuster/cloudflare-pages-deploy-action@v0
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
         with:
-          account-id: '${{ secrets.CF_ACCOUNT_ID }}'
-          project-name: '${{ env.PAGES_PROJECT_NAME }}'
-          api-key: '${{ secrets.CF_GLOBAL_APIKEY }}'
-          email: '${{ secrets.CF_EMAIL }}'
-          branch: 'staging'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+      - name: Cache dependencies
+        id: node-modules-cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      - name: Compile WASM
+        run: yarn wasm
+      - name: Build
+        run: yarn build
+
+      - name: Publish
+        uses: cloudflare/pages-action@1
+        with:
+          apiToken: ${{ secrets.CF_GLOBAL_APIKEY }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          projectName: ${{ env.PAGES_PROJECT_NAME }}
+          directory: dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I know of no way to test this besides merging it and then deploying some dummy content, so... fingers on the revert button I guess.

This attempts to switch from Cloudflare's hosted build integration to performing a build inside a Github Action and uploading the result via https://github.com/cloudflare/pages-action.

See: https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/