### PR TITLE
Feat: Simulate unbuffed hero panel attributes

### DIFF
--- a/docs/Contributing/Data Format/Modifiers.md
+++ b/docs/Contributing/Data Format/Modifiers.md
@@ -307,3 +307,21 @@ Specifies if this effect's checkbox should be checked when the user selects the 
 #### hasLifesteal (optional; food only)
 
 Specifies if this food effect should add lifesteal equal to the "lifesteal frequency" box in the UI.
+
+#### temporaryBuff
+
+Used for unbuffed, out-of-combat hero panel simulation. Required unless the item has no `attributes`, `conversion` or `conversionAfterBuffs` fields (and thus it can't affect the hero panel).
+
+- `true`: This effect is temporary; exclude it from the out-of-combat hero panel simulation. (Alternatively: this effect is never shown in the hero panel; exclude it from the out-of-combat hero panel simulation.)
+- `false`: Always include this effect.
+- `'activeOutOfCombat'`: This effect is temporary, but it reasonably would or could be active at character idle (e.g. utility writs, signet passive effects, "when wielding a rifle" conditional effects). Include this effect in the the out-of-combat hero panel simulation, ignoring its `amountData` field.
+
+This `activeOutOfCombat` implementation errs on the side of **including** both "when wielding a two-handed weapon" and "when wielding a one-handed weapon" buffs on e.g. dragonhunter, both "when in air attunement" and "when in fire attunement" on elementalist, etc. This can be inaccurate to the ingame hero panel. **Excluding** all of those effects would, of course, also be inaccurate to the ingame hero panel in some cases.
+
+We can come up with standard rules for this in some cases for more consistency, but it will never be perfect (a condi ranger could plausibly have any combination of axe, torch, and dagger; good luck).
+
+Currently used rules:
+
+- Elementalist: assume the user is in fire attunement, not air (arbitrary, but seems common)
+- Guardian: assume the user is on a dual-wield set (simulates better than the reverse if it's a full dual-wield build; a greatsword-only or staff-only build is less likely)
+- Warrior: assume the user is on a dual-wield set (simulates better than the reverse if it's a full dual-wield build; a greatsword-only build is less likely)

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -130,7 +130,6 @@ const testModifiers = async () => {
           hasLifesteal,
           displayIds,
           priceIds,
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           temporaryBuff,
           ...otherKeys
         } = item;
@@ -302,6 +301,19 @@ const testModifiers = async () => {
             parseConversionAfterBuffs(conversionAfterBuffs, id, amountData);
           }
         });
+
+        if (modifiers.attributes || modifiers.conversion || modifiers.conversionAfterBuffs) {
+          gentleAssert(
+            [true, false, 'activeOutOfCombat'].includes(temporaryBuff),
+            `err: ${id}'s temporaryBuff value is not true, false, or activeOutOfCombat!`,
+          );
+        }
+
+        /*
+        if (temporaryBuff === false && amountData) {
+          console.log(`${id} is set to be permanent and has amount data; are you sure?`);
+        }
+        */
       }
     }
   }

--- a/src/components/sections/results/ResultCharacter.jsx
+++ b/src/components/sections/results/ResultCharacter.jsx
@@ -1,8 +1,12 @@
+/* eslint-disable react/no-unescaped-entities */
 import { Character, firstUppercase } from '@discretize/react-discretize-components';
-import { FormControlLabel, Switch } from '@mui/material';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { Box, FormControlLabel, Switch } from '@mui/material';
+import { useState } from 'react';
 import { allExtrasModifiersById } from '../../../assets/modifierdata';
 import { Classes, INFUSION_IDS, WeaponTypes, getWeight } from '../../../utils/gw2-data';
 import ErrorBoundary from '../../baseComponents/ErrorBoundary';
