### PR TITLE
Chore: Remove `wasm_module` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "typeface-muli": "^1.1.13",
     "typeface-raleway": "^1.1.13",
     "urlsafe-base64": "^1.0.0",
-    "wasm-pack": "^0.12.1",
-    "wasm_module": "file:./wasm_module"
+    "wasm-pack": "^0.12.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5788,9 +5788,6 @@ wasm-pack@^0.12.1:
   dependencies:
     binary-install "^1.0.1"
 
-"wasm_module@file:./wasm_module":
-  version "0.0.0"
-
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"


### PR DESCRIPTION
As far as I know, this dependency field is not needed and just causes a lot of pollution of the Yarn global cache. Let's see if it's true.