### PR TITLE
Install `eslint-plugin-react-perf`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es6": true,
     "jquery": true
   },
-  "plugins": ["@typescript-eslint", "@jambit/eslint-plugin-typed-redux-saga"],
+  "plugins": ["@typescript-eslint", "@jambit/eslint-plugin-typed-redux-saga", "react-perf"],
   "extends": [
     "airbnb/whitespace",
     "airbnb/hooks",
@@ -91,7 +91,12 @@
     "@typescript-eslint/no-inferrable-types": "off",
     // We want to enable these eventually
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off"
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+
+    "react-perf/jsx-no-new-object-as-prop": ["warn", { "nativeAllowList": "all" }],
+    "react-perf/jsx-no-new-array-as-prop": ["warn", { "nativeAllowList": "all" }],
+    "react-perf/jsx-no-new-function-as-prop": ["warn", { "nativeAllowList": "all" }],
+    "react-perf/jsx-no-jsx-as-prop": ["warn", { "nativeAllowList": "all" }]
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1 <6.8.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-react-perf": "^3.3.2",
     "prettier": "^3.2.5",
     "rollup-preserve-directives": "^1.1.1",
     "tsx": "^4.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ devDependencies:
   eslint-plugin-react-hooks:
     specifier: ^4.3.0
     version: 4.6.0(eslint@8.57.0)
+  eslint-plugin-react-perf:
+    specifier: ^3.3.2
+    version: 3.3.2(eslint@8.57.0)
   prettier:
     specifier: ^3.2.5
     version: 3.2.5
@@ -3539,6 +3542,15 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    dependencies:
+      eslint: 8.57.0
+    dev: true
+
+  /eslint-plugin-react-perf@3.3.2(eslint@8.57.0):
+    resolution: {integrity: sha512-boVn4IDHAjgGoAuAQ5Zrewt8fNbMDdiR7B2AkuiSK8lrJ9FwlOZc085kCs7+8u6B+YZ+pOn+tYG00xktnGAfOw==}
+    engines: {node: '>=6.9.1'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       eslint: 8.57.0
     dev: true


### PR DESCRIPTION
From my github recommended repos (yes, really), I stumbled upon an eslint plugin that ensures that you don't pass nonstable props to react components, which breaks react memoization. This, of course, is only a performance improvement if your UI updates very frequently, you have wrapped your components in React.memo(), and and said components' parents are not always being successfully memoized, conditions which are not true across most of this app.

This, therefore, highlights a ton of changes one could make, at a significant time investment, 90+% of which would in practice be pointless. So, nope. Profile-then-optimize, not the other way around!

As an example, this object and function "should" be moved outside of any components so they are not recreated anew every time a table row is rendered, which we should care about as results are updated frequently in real time:

https://github.com/discretize/discretize-gear-optimizer/blob/e953cd03b9b20578f5f73d16611d3f6412cebaa1/src/components/sections/results/table/ResultTableRow.jsx#L58-L78

But react-fast-compare ensures that table rows will not be rerendered during the calculation at all:

https://github.com/discretize/discretize-gear-optimizer/blob/e953cd03b9b20578f5f73d16611d3f6412cebaa1/src/components/sections/results/table/ResultTableRow.jsx#L7

https://github.com/discretize/discretize-gear-optimizer/blob/e953cd03b9b20578f5f73d16611d3f6412cebaa1/src/components/sections/results/table/ResultTableRow.jsx#L171

This would thus only be a performance improvement when the user clicks a result. And that's if the `StarRoundedIcon` MUI component was memoized or if React implements automatic memoization, which they're apparently considering someday possibly maybe. 