### PR TITLE
Data: Split some traits

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -912,6 +912,7 @@
   "traitSubText_be careful not to overcap": "be careful not to overcap",
   "traitSubText_below": "below",
   "traitSubText_bonus": "bonus",
+  "traitSubText_buff": "buff",
   "traitSubText_bug: converted like 360 vitality": "bug: converted like 360 vitality",
   "traitSubText_bugged 10% chill mod": "bugged 10% chill mod",
   "traitSubText_clone": "clone",

--- a/src/assets/modifierdata/engineer.yaml
+++ b/src/assets/modifierdata/engineer.yaml
@@ -160,16 +160,26 @@
 
     - id: thermal-vision
       text: Thermal Vision
+      subText: base
       modifiers:
-        damage:
-          Outgoing Condition Damage: [5%, add]
         attributes:
           Expertise: [150, converted]
       wvwModifiers:
-        damage:
-          Outgoing Condition Damage: [5%, add]
         attributes:
           Expertise: [60, converted]
+      gw2id: 2006
+      defaultEnabled: true
+
+    - id: thermal-vision-buff
+      text: Thermal Vision
+      subText: buff
+      amountData:
+        label: '% uptime'
+        default: 100
+        quantityEntered: 100
+      modifiers:
+        damage:
+          Outgoing Condition Damage: [5%, add]
       gw2id: 2006
       defaultEnabled: true
 

--- a/src/assets/modifierdata/mesmer.yaml
+++ b/src/assets/modifierdata/mesmer.yaml
@@ -395,16 +395,22 @@
 
     - id: quiet-intensity
       text: Quiet Intensity
-      subText: 100% fury
+      subText: base
       minor: true
       modifiers:
         conversion:
           Ferocity: {Vitality: 10%}
+      gw2id: 2193
+      defaultEnabled: true
+
+    - id: quiet-intensity-fury
+      text: Quiet Intensity
+      subText: 100% fury
+      minor: true
+      modifiers:
         attributes:
           Critical Chance: 15%
       wvwModifiers:
-        conversion:
-          Ferocity: {Vitality: 10%}
         attributes:
           Critical Chance: 10%
       gw2id: 2193

--- a/src/assets/modifierdata/thief.yaml
+++ b/src/assets/modifierdata/thief.yaml
@@ -136,14 +136,24 @@
 
     - id: keen-observer
       text: Keen Observer
+      subText: base
+      minor: true
+      modifiers:
+        attributes:
+          Critical Chance: 10%
+      wvwModifiers:
+        attributes:
+          Critical Chance: 5%
+      gw2id: 1281
+      defaultEnabled: true
+
+    - id: keen-observer-scholar
+      text: Keen Observer
       subText: high health
       minor: true
       modifiers:
         attributes:
-          Critical Chance: 15%
-      wvwModifiers:
-        attributes:
-          Critical Chance: 10%
+          Critical Chance: 5%
       gw2id: 1281
       defaultEnabled: true
 

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -6051,6 +6051,7 @@ list:
           },
           {
             "keen-observer": {},
+            "keen-observer-scholar": {},
             "twin-fangs-scholar": {},
             "twin-fangs-flank": {},
             "practiced-tolerance": {},
@@ -6335,6 +6336,7 @@ list:
           },
           {
             "keen-observer": {},
+            "keen-observer-scholar": {},
             "twin-fangs-scholar": {},
             "twin-fangs-flank": {},
             "practiced-tolerance": {},
@@ -6415,6 +6417,7 @@ list:
           },
           {
             "keen-observer": {},
+            "keen-observer-scholar": {},
             "twin-fangs-scholar": {},
             "twin-fangs-flank": {},
             "practiced-tolerance": {},
@@ -6494,6 +6497,7 @@ list:
           },
           {
             "keen-observer": {},
+            "keen-observer-scholar": {},
             "twin-fangs-scholar": {},
             "twin-fangs-flank": {},
             "practiced-tolerance": {},
@@ -6573,6 +6577,7 @@ list:
           },
           {
             "keen-observer": {},
+            "keen-observer-scholar": {},
             "twin-fangs-scholar": {},
             "twin-fangs-flank": {},
             "practiced-tolerance": {},

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -4649,6 +4649,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },
@@ -4719,6 +4720,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },
@@ -4789,6 +4791,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },
@@ -4859,6 +4862,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },
@@ -4927,6 +4931,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {},
             "serrated-steel": {},
             "modified-ammunition": {
@@ -4993,6 +4998,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },
@@ -5059,6 +5065,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },
@@ -5125,6 +5132,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },
@@ -5200,6 +5208,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },
@@ -5275,6 +5284,7 @@ list:
             "high-caliber": {},
             "hematic-focus": {},
             "thermal-vision": {},
+            "thermal-vision-buff": {},
             "no-scope": {
               "amount": ""
             },

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -521,6 +521,7 @@ list:
             },
             "sharpening-sorrow": {},
             "quiet-intensity": {},
+            "quiet-intensity-fury": {},
             "bloodsong": {},
             "jagged-mind": {
               "amount": "6.04"
@@ -591,6 +592,7 @@ list:
             },
             "sharpening-sorrow": {},
             "quiet-intensity": {},
+            "quiet-intensity-fury": {},
             "bloodsong": {},
             "jagged-mind": {
               "amount": "5.86"
@@ -667,6 +669,7 @@ list:
             },
             "sharpening-sorrow": {},
             "quiet-intensity": {},
+            "quiet-intensity-fury": {},
             "bloodsong": {}
           }
         ]


### PR DESCRIPTION
Splits up a few trait modifiers where the trait has a base effect and a conditional effect, and both effects were combined into one checkbox/modifier.

Important for #726, and also just nice for clarity/so that people can (I guess?) simulate builds without fury or whatever.

[no previews]