### PR TITLE
Modifier updates (mostly wvw splits)

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -854,7 +854,6 @@
   "traitNote_Shiro lifesteal is not currently simulated separately.": "Shiro lifesteal is not currently simulated separately.",
   "traitSubText": "",
   "traitSubText_100%": "100%",
-  "traitSubText_100% Uptime": "100% Uptime",
   "traitSubText_100% burning enemy": "100% burning enemy",
   "traitSubText_100% earth attunement": "100% earth attunement",
   "traitSubText_100% flanking": "100% flanking",

--- a/src/assets/modifierdata/elementalist.yaml
+++ b/src/assets/modifierdata/elementalist.yaml
@@ -368,7 +368,7 @@
   id: 17
   items:
 
-    - id: piercing-blades
+    - id: piercing-shards
       text: Piercing Shards
       subText: base
       modifiers:
@@ -380,7 +380,7 @@
       gw2id: 363
       defaultEnabled: true
 
-    - id: piercing-blades-2
+    - id: piercing-shards-2
       text: Piercing Shards
       amountData:
         label: '% water attunement'

--- a/src/assets/modifierdata/elementalist.yaml
+++ b/src/assets/modifierdata/elementalist.yaml
@@ -11,8 +11,8 @@
     - id: signet-of-earth
       text: Signet of Earth
       modifiers:
-        attributes:
-          Toughness: [180, buff]
+        damage:
+          Damage Reduction: [10%, unknown]
       gw2id: 5571
 
     - id: woven-fire

--- a/src/assets/modifierdata/elementalist.yaml
+++ b/src/assets/modifierdata/elementalist.yaml
@@ -525,6 +525,10 @@
         damage:
           Outgoing Strike Damage: [10%, unknown]
           Outgoing Condition Damage: [10%, add] # unconfirmed
+      wvwModifiers:
+        damage:
+          Outgoing Strike Damage: [7%, unknown]
+          Outgoing Condition Damage: [7%, add] # unconfirmed
       gw2id: 1891
       defaultEnabled: true
 

--- a/src/assets/modifierdata/engineer.yaml
+++ b/src/assets/modifierdata/engineer.yaml
@@ -123,6 +123,9 @@
       modifiers:
         conversionAfterBuffs:
           Bleeding Coefficient: {Critical Chance: 100%}
+      wvwModifiers:
+        conversionAfterBuffs:
+          Bleeding Coefficient: {Critical Chance: 33%}
       gw2id: 515
       defaultEnabled: false
 

--- a/src/assets/modifierdata/engineer.yaml
+++ b/src/assets/modifierdata/engineer.yaml
@@ -354,7 +354,7 @@
           Power: [750, buff]
       wvwModifiers:
         attributes:
-          Power: [500, buff]
+          Power: [375, buff]
       gw2id: 1849
       defaultEnabled: true
 

--- a/src/assets/modifierdata/guardian.yaml
+++ b/src/assets/modifierdata/guardian.yaml
@@ -275,8 +275,8 @@
   id: 49
   items:
 
-    - id: invigorating-bulwark
-      text: Invigorating Bulwark
+    - id: invigorated-bulwark
+      text: Invigorated Bulwark
       amountData:
         label: 'stacks'
         default: 5
@@ -372,7 +372,7 @@
       gw2id: 624
       defaultEnabled: true
 
-    - id: virtue-of-retribution
+    - id: virtue-of-resolution
       text: Virtue of Resolution
       minor: true
       modifiers:

--- a/src/assets/modifierdata/guardian.yaml
+++ b/src/assets/modifierdata/guardian.yaml
@@ -589,8 +589,8 @@
           Outgoing Condition Damage: [3%, add] # ???
       wvwModifiers:
         damage:
-          Outgoing Strike Damage: [4%, add] # as per Cat
-          Outgoing Condition Damage: [4%, add] # ???
+          Outgoing Strike Damage: [2%, add] # as per Cat
+          Outgoing Condition Damage: [2%, add] # ???
       gw2id: 2201
       defaultEnabled: true
 

