### PR TITLE
Feat: Override extras tooltips when overriding names

### DIFF
--- a/src/assets/modifierdata/food.yaml
+++ b/src/assets/modifierdata/food.yaml
@@ -707,5 +707,6 @@
     - id: no-item-food
       text: No Item (doesn't give any stats)
       subText: No Item (doesn't give any stats)
+      textOverride: No Item (doesn't give any stats)
       modifiers: {}
       # gw2id intentionally omitted

--- a/src/assets/modifierdata/relics.yaml
+++ b/src/assets/modifierdata/relics.yaml
@@ -62,6 +62,7 @@
     - id: citadel-relic
       text: 'Relic of the Citadel: not yet implemented'
       subText: 'Relic of the Citadel: not yet implemented'
+      textOverride: 'Relic of the Citadel: not yet implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
@@ -157,6 +158,7 @@
     - id: peitha-relic
       text: 'Relic of Peitha: not yet implemented'
       subText: 'Relic of Peitha: not yet implemented'
+      textOverride: 'Relic of Peitha: not yet implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
@@ -235,12 +237,14 @@
     - id: sunless-relic
       text: 'Relic of the Sunless: not yet implemented'
       subText: 'Relic of the Sunless: not yet implemented'
+      textOverride: 'Relic of the Sunless: not yet implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
     - id: afflicted-relic
       text: 'Relic of the Afllicted: not yet implemented'
       subText: 'Relic of the Afllicted: not yet implemented'
+      textOverride: 'Relic of the Afllicted: not yet implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
@@ -329,18 +333,21 @@
     - id: midnight-king-relic
       text: 'Relic of the Midnight King: not implemented'
       subText: 'Relic of the Midnight King: not implemented'
+      textOverride: 'Relic of the Midnight King: not implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
     - id: pack-relic
       text: 'Relic of the Pack: not implemented'
       subText: 'Relic of the Pack: not implemented'
+      textOverride: 'Relic of the Pack: not implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
     - id: zephyrite-relic
       text: 'Relic of the Zephyrite: not implemented'
       subText: 'Relic of the Zephyrite: not implemented'
+      textOverride: 'Relic of the Zephyrite: not implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
@@ -362,30 +369,35 @@
     - id: karakosa-relic
       text: 'Relic of Karakosa: not implemented'
       subText: 'Relic of Karakosa: not implemented'
+      textOverride: 'Relic of Karakosa: not implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
     - id: flock-relic
       text: 'Relic of the Flock: not implemented'
       subText: 'Relic of the Flock: not implemented'
+      textOverride: 'Relic of the Flock: not implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
     - id: dwayna-relic
       text: 'Relic of Dwayna: not implemented'
       subText: 'Relic of Dwayna: not implemented'
+      textOverride: 'Relic of Dwayna: not implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
     - id: lyhr-relic
       text: 'Relic of Lyhr: not implemented'
       subText: 'Relic of Lyhr: not implemented'
+      textOverride: 'Relic of Lyhr: not implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
     - id: mercy-relic
       text: 'Relic of Mercy: not implemented'
       subText: 'Relic of Mercy: not implemented'
+      textOverride: 'Relic of Mercy: not implemented'
       modifiers: {}
       # gw2id intentionally omitted
 
@@ -395,5 +407,6 @@
     - id: no-item-relic
       text: No Item (doesn't give any stats)
       subText: No Item (doesn't give any stats)
+      textOverride: No Item (doesn't give any stats)
       modifiers: {}
       # gw2id intentionally omitted

--- a/src/assets/modifierdata/runes.yaml
+++ b/src/assets/modifierdata/runes.yaml
@@ -911,5 +911,6 @@
     - id: no-item-rune
       text: No Item (doesn't give any stats)
       subText: No Item (doesn't give any stats)
+      textOverride: No Item (doesn't give any stats)
       modifiers: {}
       # gw2id intentionally omitted

--- a/src/assets/modifierdata/sigils.yaml
+++ b/src/assets/modifierdata/sigils.yaml
@@ -594,5 +594,6 @@
     - id: no-item-sigil
       text: No Item (doesn't give any stats)
       subText: No Item (doesn't give any stats)
+      textOverride: No Item (doesn't give any stats)
       modifiers: {}
       # gw2id intentionally omitted

--- a/src/assets/modifierdata/utility.yaml
+++ b/src/assets/modifierdata/utility.yaml
@@ -361,5 +361,6 @@
     - id: no-item-utility
       text: No Item (doesn't give any stats)
       subText: No Item (doesn't give any stats)
+      textOverride: No Item (doesn't give any stats)
       modifiers: {}
       # gw2id intentionally omitted

--- a/src/components/sections/extras/ExtraSelection.jsx
+++ b/src/components/sections/extras/ExtraSelection.jsx
@@ -197,9 +197,16 @@ export default function ExtraSelection(props) {
                               <Item
                                 key={id ?? placeholderItem}
                                 id={id ?? placeholderItem}
-                                text={textOverride ?? formatApiText}
+                                text={formatApiText}
                                 disableText={!id}
-                                disableTooltip={!id}
+                                {...(textOverride
+                                  ? {
+                                      text: textOverride,
+                                      tooltipProps: {
+                                        content: textOverride,
+                                      },
+                                    }
+                                  : {})}
                               />
                             )),
                             ' / ',
@@ -207,9 +214,16 @@ export default function ExtraSelection(props) {
                         ) : (
                           <Item
                             id={gw2id ?? placeholderItem}
-                            text={textOverride ?? formatApiText}
+                            text={formatApiText}
                             disableText={!gw2id}
-                            disableTooltip={!gw2id}
+                            {...(textOverride
+                              ? {
+                                  text: textOverride,
+                                  tooltipProps: {
+                                    content: textOverride,
+                                  },
+                                }
+                              : {})}
                           />
                         )}
                       </Box>

--- a/src/components/sections/extras/ModalContent.jsx
+++ b/src/components/sections/extras/ModalContent.jsx
@@ -259,9 +259,16 @@ function ModalContent(props) {
                                       id={displayId ?? placeholderItem}
                                       key={displayId ?? placeholderItem}
                                       disableLink
-                                      text={textOverride ?? formatApiText}
+                                      text={formatApiText}
                                       disableText={!displayId}
-                                      disableTooltip={!displayId}
+                                      {...(textOverride
+                                        ? {
+                                            text: textOverride,
+                                            tooltipProps: {
+                                              content: textOverride,
+                                            },
+                                          }
+                                        : {})}
                                     />
                                   )),
                                   ' / ',
@@ -270,9 +277,16 @@ function ModalContent(props) {
                                 <Item
                                   id={gw2id ?? placeholderItem}
                                   disableLink
-                                  text={textOverride ?? formatApiText}
+                                  text={formatApiText}
                                   disableText={!gw2id}
-                                  disableTooltip={!gw2id}
+                                  {...(textOverride
+                                    ? {
+                                        text: textOverride,
+                                        tooltipProps: {
+                                          content: textOverride,
+                                        },
+                                      }
+                                    : {})}
                                 />
                               )}
                               {subText && (

--- a/src/components/sections/results/table/ResultTableRow.jsx
+++ b/src/components/sections/results/table/ResultTableRow.jsx
@@ -135,7 +135,7 @@ const ResultTableRow = ({
           .filter((type) => displayExtras[type])
           .map((key) => {
             const extra = character.settings.extrasCombination[key];
-            const id = allExtrasModifiersById[extra]?.gw2id;
+            const { gw2id: id, textOverride } = allExtrasModifiersById[extra] ?? {};
             return (
               <TableCell align="center" padding="none">
                 {extra ? (
@@ -143,7 +143,13 @@ const ResultTableRow = ({
                     id={id ?? placeholderItem}
                     disableText
                     disableLink
-                    disableTooltip={!id}
+                    {...(textOverride
+                      ? {
+                          tooltipProps: {
+                            content: textOverride,
+                          },
+                        }
+                      : {})}
                     style={{ fontSize: 23 }}
                   />
                 ) : null}


### PR DESCRIPTION
Currently we display things like "two sigils" using one of the sigils, which is kind of fine where we can override the text next to the icon, but can be confusing in the results table where there is no text and the non-overridden tooltip is the only thing visible (noticeable in #775).

I finally bothered to look at the gw2-ui `<Item />` API to (kind of) fix this and override the tooltips too.

This would be better as a simple property on `<Item />` letting the user override the tooltip with arbitrary text, or more preferably the generic "'blank sigil/rune' components using https://wiki.guildwars2.com/wiki/User:Soulblydd/Images" that I've wanted forever, but this will do for now.

[no previews]