### PR TITLE
Feat: Enable source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "prettier": "^3.2.5",
+    "rollup-preserve-directives": "^1.1.1",
     "tsx": "^4.7.2",
     "typescript": "^5.4.5",
     "typia": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ devDependencies:
   prettier:
     specifier: ^3.2.5
     version: 3.2.5
+  rollup-preserve-directives:
+    specifier: ^1.1.1
+    version: 1.1.1(rollup@4.16.1)
   tsx:
     specifier: ^4.7.2
     version: 4.7.2
@@ -5265,6 +5268,15 @@ packages:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
       estree-walker: 0.6.1
+    dev: true
+
+  /rollup-preserve-directives@1.1.1(rollup@4.16.1):
+    resolution: {integrity: sha512-+eQafbuEfDPfxQ9hQPlwaROfin4yiVRxap8hnrvvvcSGoukv1tTiYpAW9mvm3uR8J+fe4xd8FdVd5rz9q7jZ+Q==}
+    peerDependencies:
+      rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
+    dependencies:
+      magic-string: 0.30.5
+      rollup: 4.16.1
     dev: true
 
   /rollup@4.16.1:

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
+import preserveDirectives from 'rollup-preserve-directives';
 import { defineConfig } from 'vite';
 import { comlink } from 'vite-plugin-comlink';
 import wasm from 'vite-plugin-wasm';
@@ -17,6 +18,7 @@ export default defineConfig({
         main: resolve(__dirname, 'index.html'),
         build: resolve(__dirname, 'build/index.html'),
       },
+      plugins: [preserveDirectives()],
     },
     target: 'es2020',
     sourcemap: true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
       },
     },
     target: 'es2020',
+    sourcemap: true,
   },
   plugins: [comlink(), react(), yamlImporter(), wasm()],
   worker: {


### PR DESCRIPTION
Enables source map creation in production, allowing console output to link to real code instead of obfuscated code. This project is open source anyway, so there's really no reason not to.

Due to the linked bug, this causes a bunch of (seemingly harmless) error messages during build. The workaround included works fine but I have no idea what it does; don't love that.

[draft previews]