--- a/src/assets/modifierdata/guardian.yaml
+++ b/src/assets/modifierdata/guardian.yaml
@@ -499,6 +499,9 @@
       modifiers:
         damage:
           Outgoing Strike Damage: [20%, mult]
+      wvwModifiers:
+        damage:
+          Outgoing Strike Damage: [15%, mult]
       gw2id: 1955
       defaultEnabled: true
 

--- a/src/assets/modifierdata/mesmer.yaml
+++ b/src/assets/modifierdata/mesmer.yaml
@@ -320,7 +320,7 @@
           Outgoing Phantasm Damage: [100%, mult]
       wvwModifiers:
         damage:
-          Outgoing Phantasm Damage: [75%, mult]
+          Outgoing Phantasm Damage: [50%, mult]
       gw2id: 1890
       defaultEnabled: true
 

--- a/src/assets/modifierdata/mesmer.yaml
+++ b/src/assets/modifierdata/mesmer.yaml
@@ -373,7 +373,7 @@
           Bleeding Coefficient: {Critical Chance: 450%}
       wvwModifiers:
         conversionAfterBuffs:
-          Bleeding Coefficient: {Critical Chance: 500%}
+          Bleeding Coefficient: {Critical Chance: 300%}
       gw2id: 2202
       defaultEnabled: false
 

--- a/src/assets/modifierdata/necromancer.yaml
+++ b/src/assets/modifierdata/necromancer.yaml
@@ -184,12 +184,12 @@
 - section: Blood Magic
   id: 19
   items:
-    - id: banshees-wail
-      text: Banshee's Wail
+    - id: life-from-death
+      text: Life from Death
       modifiers:
         attributes:
           Outgoing Healing: 10%
-      gw2id: 799
+      gw2id: 789
       defaultEnabled: true
 
 - section: Soul Reaping

--- a/src/assets/modifierdata/necromancer.yaml
+++ b/src/assets/modifierdata/necromancer.yaml
@@ -90,6 +90,9 @@
       modifiers:
         conversionAfterBuffs:
           Bleeding Coefficient: {Critical Chance: 100%}
+      wvwModifiers:
+        conversionAfterBuffs:
+          Bleeding Coefficient: {Critical Chance: 33%}
       gw2id: 802
       defaultEnabled: false
 

--- a/src/assets/modifierdata/ranger.yaml
+++ b/src/assets/modifierdata/ranger.yaml
@@ -330,8 +330,8 @@
       gw2id: 1062
       defaultEnabled: true
 
-    - id: instinctive-reaction
-      text: Instinctive Reaction
+    - id: wellspring
+      text: Wellspring
       modifiers:
         conversion:
           Healing Power: {Power: 7%}

--- a/src/assets/modifierdata/ranger.yaml
+++ b/src/assets/modifierdata/ranger.yaml
@@ -176,6 +176,9 @@
       modifiers:
         conversionAfterBuffs:
           Bleeding Coefficient: {Critical Chance: 100%}
+      wvwModifiers:
+        conversionAfterBuffs:
+          Bleeding Coefficient: {Critical Chance: 33%}
       gw2id: 1069
       defaultEnabled: false
 

--- a/src/assets/modifierdata/revenant.yaml
+++ b/src/assets/modifierdata/revenant.yaml
@@ -498,10 +498,6 @@
       modifiers:
         damage:
           Outgoing All Damage: [2%, add]
-      wvwModifiers:
-        damage:
-          Outgoing Strike Damage: [1%, add]
-          Outgoing Condition Damage: [2%, add]
       gw2id: 2181
       defaultEnabled: true
 

--- a/src/assets/modifierdata/revenant.yaml
+++ b/src/assets/modifierdata/revenant.yaml
@@ -464,7 +464,7 @@
           Outgoing Strike Damage: [20%, add] # add according to wiki
       wvwModifiers:
         damage:
