### PR TITLE
Feat Save and show critical damage including mods

### DIFF
--- a/src/state/optimizer/optimizerCore.ts
+++ b/src/state/optimizer/optimizerCore.ts
@@ -738,10 +738,11 @@ export class OptimizerCore {
     const { settings } = this;
     const { attributes } = character;
 
-    const critDmg = attributes['Critical Damage'] * damageMultiplier['Outgoing Critical Damage'];
+    attributes['Critical Damage'] *= damageMultiplier['Outgoing Critical Damage'];
     const critChance = clamp(attributes['Critical Chance'], 0, 1);
 
-    attributes['Effective Power'] = attributes['Power'] * (1 + critChance * (critDmg - 1));
+    attributes['Effective Power'] =
+      attributes['Power'] * (1 + critChance * (attributes['Critical Damage'] - 1));
 
     // 2597: standard enemy armor value, also used for ingame damage tooltips
     let powerDamage =
@@ -756,13 +757,13 @@ export class OptimizerCore {
 
     if (attributes['Power2 Coefficient']) {
       if (settings.profession === 'Mesmer') {
-        const phantasmCritDmg =
-          attributes['Phantasm Critical Damage'] *
+        attributes['Phantasm Critical Damage'] *=
           damageMultiplier['Outgoing Phantasm Critical Damage'];
         const phantasmCritChance = clamp(attributes['Phantasm Critical Chance'], 0, 1);
 
         attributes['Phantasm Effective Power'] =
-          attributes['Power'] * (1 + phantasmCritChance * (phantasmCritDmg - 1));
+          attributes['Power'] *
+          (1 + phantasmCritChance * (attributes['Phantasm Critical Damage'] - 1));
 
         const phantasmPowerDamage =
           ((attributes['Power2 Coefficient'] || 0) / 2597) *
@@ -771,13 +772,13 @@ export class OptimizerCore {
         attributes['Power2 DPS'] = phantasmPowerDamage;
         powerDamage += phantasmPowerDamage;
       } else {
-        const alternativeCritDmg =
-          attributes['Alternative Critical Damage'] *
+        attributes['Alternative Critical Damage'] *=
           damageMultiplier['Outgoing Alternative Critical Damage'];
         const alternativeCritChance = clamp(attributes['Alternative Critical Chance'], 0, 1);
 
         attributes['Alternative Effective Power'] =
-          attributes['Alternative Power'] * (1 + alternativeCritChance * (alternativeCritDmg - 1));
+          attributes['Alternative Power'] *
+          (1 + alternativeCritChance * (attributes['Alternative Critical Damage'] - 1));
 
         const alternativePowerDamage =
           ((attributes['Power2 Coefficient'] || 0) / 2597) *

--- a/wasm_module/src/optimizer_core.rs
+++ b/wasm_module/src/optimizer_core.rs
@@ -433,13 +433,17 @@ pub fn calc_power(
     let attributes = &mut character.attributes;
     let mods = &combination.modifiers;
 
-    let crit_dmg = attributes.get_a(Attribute::CriticalDamage)
-        * mods.get_dmg_multiplier(Attribute::OutgoingCriticalDamage);
+    attributes.set_a(
+        Attribute::CriticalDamage,
+        attributes.get_a(Attribute::CriticalDamage)
+            * mods.get_dmg_multiplier(Attribute::OutgoingCriticalDamage),
+    );
     let crit_chance = clamp(attributes.get_a(Attribute::CriticalChance), 0.0, 1.0);
 
     attributes.set_a(
         Attribute::EffectivePower,
-        attributes.get_a(Attribute::Power) * (1.0 + crit_chance * (crit_dmg - 1.0)),
+        attributes.get_a(Attribute::Power)
+            * (1.0 + crit_chance * (attributes.get_a(Attribute::CriticalDamage) - 1.0)),
     );
 
     // 2597: standard enemy armor value, also used for ingame damage tooltips
@@ -455,8 +459,11 @@ pub fn calc_power(
     if attributes.get_a(Attribute::Power2Coefficient) > 0.0 {
         // do stuff
         if settings.profession.eq("Mesmer") {
-            let phantasm_crit_dmg = attributes.get_a(Attribute::PhantasmCriticalDamage)
-                * mods.get_dmg_multiplier(Attribute::OutgoingPhantasmCriticalDamage);
+            attributes.set_a(
+                Attribute::PhantasmCriticalDamage,
+                attributes.get_a(Attribute::PhantasmCriticalDamage)
+                    * mods.get_dmg_multiplier(Attribute::OutgoingPhantasmCriticalDamage),
+            );
             let phantasm_crit_chance = clamp(
                 attributes.get_a(Attribute::PhantasmCriticalChance),
                 0.0,
@@ -466,7 +473,9 @@ pub fn calc_power(
             attributes.set_a(
                 Attribute::PhantasmEffectivePower,
                 attributes.get_a(Attribute::Power)
-                    * (1.0 + phantasm_crit_chance * (phantasm_crit_dmg - 1.0)),
+                    * (1.0
+                        + phantasm_crit_chance
+                            * (attributes.get_a(Attribute::PhantasmCriticalDamage) - 1.0)),
             );
 
             let phantasm_power_damage = (attributes.get_a(Attribute::Power2Coefficient) / 2597.0)
@@ -475,14 +484,18 @@ pub fn calc_power(
             attributes.set_a(Attribute::Power2DPS, phantasm_power_damage);
             power_damage += phantasm_power_damage;
         } else {
-            let alt_crit_dmg = attributes.get_a(Attribute::AltCriticalDamage)
-                * mods.get_dmg_multiplier(Attribute::OutgoingAltCriticalDamage);
+            attributes.set_a(
+                Attribute::AltCriticalDamage,
+                attributes.get_a(Attribute::AltCriticalDamage)
+                    * mods.get_dmg_multiplier(Attribute::OutgoingAltCriticalDamage),
+            );
             let alt_crit_chance = clamp(attributes.get_a(Attribute::AltCriticalChance), 0.0, 1.0);
 
             attributes.set_a(
                 Attribute::AltEffectivePower,
                 attributes.get_a(Attribute::AltPower)
-                    * (1.0 + alt_crit_chance * (alt_crit_dmg - 1.0)),
+                    * (1.0
+                        + alt_crit_chance * (attributes.get_a(Attribute::AltCriticalDamage) - 1.0)),
             );
 
             let alt_power_damage = (attributes.get_a(Attribute::Power2Coefficient) / 2597.0)


### PR DESCRIPTION
Changes the storage and display of "critical damage" values to include +outgoing critical damage modifiers.

Resolves #479.

Notably, this will result in character data generated for the main discretize site before and and after this change to have different critical damage values in some cases. This change is technically a further departure from the ingame hero panel... but in most cases it didn't match anyway, due to things like averaging out fencer's finesse stacks.

[no previews]