### PR TITLE
Feat: Default to subtracting lifesteal in template creation tool

### DIFF
--- a/src/components/sections/results/TemplateHelper.jsx
+++ b/src/components/sections/results/TemplateHelper.jsx
@@ -118,7 +118,7 @@ const TemplateHelper = ({ character }) => {
           const nonConditionDataSection = nonConditionDataEntries.length
             ? [
                 '   -- lifesteal effects must be subtracted from power DPS! --',
-                '      (not automated; not all of these are lifesteal)',
+                '      (not all of these are lifesteal; double check this!)',
                 '\n',
                 [`Power DPS raw`, powerDPS],
                 ...nonConditionDataEntries,
@@ -243,7 +243,7 @@ const TemplateHelper = ({ character }) => {
             })
             .join('\n');
 
-          setInput({ Power: powerDPS, Power2: 0, ...conditionData });
+          setInput({ Power: powerDPSWithoutLifesteal, Power2: 0, ...conditionData });
           setUrlResult(resultAreaText);
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
The template-from-log tool tries to subtract lifesteal effects, but it doesn't do it automatically since it's not totally accurate. This is an additional manual step and it's more often than not correct, so I figure I may as well enable it by default; in the case where people double check their result they'll catch anything wrong either way and in the case where they don't this is more likely to be correct. Also yay less busywork.

@hobinjk pinging for visibility!

[no previews]