### PR TITLE
Fix: `convertafterbuffs` on precision/ferocity/concentration/vitality

### DIFF
--- a/src/state/optimizer/optimizerCore.ts
+++ b/src/state/optimizer/optimizerCore.ts
@@ -632,6 +632,27 @@ export class OptimizerCore {
       attributes[attribute] = (attributes[attribute] || 0) + bonus;
     }
 
+    for (const [attribute, conversion] of settings.modifiers['convertAfterBuffs']) {
+      const maybeRound = enumArrayIncludes(allAttributePointKeys, attribute)
+        ? round
+        : (val: number) => val;
+      for (const [source, percent] of conversion) {
+        if (source === 'Critical Chance') {
+          attributes[attribute] += maybeRound(clamp(attributes['Critical Chance'], 0, 1) * percent);
+        } else if (source === 'Clone Critical Chance') {
+          attributes[attribute] += maybeRound(
+            clamp(attributes['Clone Critical Chance'] ?? 0, 0, 1) * percent,
+          );
+        } else if (source === 'Phantasm Critical Chance') {
+          attributes[attribute] += maybeRound(
+            clamp(attributes['Phantasm Critical Chance'] ?? 0, 0, 1) * percent,
+          );
+        } else {
+          attributes[attribute] += maybeRound(attributes[source] * percent);
+        }
+      }
+    }
+
     attributes['Critical Chance'] += (attributes['Precision'] - 1000) / 21 / 100;
     attributes['Critical Damage'] += attributes['Ferocity'] / 15 / 100;
 
@@ -659,27 +680,6 @@ export class OptimizerCore {
         (attributes['Alternative Critical Damage'] ?? 0) +
         attributes['Critical Damage'] +
         (attributes['Alternative Ferocity'] ?? 0) / 15 / 100;
-    }
-
-    for (const [attribute, conversion] of settings.modifiers['convertAfterBuffs']) {
-      const maybeRound = enumArrayIncludes(allAttributePointKeys, attribute)
-        ? round
-        : (val: number) => val;
-      for (const [source, percent] of conversion) {
-        if (source === 'Critical Chance') {
-          attributes[attribute] += maybeRound(clamp(attributes['Critical Chance'], 0, 1) * percent);
-        } else if (source === 'Clone Critical Chance') {
-          attributes[attribute] += maybeRound(
-            clamp(attributes['Clone Critical Chance'] ?? 0, 0, 1) * percent,
-          );
-        } else if (source === 'Phantasm Critical Chance') {
-          attributes[attribute] += maybeRound(
-            clamp(attributes['Phantasm Critical Chance'] ?? 0, 0, 1) * percent,
-          );
-        } else {
-          attributes[attribute] += maybeRound(attributes[source] * percent);
-        }
-      }
     }
   }
 

--- a/wasm_module/src/optimizer_core.rs
+++ b/wasm_module/src/optimizer_core.rs
@@ -320,6 +320,56 @@ fn calc_stats(
         attributes.add_a(*attribute, *bonus);
     }
 
+    // handle convertAfterBuffs modifiers
+    for (attribute, conversion) in &combination.modifiers.convertAfterBuffs {
+        let maybe_round = |val: f32| {
+            if attribute.is_point_key() {
+                round(val)
+            } else {
+                val
+            }
+        };
+
+        for (source, percent) in conversion {
+            match *source {
+                Attribute::CriticalChance => {
+                    attributes.add_a(
+                        *attribute,
+                        maybe_round(
+                            clamp(attributes.get_a(Attribute::CriticalChance), 0.0, 1.0) * percent,
+                        ),
+                    );
+                }
+                Attribute::CloneCriticalChance => {
+                    // replace macro with set
+                    attributes.add_a(
+                        *attribute,
+                        maybe_round(
+                            clamp(attributes.get_a(Attribute::CloneCriticalChance), 0.0, 1.0)
+                                * percent,
+                        ),
+                    );
+                }
+                Attribute::PhantasmCriticalChance => {
+                    attributes.add_a(
+                        *attribute,
+                        maybe_round(
+                            clamp(
+                                attributes.get_a(Attribute::PhantasmCriticalChance),
+                                0.0,
+                                1.0,
+                            ) * percent,
+                        ),
+                    );
+                }
+
+                _ => {
+                    attributes.add_a(*attribute, maybe_round(attributes.get_a(*source) * percent));
+                }
+            }
+        }
+    }
+
     // recalculate attributes
     attributes.add_a(
         Attribute::CriticalChance,
@@ -372,56 +422,6 @@ fn calc_stats(
                 + attributes.get_a(Attribute::CriticalDamage)
                 + attributes.get_a(Attribute::AltFerocity) / 15.0 / 100.0,
         );
-    }
-
-    // handle convertAfterBuffs modifiers
-    for (attribute, conversion) in &combination.modifiers.convertAfterBuffs {
-        let maybe_round = |val: f32| {
-            if attribute.is_point_key() {
-                round(val)
-            } else {
-                val
-            }
-        };
-
-        for (source, percent) in conversion {
-            match *source {
-                Attribute::CriticalChance => {
-                    attributes.add_a(
-                        *attribute,
-                        maybe_round(
-                            clamp(attributes.get_a(Attribute::CriticalChance), 0.0, 1.0) * percent,
-                        ),
-                    );
-                }
-                Attribute::CloneCriticalChance => {
-                    // replace macro with set
-                    attributes.add_a(
-                        *attribute,
-                        maybe_round(
-                            clamp(attributes.get_a(Attribute::CloneCriticalChance), 0.0, 1.0)
-                                * percent,
-                        ),
-                    );
-                }
-                Attribute::PhantasmCriticalChance => {
-                    attributes.add_a(
-                        *attribute,
-                        maybe_round(
-                            clamp(
-                                attributes.get_a(Attribute::PhantasmCriticalChance),
-                                0.0,
-                                1.0,
-                            ) * percent,
-                        ),
-                    );
-                }
-
-                _ => {
-                    attributes.add_a(*attribute, maybe_round(attributes.get_a(*source) * percent));
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
We don't use `convertafterbuffs` on any of these attributes (after the previous fix to reinforced armor), so this actually does nothing, but this fixes them not being applied in those cases.