+import Info from '../../baseComponents/Info';
 
 const CustomSwitch = ({ onChange, label }) => (
   <FormControlLabel control={<Switch onChange={onChange} />} label={label} />
@@ -127,7 +131,7 @@ export default function ResultCharacter({
   }
 
   // Calculate armor props
-  const { gear, attributes } = character;
+  const { gear, attributes, results: { unbuffedAttributes } = {} } = character;
   const runeId = rune ? rune.gw2id : undefined;
   const armorPropsAPI = {
     weight: firstUppercase(weight),
@@ -190,10 +194,39 @@ export default function ResultCharacter({
 
   const relicId = allExtrasModifiersById[relics]?.gw2id;
 
+  const [showUnbuffed, setShowUnbuffed] = useState(false);
+
   return (
     <ErrorBoundary location="Character" resetKeys={[character]}>
+      {unbuffedAttributes && (
+        <>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showUnbuffed}
+                onChange={(e) => setShowUnbuffed(e.target.checked)}
+                name="checked"
+                color="primary"
+              />
+            }
+            label="Simulate Unbuffed Attributes"
+          />
+
+          {showUnbuffed && (
+            <Box sx={{ p: 1 }}>
+              <Info icon={<WarningAmberIcon />}>
+                Simulated unbuffed attributes are not exact and may not match ingame hero panel! For
+                example, soulbeast's "with axe" and "with torch/dagger" buffs are both included,
+                simulating a scenario which doesn't occur in either weapon set on some builds. Use
+                with caution.
+              </Info>
+            </Box>
+          )}
+        </>
+      )}
+
       <Character
-        attributes={{ profession, data: attributes }}
+        attributes={{ profession, data: (showUnbuffed && unbuffedAttributes) || attributes }}
         armor={armorPropsAPI}
         weapon={weaponPropsAPI}
         backAndTrinket={backAndTrinketPropsAPI}

--- a/src/components/sections/results/ResultCharacter.jsx
+++ b/src/components/sections/results/ResultCharacter.jsx
@@ -198,31 +198,34 @@ export default function ResultCharacter({
 
   return (
     <ErrorBoundary location="Character" resetKeys={[character]}>
-      {unbuffedAttributes && (
-        <>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={showUnbuffed}
-                onChange={(e) => setShowUnbuffed(e.target.checked)}
-                name="checked"
-                color="primary"
-              />
-            }
-            label="Simulate Unbuffed Attributes"
-          />
+      {unbuffedAttributes && showUnbuffed && (
+        <Box sx={{ p: 1 }}>
+          <Info icon={<WarningAmberIcon />}>
+            Simulated unbuffed attributes are not exact and may not match ingame hero panel! For
+            example, soulbeast's "with axe" and "with torch/dagger" buffs are both included,
+            simulating a scenario which doesn't occur in either weapon set on some builds. Use with
+            caution.
+          </Info>
+        </Box>
+      )}
 
-          {showUnbuffed && (
-            <Box sx={{ p: 1 }}>
-              <Info icon={<WarningAmberIcon />}>
-                Simulated unbuffed attributes are not exact and may not match ingame hero panel! For
-                example, soulbeast's "with axe" and "with torch/dagger" buffs are both included,
-                simulating a scenario which doesn't occur in either weapon set on some builds. Use
-                with caution.
-              </Info>
-            </Box>
-          )}
-        </>
+      {unbuffedAttributes && (
+        <FormControlLabel
+          sx={{
+            position: { sm: 'absolute' },
+            left: { sm: '50%' },
+            transform: { sm: 'translate(-50%)' },
+          }}
+          control={
+            <Switch
+              checked={showUnbuffed}
+              onChange={(e) => setShowUnbuffed(e.target.checked)}
+              name="checked"
+              color="primary"
+            />
+          }
+          label="Show Unbuffed"
+        />
       )}
 
       <Character


### PR DESCRIPTION
Implements a long-requested toggle to simulate character attributes when out of combat, so users can compare the ingame hero panel to the optimizer's. This is not, and cannot, be perfect (at least without more user input UI). Is a soulbeast player equipping an axe? A torch or dagger? Both? Neither? There's no way to know or assume in a way that would be consistent for every build.

On a best-effort basis, this assumes that an elementalist is in fire attunement (not air) and a power guardian or warrior isn't on their greatsword set; these are kind of arbitrary and the UI warning shouldn't commit to us keeping those kinds of things true as it's quite hard.

I don't know how to integrate this into the UI; not a big fan of what's committed here at all. Maybe an implementation within the `<Character>` component? That would allow the main site to have this toggle, which obviously a ton of people want. Help wanted there.

(Simulation changes and data fields for this feature were merged in #726 and are live.)

Notes:
- No build page support (would need schema v4)
- No unbuffed generation in Rust mode (probably not worth implementing in Rust)

[draft previews]