-          Outgoing Strike Damage: [15%, add] # add according to wiki
+          Outgoing Strike Damage: [13%, add] # add according to wiki
       gw2id: 1803
       defaultEnabled: true
 

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -548,15 +548,6 @@
       gw2id: 2038
       defaultEnabled: true
 
-    - id: eternal-champion
-      text: Eternal Champion
-      subText: toughness during berserk
-      modifiers:
-        attributes:
-          Toughness: [300, buff]
-      gw2id: 2043
-      defaultEnabled: true
-
 - section: Spellbreaker
   id: 61
   items:

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -503,28 +503,6 @@
       gw2id: 2011
       defaultEnabled: true
 
-    - id: heat-the-soul
-      text: Heat the Soul
-      subText: base
-      modifiers:
-        attributes:
-          Condition Damage: [120, converted] # from sheet by Bekko
-      gw2id: 2042
-      defaultEnabled: true
-
-    - id: heat-the-soul-with
-      text: Heat the Soul
-      subText: with torch
-      amountData:
-        label: '% uptime'
-        default: 50
-        quantityEntered: 100
-      modifiers:
-        attributes:
-          Condition Damage: [120, converted] # from sheet by Bekko
-      gw2id: 2042
-      defaultEnabled: true
-
     - id: fatal-frenzy-power-condi
       text: Fatal Frenzy
       subText: power/condition damage

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -612,9 +612,9 @@
           Precision: [250, buff]
       wvwModifiers:
         attributes:
-          Ferocity: [175, buff]
-          Power: [175, buff]
-          Precision: [175, buff]
+          Ferocity: [150, buff]
+          Power: [150, buff]
+          Precision: [150, buff]
       gw2id: 2130
       defaultEnabled: true
 

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -261,6 +261,9 @@
       modifiers:
         conversionAfterBuffs:
           Bleeding Coefficient: {Critical Chance: 100%}
+      wvwModifiers:
+        conversionAfterBuffs:
+          Bleeding Coefficient: {Critical Chance: 33%}
       gw2id: 1337
       defaultEnabled: false
 

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -186,7 +186,7 @@
 
     - id: unsuspecting-foe-full
       text: Unsuspecting Foe
-      subText: 100% Uptime # variable crit chance would be inaccurate
+      subText: 100% uptime # variable crit chance would be inaccurate
       modifiers:
         attributes:
           Critical Chance: 25%
@@ -455,7 +455,7 @@
 
     - id: smash-brawler-full
       text: Smash Brawler
-      subText: 100% Uptime # variable crit chance would be inaccurate
+      subText: 100% uptime # variable crit chance would be inaccurate
       modifiers:
         attributes:
           Critical Chance: 15%

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -515,6 +515,10 @@
         attributes:
           Power: [300, buff]
           Condition Damage: [300, buff]
+      wvwModifiers:
+        attributes:
+          Power: [150, buff]
+          Condition Damage: [300, buff]
       gw2id: 2046
       defaultEnabled: true
 

--- a/src/assets/modifierdata/warrior.yaml
+++ b/src/assets/modifierdata/warrior.yaml
@@ -427,6 +427,9 @@
       modifiers:
         attributes:
           Outgoing Healing: 15%
+      wvwModifiers:
+        attributes:
+          Outgoing Healing: 10%
       gw2id: 1381
       defaultEnabled: true
 

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -790,7 +790,7 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": ""
             },
@@ -888,7 +888,7 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": "80"
             },
@@ -1020,7 +1020,7 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": "90.4"
             },
@@ -1094,7 +1094,7 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": ""
             },
@@ -1162,7 +1162,7 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": ""
             },
@@ -1235,7 +1235,7 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": ""
             },
