### PR TITLE
Feat: Faster calc when in background; improve perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@reduxjs/toolkit": "^2.2.3",
     "axios": "^1.6.8",
     "classnames": "^2.3.1",
+    "comlink": "^4.4.1",
     "i18next": "^23.11.2",
     "js-yaml": "^4.1.0",
     "json-url": "^3.0.0",
@@ -66,6 +67,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.13",
+    "react-fast-compare": "^3.2.2",
     "react-i18next": "^14.1.0",
     "react-redux": "^9.1.1",
     "redux": "^5.0.1",
@@ -112,6 +114,7 @@
     "typescript": "^5.4.5",
     "typia": "^6.0.3",
     "vite": "^5.2.10",
+    "vite-plugin-comlink": "^4.0.3",
     "vite-plugin-wasm": "^3.3.0",
     "wasm-pack": "^0.12.1",
     "wrangler": "^3.51.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   classnames:
     specifier: ^2.3.1
     version: 2.5.1
+  comlink:
+    specifier: ^4.4.1
+    version: 4.4.1
   i18next:
     specifier: ^23.11.2
     version: 23.11.2
@@ -71,6 +74,9 @@ dependencies:
   react-error-boundary:
     specifier: ^4.0.13
     version: 4.0.13(react@18.2.0)
+  react-fast-compare:
+    specifier: ^3.2.2
+    version: 3.2.2
   react-i18next:
     specifier: ^14.1.0
     version: 14.1.0(i18next@23.11.2)(react-dom@18.2.0)(react@18.2.0)
@@ -205,6 +211,9 @@ devDependencies:
   vite:
     specifier: ^5.2.10
     version: 5.2.10(@types/node@20.12.7)
+  vite-plugin-comlink:
+    specifier: ^4.0.3
+    version: 4.0.3(comlink@4.4.1)(vite@5.2.10)
   vite-plugin-wasm:
     specifier: ^3.3.0
     version: 3.3.0(vite@5.2.10)
@@ -2836,6 +2845,9 @@ packages:
       delayed-stream: 1.0.0
     dev: false
 
+  /comlink@4.4.1:
+    resolution: {integrity: sha512-+1dlx0aY5Jo1vHy/tSsIGpSkN4tS9rZSW8FIhG0JH/crs9wwweswIo/POr451r7bZww3hFbPAKnTpimzL/mm4Q==}
+
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -4547,6 +4559,13 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
@@ -5005,6 +5024,10 @@ packages:
       react: 18.2.0
     dev: false
 
+  /react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+    dev: false
+
   /react-i18next@14.1.0(i18next@23.11.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-3KwX6LHpbvGQ+sBEntjV4sYW3Zovjjl3fpoHbUwSgFHf0uRBcbeCBLR5al6ikncI5+W0EFb71QXZmfop+J6NrQ==}
     peerDependencies:
@@ -5429,6 +5452,11 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map@0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
     dev: true
 
   /sourcemap-codec@1.4.8:
@@ -5884,6 +5912,19 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  /vite-plugin-comlink@4.0.3(comlink@4.4.1)(vite@5.2.10):
+    resolution: {integrity: sha512-CJVVd4h6YkeIxXEbRTbkvlbDwAHa1eOSl20AtNux9jd9aPe3AVKkYSxyTjGI9331Rg3wzAYsCUBSsnWHl1Ph0g==}
+    peerDependencies:
+      comlink: ^4.3.1
+      vite: '>=2.9.6'
+    dependencies:
+      comlink: 4.4.1
+      json5: 2.2.3
+      magic-string: 0.30.5
+      source-map: 0.7.4
+      vite: 5.2.10(@types/node@20.12.7)
+    dev: true
 
   /vite-plugin-wasm@3.3.0(vite@5.2.10):
     resolution: {integrity: sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==}

