### PR TITLE
Fix: Crash when selecting result during multicore calculation

### DIFF
--- a/src/state/optimizer-parallel/modes/normal.ts
+++ b/src/state/optimizer-parallel/modes/normal.ts
@@ -26,6 +26,8 @@ const PROGRESS_UPDATE_INTERVALL = 2000000;
 let currentProgress = 0;
 let results: Character[][] = [];
 
+let temp: Combination[] = [];
+
 function onMessage(
   e: MessageEvent<MessageType>,
   dispatch: AppDispatch,
@@ -74,7 +76,7 @@ function onMessage(
     const progress = Math.round((currentProgress / message.total) * 100);
     // dispatch as a percentage of total combinations
     console.log('Progress', currentProgress, '/', message.total, '=', progress, '%');
-    console.log('Results', message.results);
+    console.log('Raw Results', message.results);
     dispatch(changeProgress(progress));
 
     // only update the list for the first thread that sends an update
@@ -87,7 +89,7 @@ function onMessage(
             data: enhanceResults(
               message.results,
               settings,
-              message.combinations,
+              temp,
               getResultProperties(reduxState, resultData),
             ),
           }),
@@ -130,6 +132,7 @@ export default function runCalcNormal(
   maxThreads: number,
   withHeuristics: boolean,
 ) {
+  temp = combinations;
   const affixArray = settings?.affixesArray;
   if (!affixArray) {
     console.error('No affixes found');

--- a/src/state/optimizer-parallel/modes/normal.ts
+++ b/src/state/optimizer-parallel/modes/normal.ts
@@ -26,83 +26,6 @@ const PROGRESS_UPDATE_INTERVALL = 2000000;
 let currentProgress = 0;
 let results: Character[][] = [];
 
-let temp: Combination[] = [];
-
-function onMessage(
-  e: MessageEvent<MessageType>,
-  dispatch: AppDispatch,
-  index: number,
-  workers: WorkerWrapper[],
-  maxResults: number,
-  numThreads: number,
-  settings: Settings,
-  resultData: ResultData[],
-  reduxState: RootState,
-) {
-  let message = e.data;
-  if (typeof e.data === 'string') {
-    message = JSON.parse(e.data) as any;
-  }
-
-  if (isFinishMessage(message)) {
-    results.push(message.data);
-    workers[index].status = 'finished';
-
-    // check if all workers finished
-    if (workers.slice(0, numThreads).every(({ status }) => status === 'finished')) {
-      workers.forEach((workerObj) => {
-        workerObj.status = 'idle';
-      });
-      const sortedResults = results
-        .flat(1)
-        .sort((a, b) => b.attributes[b.settings.rankby] - a.attributes[a.settings.rankby])
-        .slice(0, maxResults);
-
-      console.log('All workers finished');
-      console.log('Results', sortedResults);
-
-      if (!dispatch) {
-        throw new Error('Dispatch not set');
-      }
-
-      dispatch(changeStatus(SUCCESS));
-      dispatch(changeList(sortedResults));
-      dispatch(changeSelectedCharacter(sortedResults[0]));
-    }
-  } else if (isProgressMessage(message)) {
-    currentProgress += message.new;
-
-    // eslint-disable-next-line no-case-declarations
-    const progress = Math.round((currentProgress / message.total) * 100);
-    // dispatch as a percentage of total combinations
-    console.log('Progress', currentProgress, '/', message.total, '=', progress, '%');
-    console.log('Raw Results', message.results);
-    dispatch(changeProgress(progress));
-
-    // only update the list for the first thread that sends an update
-    if (currentProgress % (numThreads * PROGRESS_UPDATE_INTERVALL) === 0) {
-      // update result table
-      if (message.results.length > 0)
-        dispatch(
-          addToList({
-            rankby: settings.rankby,
-            data: enhanceResults(
-              message.results,
-              settings,
-              temp,
-              getResultProperties(reduxState, resultData),
-            ),
-          }),
-        );
-    }
-  } else if (isErrorMessage(message)) {
-    console.error('Error', message.data);
-    dispatch(changeStatus(ERROR));
-  } else {
-    console.error('Unknown message', message);
-  }
-}
-
 /**
  * Performs the calculation in normal mode. This means that the calculation is split into chunks of work
  * based on the affix tree structure. Each chunk is then calculated by a separate thread.
@@ -132,7 +55,6 @@ export default function runCalcNormal(
   maxThreads: number,
   withHeuristics: boolean,
 ) {
-  temp = combinations;
   const affixArray = settings?.affixesArray;
   if (!affixArray) {
     console.error('No affixes found');
@@ -147,23 +69,78 @@ export default function runCalcNormal(
   const chunks = splitCombinations(affixcombinations, effectiveThreads);
 
   const maxResults = settings?.maxResults;
+
+  function onMessage(e: MessageEvent<MessageType>, index: number) {
+    let message = e.data;
+    if (typeof e.data === 'string') {
+      message = JSON.parse(e.data) as any;
+    }
+
+    if (isFinishMessage(message)) {
+      results.push(message.data);
+      workers[index].status = 'finished';
+
+      // check if all workers finished
+      if (workers.slice(0, effectiveThreads).every(({ status }) => status === 'finished')) {
+        workers.forEach((workerObj) => {
+          workerObj.status = 'idle';
+        });
+        const sortedResults = results
+          .flat(1)
+          .sort((a, b) => b.attributes[b.settings.rankby] - a.attributes[a.settings.rankby])
+          .slice(0, maxResults);
+
+        console.log('All workers finished');
+        console.log('Results', sortedResults);
+
+        if (!dispatch) {
+          throw new Error('Dispatch not set');
+        }
+
+        dispatch(changeStatus(SUCCESS));
+        dispatch(changeList(sortedResults));
+        dispatch(changeSelectedCharacter(sortedResults[0]));
+      }
+    } else if (isProgressMessage(message)) {
+      currentProgress += message.new;
+
+      // eslint-disable-next-line no-case-declarations
+      const progress = Math.round((currentProgress / message.total) * 100);
+      // dispatch as a percentage of total combinations
+      console.log('Progress', currentProgress, '/', message.total, '=', progress, '%');
+      console.log('Raw Results', message.results);
+      dispatch(changeProgress(progress));
+
+      // only update the list for the first thread that sends an update
+      if (currentProgress % (effectiveThreads * PROGRESS_UPDATE_INTERVALL) === 0) {
+        // update result table
+        if (message.results.length > 0)
+          dispatch(
+            addToList({
+              rankby: settings.rankby,
+              data: enhanceResults(
+                message.results,
+                settings,
+                combinations,
+                getResultProperties(reduxState, resultData),
+              ),
+            }),
+          );
+      }
+    } else if (isErrorMessage(message)) {
+      console.error('Error', message.data);
+      dispatch(changeStatus(ERROR));
+    } else {
+      console.error('Unknown message', message);
+    }
+  }
+
   // attach listener
   workers.forEach(({ worker }, index) => {
     if (index >= effectiveThreads) {
       return;
     }
-    worker.onmessage = (e: MessageEvent<MessageType>) =>
-      onMessage(
-        e,
-        dispatch,
-        index,
-        workers,
-        maxResults,
-        effectiveThreads,
-        settings,
-        resultData,
-        reduxState,
-      );
+    worker.onmessage = (e: MessageEvent<MessageType>) => onMessage(e, index);
   });
 
   currentProgress = 0;

--- a/src/state/optimizer-parallel/worker/workerMessageTypes.ts
+++ b/src/state/optimizer-parallel/worker/workerMessageTypes.ts
@@ -52,7 +52,6 @@ export interface ProgressMessage {
   new: number;
   total: number;
   results: Character[];
-  combinations: Combination[];
 }
 export interface ErrorMessage {
   type: typeof ERROR;

--- a/wasm_module/src/optimizer_core.rs
+++ b/wasm_module/src/optimizer_core.rs
@@ -10,7 +10,7 @@ use crate::{
     result::Result,
     utils::{clamp, get_random_affix_combination, get_total_combinations, round_even},
 };
-use std::{cell::RefCell, collections::HashMap};
+use std::cell::RefCell;
 use wasm_bindgen::JsValue;
 use web_sys::{console, DedicatedWorkerGlobalScope};
 
@@ -65,30 +65,12 @@ pub fn start(
             if *counter.borrow() % PROGRESS_UPDATE_INTERVALL == 0 {
                 result.on_complete(settings, combinations);
 
-                // get json value of best characters
-                let mut best_combinations: Vec<Combination> = vec![];
-                let mut combination_indices: HashMap<u32, usize> = HashMap::new();
-                let mut best_characters = result.best_characters.clone();
-
-                best_characters.iter_mut().for_each(|character| {
-                    let combination = combinations.get(character.combination_id as usize).unwrap();
-                    let current_id = character.combination_id;
-                    if let Some(comb_index) = combination_indices.get(&current_id) {
-                        character.combination_id = *comb_index as u32;
-                    } else {
-                        let comb_index = best_combinations.len();
-                        combination_indices.insert(current_id, comb_index);
-                        best_combinations.push(combination.clone());
-                        character.combination_id = comb_index as u32;
-                    }
-                });
-                let best_character_json = serde_json::to_string(&best_characters).unwrap();
-                let best_combinations_json = serde_json::to_string(&best_combinations).unwrap();
+                let best_character_json = serde_json::to_string(&result.best_characters).unwrap();
 
                 workerglobal.and_then(|w| {
                     w.post_message(&JsValue::from_str(&format!(
-                        "{{ \"type\": \"PROGRESS\", \"total\": {}, \"new\": {}, \"results\": {}, \"combinations\": {} }}",
-                        total_combinations, PROGRESS_UPDATE_INTERVALL,best_character_json, best_combinations_json
+                        "{{ \"type\": \"PROGRESS\", \"total\": {}, \"new\": {}, \"results\": {} }}",
+                        total_combinations, PROGRESS_UPDATE_INTERVALL, best_character_json,
                     )))
                     .ok()
                 });


### PR DESCRIPTION
Currently, during a multicore Rust mode calculation, the Rust module sends its list of Combination objects back to the main thread with each progress update, and `enhanceResults` is called using the rust-serialized Combination object. This, notably, isn't the same thing that happens when the final results are calculated, which simply references the Combination objects that have been on the Javascript side the whole time. The progress-mode code here causes the result character display to crash, since the Rust-side version of the Combination object excludes some data and we don't properly fix it in `enhanceResults`.

This PR removes the Rust-to-JS serialization and uses the same always-javascript Combination objects to run `enhanceResults` in progress mode as in finish mode.

Note that `character.combination_id` relies on the list of Combination objects being the same and being in a set order; that I can tell, this should still be true in heuristics mode since `runCalcHeuristics` just calls `runCalcNormal` with its list of favorite combinations, so we don't need special logic to figure out which combination is being referred to.