### PR TITLE
Chore: Migrate from `buffer` to `Uint8Array`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,7 @@
     "@mui/icons-material": "^5.15.11",
     "@mui/material": "^5.15.11",
     "@reduxjs/toolkit": "^2.2.1",
-    "arraybuffer-equal": "^1.0.4",
     "axios": "^1.5.1",
-    "buffer": "^6.0.3",
     "classnames": "^2.3.1",
     "i18next": "^23.10.0",
     "js-yaml": "^4.1.0",
@@ -76,7 +74,7 @@
     "typeface-fira-mono": "^1.1.13",
     "typeface-muli": "^1.1.13",
     "typeface-raleway": "^1.1.13",
-    "urlsafe-base64": "^1.0.0"
+    "uint8array-extras": "^1.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,15 +38,9 @@ dependencies:
   '@reduxjs/toolkit':
     specifier: ^2.2.1
     version: 2.2.1(react-redux@9.1.0)(react@18.2.0)
-  arraybuffer-equal:
-    specifier: ^1.0.4
-    version: 1.0.4
   axios:
     specifier: ^1.5.1
     version: 1.6.7
-  buffer:
-    specifier: ^6.0.3
-    version: 6.0.3
   classnames:
     specifier: ^2.3.1
     version: 2.5.1
@@ -104,9 +98,9 @@ dependencies:
   typeface-raleway:
     specifier: ^1.1.13
     version: 1.1.13
-  urlsafe-base64:
-    specifier: ^1.0.0
-    version: 1.0.0
+  uint8array-extras:
+    specifier: ^1.1.0
+    version: 1.1.0
 
 devDependencies:
   '@babel/cli':
@@ -2263,10 +2257,6 @@ packages:
       es-shim-unscopables: 1.0.2
     dev: true
 
-  /arraybuffer-equal@1.0.4:
-    resolution: {integrity: sha512-B/HbicKd82qtq5NiNShqx6oAhHkYi+VFREUyHo9qdjyEwQDLL626XM80M88Pvr2TC7roUX3UsVALGvNIqeqc1g==}
-    dev: false
-
   /arraybuffer.prototype.slice@1.0.3:
     resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
@@ -2363,10 +2353,6 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
-  /base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: false
-
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -2429,13 +2415,6 @@ packages:
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
     dev: true
-
-  /buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: false
 
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -3556,10 +3535,6 @@ packages:
     resolution: {integrity: sha512-/TgHOqsa7/9abUKJjdPeydoyDc0oTi/7u9F8lMSj6ufg4cbC1Oj3f/Jja7zj7WRIhEQKB7Q4eN6y68I9RDxxGQ==}
     dependencies:
       '@babel/runtime': 7.24.0
-
-  /ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-    dev: false
 
   /ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
@@ -5109,6 +5084,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
+
+  /uint8array-extras@1.1.0:
+    resolution: {integrity: sha512-CVaBSyOmGoFHu+zOVPbetXEXykOd8KHVBHLlqvmaMWpwcq3rewj18xVNbU5uzf48hclnNQhfNaNany2cMHFK/g==}
+    engines: {node: '>=18'}
+    dev: false
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}


### PR DESCRIPTION
As well-described in [Sindre Sorhus' post here](https://sindresorhus.com/blog/goodbye-nodejs-buffer), node's `buffer` is basically just a weird `Uint8Array`. We're using some dependencies in the short link generation cloudflare function that expect `buffer`s and also aren't typed. This uses the `uint8array-extras` package instead.