### PR TITLE
simplify "pinned" / "starred" language in UI

### DIFF
--- a/src/components/sections/results/SavedResultManager/SavedResultManager.jsx
+++ b/src/components/sections/results/SavedResultManager/SavedResultManager.jsx
@@ -215,7 +215,7 @@ export default function SavedResultManager({ isOpen, setOpen }) {
 
       <DialogContent sx={{ padding: 2 }} dividers>
         <Typography fontWeight={200}>
-          <Trans>Temporary saved builds</Trans>{' '}
+          <Trans>Current pinned builds</Trans>{' '}
           <HelperIcon
             text={t('These builds will be deleted after you leave or refresh this page.')}
             size="small"
@@ -343,7 +343,7 @@ export default function SavedResultManager({ isOpen, setOpen }) {
                       </IconButton>
                     </Tooltip>
 
-                    <Tooltip title={t('Copy build to temporary saved builds')}>
+                    <Tooltip title={t('Load as pinned build')}>
                       <IconButton onClick={handleCopyToTemporary(character)}>
                         <ArrowCircleUpIcon fontSize="small" />
                       </IconButton>

--- a/src/components/sections/results/table/ResultTable.jsx
+++ b/src/components/sections/results/table/ResultTable.jsx
@@ -1,5 +1,4 @@
-import { HelperIcon } from '@discretize/react-discretize-components';
-import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
+import SaveAsIcon from '@mui/icons-material/SaveAs';
 import { Box, IconButton, Typography } from '@mui/material';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -220,15 +219,11 @@ const StickyHeadTable = () => {
 
       <Box display="flex" alignItems="center" className={classes.tablehead}>
         <Typography flexGrow={1} ml={2} fontWeight={600} fontFamily="Raleway">
-          <Trans>Saved Results</Trans>{' '}
-          <HelperIcon
-            text={t('Click the star icon to save a result for comparison.')}
-            fontSize="1rem"
-          />
+          <Trans>Pinned Results</Trans>{' '}
         </Typography>
 
         <IconButton size="small" sx={{ margin: 1 }} onClick={() => setManagerOpen(true)}>
-          <ManageAccountsIcon />
+          <SaveAsIcon />
         </IconButton>
         <SavedResultManager isOpen={managerOpen} setOpen={setManagerOpen} />
       </Box>

--- a/src/components/sections/results/table/ResultTableHeaderRow.jsx
+++ b/src/components/sections/results/table/ResultTableHeaderRow.jsx
@@ -47,10 +47,7 @@ const ResultTableHeaderRow = ({
   return (
     <TableRow>
       <TableCell className={classes.tablehead} align="center" padding="none">
-        <HelperIcon
-          text={t('Click the star icon to save a result for comparison.')}
-          fontSize="1rem"
-        />
+        <HelperIcon text={t('Pin results for comparison between calculations.')} fontSize="1rem" />
       </TableCell>
       <TableCell className={classes.tablehead}>
         {t('priorityGoal', {

--- a/src/components/sections/results/table/ResultTableRow.jsx
+++ b/src/components/sections/results/table/ResultTableRow.jsx
@@ -1,6 +1,6 @@
 import { Item, Profession } from '@discretize/gw2-ui-new';
 import CloseIcon from '@mui/icons-material/Close';
-import StarRoundedIcon from '@mui/icons-material/StarRounded';
+import PushPinIcon from '@mui/icons-material/PushPin';
 import { Typography } from '@mui/material';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
@@ -82,17 +82,17 @@ const ResultTableRow = ({
             }}
           />
         ) : (
-          <StarRoundedIcon
+          <PushPinIcon
             sx={
               saved
                 ? {
-                    color: 'star',
+                    color: 'primary.main',
                   }
                 : {
                     opacity: '0.2',
                     '&:hover': {
                       opacity: '1',
-                      color: 'star',
+                      color: 'primary.main',
                     },
                   }
             }


### PR DESCRIPTION
The terminology of different kind of saved results gets a bit confusing in the local storage PR.

Here's an idea about how to make it clearer: we could always use "save" to refer to saving builds to local storage, and always refer to the temporary storage as "pinning" (a word that generally implies that something is being kept around for a particular purpose temporarily).

(On the other hand, I bet some people would prefer it if we didn't make a distinction at all and just persisted all starred builds to local storage. This would prevent people from losing results when they closed the page without manually going into the menu, but it would clutter the main UI—and screenshots of it—for power users with a lot of saved builds.)