### PR TITLE
Update rust-toolchain file

### DIFF
--- a/wasm_module/rust-toolchain
+++ b/wasm_module/rust-toolchain
@@ -1,1 +1,2 @@
-stable
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
The rust-toolchain file is apparently supposed to be toml now: https://blog.rust-lang.org/2020/11/27/Rustup-1.23.0.html#new-format-for-rust-toolchain

I know nothing about this ecosystem; should this also use the `components` or the `targets` field?