### PR TITLE
chore: Use `cloudflare/wrangler-action` in deploy

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -71,6 +71,7 @@ jobs:
           apiToken: ${{ secrets.CI_CF_PAGES }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: pages deploy dist-cf --project-name=${{ env.PAGES_PROJECT_NAME }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Github Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -66,14 +66,11 @@ jobs:
         run: pnpm build-all
 
       - name: Deploy to Cloudflare
-        uses: cloudflare/pages-action@1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CI_CF_PAGES }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          projectName: ${{ env.PAGES_PROJECT_NAME }}
-          directory: dist-cf
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          wranglerVersion: '3'
+          command: pages deploy dist-cf --project-name=${{ env.PAGES_PROJECT_NAME }}
 
       - name: Setup Github Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/build-with-image.yml
+++ b/.github/workflows/build-with-image.yml
@@ -54,6 +54,7 @@ jobs:
           apiToken: ${{ secrets.CI_CF_PAGES }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: pages deploy dist-cf --project-name=${{ env.PAGES_PROJECT_NAME }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Github Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/build-with-image.yml
+++ b/.github/workflows/build-with-image.yml
@@ -49,14 +49,11 @@ jobs:
         run: pnpm build-all
 
       - name: Deploy to Cloudflare
-        uses: cloudflare/pages-action@1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CI_CF_PAGES }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          projectName: ${{ env.PAGES_PROJECT_NAME }}
-          directory: dist-cf
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          wranglerVersion: '3'
+          command: pages deploy dist-cf --project-name=${{ env.PAGES_PROJECT_NAME }}
 
       - name: Setup Github Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/previews-cf.yml
+++ b/.github/workflows/previews-cf.yml
@@ -94,6 +94,6 @@ jobs:
             | ----------------------- | - |
             | **Last commit:**        | ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }} |
             | **Preview URL**:        | ${{ steps.wrangler-action.outputs.deployment-url }} |
-            | **Branch Preview URL**: | https://${{ github.head_ref || github.ref_name }}.${{ env.PAGES_PROJECT_URL_SLUG }}.pages.dev |
+            | **Branch Preview URL**: | ${{ steps.wrangler-action.outputs.pages-deployment-alias-url }} |
           comment-tag: deployment
           mode: upsert

--- a/.github/workflows/previews-cf.yml
+++ b/.github/workflows/previews-cf.yml
@@ -76,27 +76,23 @@ jobs:
         run: pnpm build-cf
 
       - name: Deploy preview to Cloudflare
-        uses: cloudflare/pages-action@1
-        id: pages-action
+        uses: cloudflare/wrangler-action@v3
+        id: wrangler-action
         with:
           apiToken: ${{ secrets.CI_CF_PAGES }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          projectName: ${{ env.PAGES_PROJECT_NAME }}
-          directory: dist
-          branch: ${{ github.head_ref || github.ref_name }} 
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          wranglerVersion: '3'
+          command: pages deploy dist --project-name=${{ env.PAGES_PROJECT_NAME }} --branch=${{ github.head_ref || github.ref_name }}
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
-            Deployed ${{ steps.pages-action.outputs.environment }} build to Cloudflare!
+            Deployed build to Cloudflare!
 
             |                         |   |
             | ----------------------- | - |
             | **Last commit:**        | ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }} |
-            | **Preview URL**:        | ${{ steps.pages-action.outputs.url }} |
+            | **Preview URL**:        | ${{ steps.wrangler-action.outputs.deployment-url }} |
             | **Branch Preview URL**: | https://${{ github.head_ref || github.ref_name }}.${{ env.PAGES_PROJECT_URL_SLUG }}.pages.dev |
           comment-tag: deployment
           mode: upsert

--- a/.github/workflows/previews-cf.yml
+++ b/.github/workflows/previews-cf.yml
@@ -82,6 +82,7 @@ jobs:
           apiToken: ${{ secrets.CI_CF_PAGES }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: pages deploy dist --project-name=${{ env.PAGES_PROJECT_NAME }} --branch=${{ github.head_ref || github.ref_name }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v3


### PR DESCRIPTION
`cloudflare/pages-action` appears to be abandoned (without a note in the readme! I am not impressed by the state of your tooling, cloudflare!), so I think we'll eventually have to do this. `cloudflare/wrangler-action` currently does not create github deployments, to my knowledge, however, so I'm happy to wait.

See https://github.com/cloudflare/pages-action/issues/117 and https://github.com/cloudflare/wrangler-action/issues/274.

- [x] check if there are new/different action outputs to improve the PR comment

[draft previews]