--- a/src/components/sections/results/table/ResultTable.jsx
+++ b/src/components/sections/results/table/ResultTable.jsx
@@ -222,7 +222,7 @@ const StickyHeadTable = () => {
                   <ResultTableRow
                     character={character}
                     key={character.id}
-                    selected={character === selectedCharacter}
+                    selected={character.id === selectedCharacter?.id}
                     saved={saved.includes(character)}
                     mostCommonAffix={mostCommonAffix}
                     mostCommonRarity={mostCommonRarity}
@@ -274,7 +274,7 @@ const StickyHeadTable = () => {
                       <ResultTableRow
                         character={character}
                         key={character.id}
-                        selected={character === selectedCharacter}
+                        selected={character.id === selectedCharacter?.id}
                         saved={saved.includes(character)}
                         mostCommonAffix={mostCommonAffix}
                         mostCommonRarity={mostCommonRarity}

--- a/src/components/sections/results/table/ResultTable.jsx
+++ b/src/components/sections/results/table/ResultTable.jsx
@@ -12,10 +12,9 @@ import { makeStyles } from 'tss-react/mui';
 import {
   getCompareByPercent,
   getDisplayAttributes,
-  getFilteredList,
   getFilterMode,
+  getFilteredLists,
   getList,
-  getExtraFilteredLists,
   getSaved,
   getSelectedCharacter,
   getTallTable,
@@ -81,8 +80,7 @@ const StickyHeadTable = () => {
   const { t } = useTranslation();
   const selectedCharacter = useSelector(getSelectedCharacter);
   const normalList = useSelector(getList);
-  const filteredList = useSelector(getFilteredList);
-  const extraFilteredLists = useSelector(getExtraFilteredLists);
+  const filteredLists = useSelector(getFilteredLists);
   const saved = useSelector(getSaved) || emptyArray;
   const compareByPercent = useSelector(getCompareByPercent);
   const filterMode = useSelector(getFilterMode);
@@ -90,8 +88,7 @@ const StickyHeadTable = () => {
 
   const list = {
     None: normalList,
-    Combinations: filteredList,
-    ...extraFilteredLists,
+    ...filteredLists,
   }[filterMode];
 
   let mostCommonAffix = null;

--- a/src/components/sections/results/table/ResultTable.jsx
+++ b/src/components/sections/results/table/ResultTable.jsx
@@ -15,6 +15,7 @@ import {
   getFilteredList,
   getFilterMode,
   getList,
+  getExtraFilteredLists,
   getSaved,
   getSelectedCharacter,
   getTallTable,
@@ -79,43 +80,19 @@ const StickyHeadTable = () => {
 
   const { t } = useTranslation();
   const selectedCharacter = useSelector(getSelectedCharacter);
-  const normalList = useSelector(getList) || emptyArray;
-  const rawFilteredList = useSelector(getFilteredList) || emptyArray;
+  const normalList = useSelector(getList);
+  const filteredList = useSelector(getFilteredList);
+  const extraFilteredLists = useSelector(getExtraFilteredLists);
   const saved = useSelector(getSaved) || emptyArray;
   const compareByPercent = useSelector(getCompareByPercent);
   const filterMode = useSelector(getFilterMode);
   const tallTable = useSelector(getTallTable);
 
-  const list = React.useMemo(() => {
-    if (filterMode === 'None') {
-      return normalList;
-    }
-    if (filterMode === 'Combinations') {
-      return rawFilteredList;
-    }
-    if (filterMode === 'Sigils') {
-      return rawFilteredList.filter((character, i) => {
-        const isWorse = rawFilteredList.slice(0, i).some((prevChar) => {
-          const sameSigils =
-            prevChar.settings.extrasCombination.Sigil1 ===
-              character.settings.extrasCombination.Sigil1 &&
-            prevChar.settings.extrasCombination.Sigil2 ===
-              character.settings.extrasCombination.Sigil2;
-          return sameSigils && prevChar.results.value > character.results.value;
-        });
-        return !isWorse;
-      });
-    }
-    return rawFilteredList.filter((character, i) => {
-      const isWorse = rawFilteredList.slice(0, i).some((prevChar) => {
-        const sameExtra =
-          prevChar.settings.extrasCombination[filterMode] ===
-          character.settings.extrasCombination[filterMode];
-        return sameExtra && prevChar.results.value > character.results.value;
-      });
-      return !isWorse;
-    });
-  }, [filterMode, normalList, rawFilteredList]);
+  const list = {
+    None: normalList,
+    Combinations: filteredList,
+    ...extraFilteredLists,
+  }[filterMode];
 
   let mostCommonAffix = null;
   let mostCommonRarity = null;

--- a/src/components/sections/results/table/ResultTable.jsx
+++ b/src/components/sections/results/table/ResultTable.jsx
@@ -91,7 +91,7 @@ const StickyHeadTable = () => {
       return normalList;
     }
     if (filterMode === 'Combinations') {
-      return rawFilteredList.slice(0, 100);
+      return rawFilteredList;
     }
     if (filterMode === 'Sigils') {
       return rawFilteredList.filter((character, i) => {

--- a/src/components/sections/results/table/ResultTableRow.jsx
+++ b/src/components/sections/results/table/ResultTableRow.jsx
@@ -4,6 +4,7 @@ import { Typography } from '@mui/material';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import React from 'react';
+import isEqual from 'react-fast-compare';
 import { useDispatch } from 'react-redux';
 import { allExtrasModifiersById, placeholderItem } from '../../../../assets/modifierdata';
 import { percents } from '../../../../assets/modifierdata/metadata';
@@ -152,4 +153,4 @@ const ResultTableRow = ({
   );
 };
 
-export default React.memo(ResultTableRow);
+export default React.memo(ResultTableRow, isEqual);

--- a/src/state/optimizer-parallel/calculate.ts
+++ b/src/state/optimizer-parallel/calculate.ts
@@ -1,5 +1,6 @@
 import { RUNNING } from '../optimizer/status';
 import {
+  changeExtraFilteredLists,
   changeFilteredList,
   changeList,
   changeProgress,
@@ -26,6 +27,15 @@ export default function calculate(reduxState: RootState, dispatch: AppDispatch):
   dispatch(changeStatus(RUNNING));
   dispatch(changeList([]));
   dispatch(changeFilteredList([]));
+  dispatch(
+    changeExtraFilteredLists({
+      Sigils: [],
+      Runes: [],
+      Relics: [],
+      Nourishment: [],
+      Enhancement: [],
+    }),
+  );
   dispatch(changeProgress(0));
   dispatch(changeSelectedCharacter(null));
 

--- a/src/state/optimizer-parallel/calculate.ts
+++ b/src/state/optimizer-parallel/calculate.ts
@@ -1,7 +1,6 @@
 import { RUNNING } from '../optimizer/status';
 import {
-  changeExtraFilteredLists,
-  changeFilteredList,
+  changeFilteredLists,
   changeList,
   changeProgress,
   changeSelectedCharacter,
@@ -26,9 +25,9 @@ export default function calculate(reduxState: RootState, dispatch: AppDispatch):
 
   dispatch(changeStatus(RUNNING));
   dispatch(changeList([]));
-  dispatch(changeFilteredList([]));
   dispatch(
-    changeExtraFilteredLists({
+    changeFilteredLists({
+      Combinations: [],
       Sigils: [],
       Runes: [],
       Relics: [],

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -14,8 +14,6 @@ const isArrayDifferent = (a: any[], b: any[]) => {
   return a.some((_, i) => a[i] !== b[i]);
 };
 
-// todo: convert this file to a web worker handler
-
 interface Combination extends ExtrasCombinationEntry {
   settings: OptimizerCoreSettings;
   core: OptimizerCore;

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -26,15 +26,13 @@ type Result =
       percent: number;
       isChanged: true;
       list: Character[];
-      filteredList: Character[];
-      extraFilteredLists: Record<ExtraFilterMode, Character[]>;
+      filteredLists: Record<ExtraFilterMode, Character[]>;
     }
   | {
       percent: number;
       isChanged: false;
       list: undefined;
-      filteredList: undefined;
-      extraFilteredLists: undefined;
+      filteredLists: undefined;
     };
 
 function* calculate(reduxState: RootState) {
@@ -116,8 +114,6 @@ function* calculate(reduxState: RootState) {
         .filter(Boolean)
         .sort((a, b) => characterLT(a, b, rankby));
 
-      const filteredList = combinationBestResults.slice(0, 100);
-
       const findExtraBestResults = (...extrasTypes: ExtrasType[]) => {
         const result: Character[] = [];
         combinationBestResults.forEach((character) => {
@@ -135,7 +131,8 @@ function* calculate(reduxState: RootState) {
         return result;
       };
 
-      const extraFilteredLists: Record<ExtraFilterMode, Character[]> = {
+      const filteredLists: Record<ExtraFilterMode, Character[]> = {
+        Combinations: combinationBestResults.slice(0, 100),
         Sigils: findExtraBestResults('Sigil1', 'Sigil2'),
         Runes: findExtraBestResults('Runes'),
         Relics: findExtraBestResults('Relics'),
@@ -147,8 +144,7 @@ function* calculate(reduxState: RootState) {
         percent: Math.floor((globalCalculationRuns * 100) / globalCalculationTotal),
         isChanged,
         list: normalList,
-        filteredList,
-        extraFilteredLists,
+        filteredLists,
       } as Result;
     };
 

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -102,9 +102,10 @@ export function* calculate(reduxState: RootState) {
 
       const filteredList = combinationBestResults.slice(0, 100);
 
-      const findExtraBestResults = (...extrasTypes: ExtrasType[]) =>
-        combinationBestResults.filter((character, j) => {
-          const isWorse = combinationBestResults.slice(0, j).some((prevChar) => {
+      const findExtraBestResults = (...extrasTypes: ExtrasType[]) => {
+        const result: Character[] = [];
+        combinationBestResults.forEach((character) => {
+          const isWorse = result.some((prevChar) => {
             const sameExtra = extrasTypes.every(
               (extra) =>
                 prevChar.settings.extrasCombination[extra] ===
@@ -113,8 +114,10 @@ export function* calculate(reduxState: RootState) {
 
             return sameExtra && prevChar.results!.value > character.results!.value;
           });
-          return !isWorse;
+          if (!isWorse) result.push(character);
         });
+        return result;
+      };
 
       const extraFilteredLists: Record<ExtraFilterMode, Character[]> = {
         Sigils: findExtraBestResults('Sigil1', 'Sigil2'),

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -5,6 +5,7 @@ import {
   characterLT,
   OptimizerCore,
   OptimizerCoreSettings,
+  UPDATE_MS,
 } from './optimizerCore';
 import { ExtrasCombinationEntry, setupCombinations } from './optimizerSetup';
 
@@ -58,6 +59,8 @@ export function* calculate(reduxState: RootState) {
   let globalFilteredList: Character[] = [];
 
   let globalWorstScore = 0;
+
+  let iterationTimer = Date.now();
 
   while (true) {
     const combination = combinations[i];
@@ -117,7 +120,10 @@ export function* calculate(reduxState: RootState) {
     };
 
     if (combinations.some((comb) => !comb.done)) {
-      yield result;
+      if (Date.now() - iterationTimer > UPDATE_MS / 2) {
+        yield result;
+        iterationTimer = Date.now();
+      }
     } else {
       return result;
     }

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -81,10 +81,7 @@ export function* calculate(reduxState: RootState) {
       combination.list = newList;
     }
 
-    if (
-      everyCombinationDone ||
-      (isChanged && newList && Date.now() - iterationTimer > UPDATE_MS / 2)
-    ) {
+    if (everyCombinationDone || (isChanged && newList && Date.now() - iterationTimer > UPDATE_MS)) {
       const normalList = combinations
         .flatMap(({ list }) => list)
         // eslint-disable-next-line no-loop-func

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -37,8 +37,7 @@ type Result =
       extraFilteredLists: undefined;
     };
 
-// eslint-disable-next-line import/prefer-default-export
-export function* calculate(reduxState: RootState) {
+function* calculate(reduxState: RootState) {
   /**
    * set up input
    */
@@ -163,3 +162,10 @@ export function* calculate(reduxState: RootState) {
     }
   }
 }
+
+let generator: ReturnType<typeof calculate>;
+
+export const setup = (reduxState: RootState) => {
+  generator = calculate(reduxState);
+};
+export const next = () => generator.next();

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -94,7 +94,8 @@ export function* calculate(reduxState: RootState) {
       const newGlobalFilteredList = combinations
         .map(({ list }) => list[0])
         .filter(Boolean)
-        .sort((a, b) => characterLT(a, b, rankby));
+        .sort((a, b) => characterLT(a, b, rankby))
+        .slice(0, 100);
 
       if (isArrayDifferent(globalFilteredList, newGlobalFilteredList)) {
         globalFilteredList = newGlobalFilteredList;

--- a/src/state/optimizer/optimizerCore.ts
+++ b/src/state/optimizer/optimizerCore.ts
@@ -193,6 +193,8 @@ export type AttributeName = string; // TODO: replace with AttributeName from gw2
 
 export type CalculateGenerator = ReturnType<OptimizerCore['calculate']>;
 
+export const UPDATE_MS = 90;
+
 export class OptimizerCore {
   settings: OptimizerCoreSettings;
   minimalSettings: OptimizerCoreMinimalSettings;
@@ -269,13 +271,12 @@ export class OptimizerCore {
     calculationStatsQueue.push({});
 
     let iterationTimer = Date.now();
-    const UPDATE_MS = 90;
     let cycles = 0;
     this.isChanged = true;
     while (calculationQueue.length > 0) {
       cycles++;
 
-      // pause to update UI at around 15 frames per second
+      // pause to update UI
       if (cycles % 1000 === 0 && Date.now() - iterationTimer > UPDATE_MS) {
         yield {
           isChanged: this.isChanged,
@@ -283,7 +284,6 @@ export class OptimizerCore {
           newList: this.isChanged ? this.list.slice() : null,
         };
         this.isChanged = false;
-        // UPDATE_MS = 55;
         iterationTimer = Date.now();
       }
 

--- a/src/state/optimizer/optimizerCore.ts
+++ b/src/state/optimizer/optimizerCore.ts
@@ -281,7 +281,7 @@ export class OptimizerCore {
         yield {
           isChanged: this.isChanged,
           calculationRuns,
-          newList: this.isChanged ? this.list.slice() : null,
+          newList: this.list,
         };
         this.isChanged = false;
         iterationTimer = Date.now();
@@ -354,7 +354,7 @@ export class OptimizerCore {
     return {
       isChanged: this.isChanged,
       calculationRuns,
-      newList: this.isChanged ? this.list.slice() : null,
+      newList: this.list,
     };
   }
 

--- a/src/state/optimizer/worker.ts
+++ b/src/state/optimizer/worker.ts
@@ -1,0 +1,9 @@
+import { calculate } from './optimizer';
+import type { RootState } from '../store';
+
+let resultGenerator: ReturnType<typeof calculate>;
+
+export const setup = (reduxState: RootState) => {
+  resultGenerator = calculate(reduxState);
+};
+export const next = () => resultGenerator.next();

--- a/src/state/optimizer/worker.ts
+++ b/src/state/optimizer/worker.ts
@@ -1,9 +1,0 @@
-import { calculate } from './optimizer';
-import type { RootState } from '../store';
-
-let resultGenerator: ReturnType<typeof calculate>;
-
-export const setup = (reduxState: RootState) => {
-  resultGenerator = calculate(reduxState);
-};
-export const next = () => resultGenerator.next();

--- a/src/state/sagas/calculationSaga.ts
+++ b/src/state/sagas/calculationSaga.ts
@@ -28,8 +28,8 @@ function* runCalc() {
   const state = reduxState.optimizer;
 
   let currentList: Character[] = [];
-  let currentFilteredList: Character[] = [];
-  let currentExtrasFilteredLists: Record<ExtraFilterMode, Character[]> = {
+  let currentFilteredLists: Record<ExtraFilterMode, Character[]> = {
+    Combinations: [],
     Sigils: [],
     Runes: [],
     Relics: [],
@@ -54,26 +54,23 @@ function* runCalc() {
       // eslint-disable-next-line no-loop-func
       const result = yield* call(() => nextPromise);
 
-      const { percent, isChanged, list, filteredList, extraFilteredLists } = result.value;
+      const { percent, isChanged, list, filteredLists } = result.value;
       currentPercent = percent;
 
       if (isChanged) {
         // shallow freeze as a performance optimization; immer freezes recursively instead by default
         freeze(list, false);
-        freeze(filteredList, false);
-        freeze(currentExtrasFilteredLists, false);
+        freeze(filteredLists, false);
 
         currentList = list;
-        currentFilteredList = filteredList;
-        currentExtrasFilteredLists = extraFilteredLists;
+        currentFilteredLists = filteredLists;
       }
 
       if (result.done) {
         yield* put(
           updateResults({
             list: currentList,
-            filteredList: currentFilteredList,
-            extraFilteredLists: currentExtrasFilteredLists,
+            filteredLists: currentFilteredLists,
             progress: currentPercent,
           }),
         );
@@ -86,8 +83,7 @@ function* runCalc() {
       yield* put(
         updateResults({
           list: currentList,
-          filteredList: currentFilteredList,
-          extraFilteredLists: currentExtrasFilteredLists,
+          filteredLists: currentFilteredLists,
           progress: currentPercent,
         }),
       );

--- a/src/state/sagas/calculationSaga.ts
+++ b/src/state/sagas/calculationSaga.ts
@@ -16,8 +16,8 @@ import {
 import type { RootState } from '../store';
 import SagaTypes from './sagaTypes';
 
-const resultGenerator = new ComlinkWorker<typeof import('../optimizer/worker')>(
-  new URL('../optimizer/worker.ts', import.meta.url),
+const worker = new ComlinkWorker<typeof import('../optimizer/optimizer')>(
+  new URL('../optimizer/optimizer.ts', import.meta.url),
   {
     type: 'module',
   },
@@ -46,9 +46,9 @@ function* runCalc() {
     let elapsed = 0;
     let timer = performance.now();
 
-    yield resultGenerator.setup(reduxState);
+    yield worker.setup(reduxState);
 
-    let nextPromise = resultGenerator.next();
+    let nextPromise = worker.next();
 
     while (true) {
       // eslint-disable-next-line no-loop-func
@@ -69,7 +69,7 @@ function* runCalc() {
 
       if (!result.done) {
         // concurrency: send next request to worker thread before rendering current on main thread
-        nextPromise = resultGenerator.next();
+        nextPromise = worker.next();
       }
 
       yield* put(

--- a/src/state/sagas/calculationSaga.ts
+++ b/src/state/sagas/calculationSaga.ts
@@ -55,6 +55,8 @@ function* runCalc() {
       const result = yield* call(() => nextPromise);
 
       const { percent, isChanged, list, filteredList, extraFilteredLists } = result.value;
+      currentPercent = percent;
+
       if (isChanged) {
         // shallow freeze as a performance optimization; immer freezes recursively instead by default
         freeze(list, false);
@@ -64,7 +66,6 @@ function* runCalc() {
         currentList = list;
         currentFilteredList = filteredList;
         currentExtrasFilteredLists = extraFilteredLists;
-        currentPercent = percent;
       }
 
       if (!result.done) {

--- a/src/state/sagas/calculationSaga.ts
+++ b/src/state/sagas/calculationSaga.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { freeze } from '@reduxjs/toolkit';
 import { call, put, select, take, takeEvery, takeLatest } from 'typed-redux-saga';
 import type { Character } from '../optimizer/optimizerCore';
 import { ERROR, RUNNING, STOPPED, SUCCESS, WAITING } from '../optimizer/status';
@@ -63,6 +64,9 @@ function* runCalc() {
       currentPercent = percent;
 
       if (isChanged) {
+        // shallow freeze as a performance optimization; immer freezes recursively instead by default
+        freeze(list, false);
+        freeze(filteredList, false);
         yield* put(
           updateResults({
             list: currentList,

--- a/src/state/sagas/calculationSaga.ts
+++ b/src/state/sagas/calculationSaga.ts
@@ -68,10 +68,20 @@ function* runCalc() {
         currentExtrasFilteredLists = extraFilteredLists;
       }
 
-      if (!result.done) {
-        // concurrency: send next request to worker thread before rendering current on main thread
-        nextPromise = worker.next();
+      if (result.done) {
+        yield* put(
+          updateResults({
+            list: currentList,
+            filteredList: currentFilteredList,
+            extraFilteredLists: currentExtrasFilteredLists,
+            progress: currentPercent,
+          }),
+        );
+        break;
       }
+
+      // concurrency: send next request to worker thread before rendering current on main thread
+      nextPromise = worker.next();
 
       yield* put(
         updateResults({
@@ -81,10 +91,6 @@ function* runCalc() {
           progress: currentPercent,
         }),
       );
-
-      if (result.done) {
-        break;
-      }
 
       // check if calculation stopped
       const status = yield* select(getStatus);

--- a/src/state/sagas/calculationSaga.ts
+++ b/src/state/sagas/calculationSaga.ts
@@ -16,11 +16,6 @@ import {
 import type { RootState } from '../store';
 import SagaTypes from './sagaTypes';
 
-const delay = (ms: number) =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-
 const resultGenerator = new ComlinkWorker<typeof import('../optimizer/worker')>(
   new URL('../optimizer/worker.ts', import.meta.url),
   {
@@ -82,8 +77,6 @@ function* runCalc() {
           }),
         );
       }
-
-      yield delay(0);
 
       // check if calculation stopped
       const status = yield* select(getStatus);

--- a/src/state/slices/controlsSlice.ts
+++ b/src/state/slices/controlsSlice.ts
@@ -70,14 +70,19 @@ export type FilterMode =
   | 'Nourishment'
   | 'Enhancement';
 
-export type ExtraFilterMode = 'Sigils' | 'Runes' | 'Relics' | 'Nourishment' | 'Enhancement';
+export type ExtraFilterMode =
+  | 'Combinations'
+  | 'Sigils'
+  | 'Runes'
+  | 'Relics'
+  | 'Nourishment'
+  | 'Enhancement';
 
 type DisplayAttributes = ('Toughness' | 'Boon Duration' | 'Health' | 'Critical Chance')[];
 
 const initialState: {
   list: Character[];
-  filteredList: Character[];
-  extraFilteredLists: Record<ExtraFilterMode, Character[]>;
+  filteredLists: Record<ExtraFilterMode, Character[]>;
   saved: Character[];
   compareByPercent: boolean;
   tallTable: boolean;
@@ -95,8 +100,8 @@ const initialState: {
   error: string;
 } = {
   list: [],
-  filteredList: [],
-  extraFilteredLists: {
+  filteredLists: {
+    Combinations: [],
     Sigils: [],
     Runes: [],
     Relics: [],
@@ -168,29 +173,21 @@ export const controlSlice = createSlice({
 
       return { ...state, list: newList.slice(0, 100) };
     },
-    changeFilteredList: (state, action: PayloadAction<Character[]>) => {
-      return { ...state, filteredList: action.payload };
-    },
-    changeExtraFilteredLists: (
-      state,
-      action: PayloadAction<Record<ExtraFilterMode, Character[]>>,
-    ) => {
+    changeFilteredLists: (state, action: PayloadAction<Record<ExtraFilterMode, Character[]>>) => {
       return { ...state, ...action.payload };
     },
     updateResults: (
       state,
       action: PayloadAction<{
         list?: Character[];
-        filteredList?: Character[];
-        extraFilteredLists?: Record<ExtraFilterMode, Character[]>;
+        filteredLists?: Record<ExtraFilterMode, Character[]>;
         progress: number;
       }>,
     ) => {
-      const { list, filteredList, extraFilteredLists, progress } = action.payload;
+      const { list, filteredLists, progress } = action.payload;
       state.progress = progress;
       if (list) state.list = list;
-      if (filteredList) state.filteredList = filteredList;
-      if (extraFilteredLists) state.extraFilteredLists = extraFilteredLists;
+      if (filteredLists) state.filteredLists = filteredLists;
     },
     toggleSaved: (state, action: PayloadAction<Character>) => {
       // required to use reference equality check with immer.js
@@ -244,9 +241,7 @@ export const getSelectedSpecialization = (state: RootState) =>
   state.optimizer.control.selectedSpecialization;
 export const getStatus = (state: RootState) => state.optimizer.control.status;
 export const getList = (state: RootState) => state.optimizer.control.list;
-export const getFilteredList = (state: RootState) => state.optimizer.control.filteredList;
-export const getExtraFilteredLists = (state: RootState) =>
-  state.optimizer.control.extraFilteredLists;
+export const getFilteredLists = (state: RootState) => state.optimizer.control.filteredLists;
 export const getSaved = (state: RootState) => state.optimizer.control.saved;
 export const getCompareByPercent = (state: RootState) => state.optimizer.control.compareByPercent;
 export const getFilterMode = (state: RootState) => state.optimizer.control.filterMode;
@@ -267,8 +262,7 @@ export const {
   changeStatus,
   changeProgress,
   changeList,
-  changeFilteredList,
-  changeExtraFilteredLists,
+  changeFilteredLists,
   updateResults,
   changeFilterMode,
   changeDisplayAttributes,

--- a/src/state/slices/controlsSlice.ts
+++ b/src/state/slices/controlsSlice.ts
@@ -61,7 +61,7 @@ const logAttributeDiff = (newCharacter: Character | null, oldCharacter: Characte
   }
 };
 
-type FilterMode =
+export type FilterMode =
   | 'None'
   | 'Combinations'
   | 'Sigils'
@@ -70,11 +70,14 @@ type FilterMode =
   | 'Nourishment'
   | 'Enhancement';
 
+export type ExtraFilterMode = 'Sigils' | 'Runes' | 'Relics' | 'Nourishment' | 'Enhancement';
+
 type DisplayAttributes = ('Toughness' | 'Boon Duration' | 'Health' | 'Critical Chance')[];
 
 const initialState: {
   list: Character[];
   filteredList: Character[];
+  extraFilteredLists: Record<ExtraFilterMode, Character[]>;
   saved: Character[];
   compareByPercent: boolean;
   tallTable: boolean;
@@ -93,6 +96,13 @@ const initialState: {
 } = {
   list: [],
   filteredList: [],
+  extraFilteredLists: {
+    Sigils: [],
+    Runes: [],
+    Relics: [],
+    Nourishment: [],
+    Enhancement: [],
+  },
   saved: [],
   compareByPercent: false,
   tallTable: false,
@@ -161,18 +171,26 @@ export const controlSlice = createSlice({
     changeFilteredList: (state, action: PayloadAction<Character[]>) => {
       return { ...state, filteredList: action.payload };
     },
+    changeExtraFilteredLists: (
+      state,
+      action: PayloadAction<Record<ExtraFilterMode, Character[]>>,
+    ) => {
+      return { ...state, ...action.payload };
+    },
     updateResults: (
       state,
       action: PayloadAction<{
         list?: Character[];
         filteredList?: Character[];
+        extraFilteredLists?: Record<ExtraFilterMode, Character[]>;
         progress: number;
       }>,
     ) => {
-      const { list, filteredList, progress } = action.payload;
+      const { list, filteredList, extraFilteredLists, progress } = action.payload;
       state.progress = progress;
       if (list) state.list = list;
       if (filteredList) state.filteredList = filteredList;
+      if (extraFilteredLists) state.extraFilteredLists = extraFilteredLists;
     },
     toggleSaved: (state, action: PayloadAction<Character>) => {
       // required to use reference equality check with immer.js
@@ -227,6 +245,8 @@ export const getSelectedSpecialization = (state: RootState) =>
 export const getStatus = (state: RootState) => state.optimizer.control.status;
 export const getList = (state: RootState) => state.optimizer.control.list;
 export const getFilteredList = (state: RootState) => state.optimizer.control.filteredList;
+export const getExtraFilteredLists = (state: RootState) =>
+  state.optimizer.control.extraFilteredLists;
 export const getSaved = (state: RootState) => state.optimizer.control.saved;
 export const getCompareByPercent = (state: RootState) => state.optimizer.control.compareByPercent;
 export const getFilterMode = (state: RootState) => state.optimizer.control.filterMode;
@@ -248,6 +268,7 @@ export const {
   changeProgress,
   changeList,
   changeFilteredList,
+  changeExtraFilteredLists,
   updateResults,
   changeFilterMode,
   changeDisplayAttributes,

--- a/src/state/slices/extras.ts
+++ b/src/state/slices/extras.ts
@@ -25,7 +25,7 @@ export const lifestealData = {
 interface ExtraValue {
   amount?: string;
 }
-type ExtrasType = 'Sigil1' | 'Sigil2' | 'Runes' | 'Relics' | 'Nourishment' | 'Enhancement';
+export type ExtrasType = 'Sigil1' | 'Sigil2' | 'Runes' | 'Relics' | 'Nourishment' | 'Enhancement';
 
 // todo: specify extras keys
 type ExtrasValues = Record<string, ExtraValue>;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-comlink/client" />

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
+import { comlink } from 'vite-plugin-comlink';
 import wasm from 'vite-plugin-wasm';
 import yamlImporter from './plugins/YAMLImporter';
 
@@ -19,9 +20,9 @@ export default defineConfig({
     },
     target: 'es2020',
   },
-  plugins: [react(), yamlImporter(), wasm()],
+  plugins: [comlink(), react(), yamlImporter(), wasm()],
   worker: {
     format: 'iife',
-    plugins: () => [yamlImporter(), wasm()],
+    plugins: () => [comlink(), yamlImporter(), wasm()],
   },
 });


### PR DESCRIPTION
There's a longstanding annoyance where optimizer browser tabs that weren't currently visible onscreen would be throttled by the browser to calculate at tiny fractions of full speed. Browsers only do this when you run expensive math on the main rendering thread, which you aren't supposed to do (I had put a lot of work into carefully doing it so it wouldn't freeze the page, but still).

This enables full-speed background calculation by moving the "regular" mode's calculation to a worker thread where it should be using vite-plugin-comlink, and removes some hard-to-read code that was used to mitigate the performance impact of not having done that.

This is also a slight performance gain, as rendering UI updates doesn't interrupt calculation anymore, but it was already optimized fairly well so the gain is minimal in most cases. Edge cases like locking every gear slot and selecting many extras are significantly improved due to included fixes, though.

The drawback of this from the internals side is that sending the same javascript object from a worker context makes a new copy each time (e.g. as if they were serialized to JSON and back), making duplicates that take up more memory/must be garbage collected and can't be compared via reference equality. This doesn't have a significant performance impact and it would take a lot of code to avoid it; a few comparison tweaks and a single deep equality check in `ResultTableRow`'s useMemo mitigate any performance impact.

(None of this applies to the experimental multithreaded Rust code, of course, which was already using worker threads.)