@@ -1295,7 +1295,7 @@ list:
             "righteous-instincts": {}
           },
           {
-            "invigorating-bulwark": {
+            "invigorated-bulwark": {
               "amount": ""
             },
             "honorable-staff": {},
@@ -1353,14 +1353,14 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": ""
             },
             "power-of-the-virtuous": {}
           },
           {
-            "invigorating-bulwark": {
+            "invigorated-bulwark": {
               "amount": ""
             },
             "honorable-staff": {},
@@ -1416,14 +1416,14 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": ""
             },
             "power-of-the-virtuous": {}
           },
           {
-            "invigorating-bulwark": {
+            "invigorated-bulwark": {
               "amount": ""
             },
             "honorable-staff": {},
@@ -1550,7 +1550,7 @@ list:
             "inspired-virtue": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": "79"
             },
@@ -1640,7 +1640,7 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": ""
             },
@@ -1702,7 +1702,7 @@ list:
             "unscathed-contender": {
               "amount": ""
             },
-            "virtue-of-retribution": {},
+            "virtue-of-resolution": {},
             "inspiring-virtue": {
               "amount": ""
             },

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -3410,7 +3410,7 @@ list:
             }
           },
           {
-            "piercing-blades": {},
+            "piercing-shards": {},
             "flow-like-water": {
               "amount": ""
             },

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -5715,7 +5715,7 @@ list:
         ],
         "items": [
           {
-            "banshees-wail": {}
+            "life-from-death": {}
           },
           {
             "soul-barbs": {

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -1802,7 +1802,6 @@ list:
               "amount": "100"
             },
             "king-of-fires": {},
-            "eternal-champion": {},
             "smash-brawler-full": {}
           }
         ]
@@ -1879,7 +1878,6 @@ list:
               "amount": "100"
             },
             "king-of-fires": {},
-            "eternal-champion": {},
             "smash-brawler-full": {}
           }
         ]
@@ -1967,8 +1965,7 @@ list:
             "bloody-roar": {
               "amount": ""
             },
-            "king-of-fires": {},
-            "eternal-champion": {}
+            "king-of-fires": {}
           }
         ]
       }
@@ -2052,8 +2049,7 @@ list:
             "bloody-roar": {
               "amount": ""
             },
-            "king-of-fires": {},
-            "eternal-champion": {}
+            "king-of-fires": {}
           }
         ]
       }

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -3612,7 +3612,7 @@ list:
             "bountiful-hunter": {
               "amount": ""
             },
-            "instinctive-reaction": {},
+            "wellspring": {},
             "lingering-magic": {}
           },
           {
@@ -4008,7 +4008,7 @@ list:
             "bountiful-hunter": {
               "amount": ""
             },
-            "instinctive-reaction": {},
+            "wellspring": {},
             "lingering-magic": {}
           },
           {

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -1794,10 +1794,6 @@ list:
             "blood-reaction-with": {
               "amount": "100"
             },
-            "heat-the-soul": {},
-            "heat-the-soul-with": {
-              "amount": ""
-            },
             "fatal-frenzy-power-condi": {
               "amount": "100"
             },
@@ -1874,10 +1870,6 @@ list:
             "blood-reaction-base": {},
             "blood-reaction-with": {
               "amount": "100"
-            },
-            "heat-the-soul": {},
-            "heat-the-soul-with": {
-              "amount": ""
             },
             "fatal-frenzy-power-condi": {
               "amount": "100"
@@ -1968,10 +1960,6 @@ list:
             "blood-reaction-with": {
               "amount": ""
             },
-            "heat-the-soul": {},
-            "heat-the-soul-with": {
-              "amount": ""
-            },
             "fatal-frenzy-power-condi": {
               "amount": "72.7"
             },
@@ -2055,10 +2043,6 @@ list:
           {
             "blood-reaction-base": {},
             "blood-reaction-with": {
-              "amount": ""
-            },
-            "heat-the-soul": {},
-            "heat-the-soul-with": {
               "amount": ""
             },
             "fatal-frenzy-power-condi": {


### PR DESCRIPTION
Also some very persnickety renames for consistency

Of note are the removal of stats on Heat the Soul and Eternal Champion, causing the removal of both trait's modifier data. Next, there's the movement of the healing modifier from Banshee's Wail to Life from Death, a minor fix for the heal scourge template