### PR TITLE
Feat: Implement stop button in multicore mode

### DIFF
--- a/src/components/nav/NavSettings.jsx
+++ b/src/components/nav/NavSettings.jsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
+import { stopCalculation } from '../../state/optimizer-parallel/calculate';
 import SagaTypes from '../../state/sagas/sagaTypes';
 import {
   changeHeuristics,
@@ -115,6 +116,13 @@ export default function NavSettings({
   };
 
   const changeMulticoreHandler = (e) => {
+    if (!enableMulticore) {
+      dispatch({ type: SagaTypes.Stop });
+    } else {
+      // workers.forEach(({ worker }) => worker.postMessage({ type: STOP }));
+      stopCalculation(dispatch);
+    }
+
     const newMulticore = e.target.checked;
     dispatch(changeMulticore(newMulticore));
   };

--- a/src/components/nav/NavSettings.jsx
+++ b/src/components/nav/NavSettings.jsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
-import { stopCalculation } from '../../state/optimizer-parallel/calculate';
+import { stopCalculationParallel } from '../../state/optimizer-parallel/calculate';
 import SagaTypes from '../../state/sagas/sagaTypes';
 import {
   changeHeuristics,
@@ -120,7 +120,7 @@ export default function NavSettings({
       dispatch({ type: SagaTypes.Stop });
     } else {
       // workers.forEach(({ worker }) => worker.postMessage({ type: STOP }));
-      stopCalculation(dispatch);
+      stopCalculationParallel(dispatch);
     }
 
     const newMulticore = e.target.checked;

--- a/src/components/sections/controls/Controls.jsx
+++ b/src/components/sections/controls/Controls.jsx
@@ -8,7 +8,10 @@ import { Box, Button, Chip, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector, useStore } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
-import calculate, { stopCalculation } from '../../../state/optimizer-parallel/calculate';
+import {
+  calculateParallel,
+  stopCalculationParallel,
+} from '../../../state/optimizer-parallel/calculate';
 import { ERROR, RUNNING, STOPPED, SUCCESS, WAITING } from '../../../state/optimizer/status';
 import SagaTypes from '../../../state/sagas/sagaTypes';
 import {
@@ -70,7 +73,7 @@ const ControlsBox = () => {
       dispatch(changeError(''));
       dispatch({ type: SagaTypes.Start });
     } else {
-      calculate(store.getState(), dispatch);
+      calculateParallel(store.getState(), dispatch);
     }
   };
 
@@ -88,7 +91,7 @@ const ControlsBox = () => {
       dispatch({ type: SagaTypes.Stop });
     } else {
       // workers.forEach(({ worker }) => worker.postMessage({ type: STOP }));
-      stopCalculation(dispatch);
+      stopCalculationParallel(dispatch);
     }
   };
 

--- a/src/components/sections/controls/Controls.jsx
+++ b/src/components/sections/controls/Controls.jsx
@@ -8,7 +8,7 @@ import { Box, Button, Chip, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector, useStore } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
-import calculate from '../../../state/optimizer-parallel/calculate';
+import calculate, { stopCalculation } from '../../../state/optimizer-parallel/calculate';
 import { ERROR, RUNNING, STOPPED, SUCCESS, WAITING } from '../../../state/optimizer/status';
 import SagaTypes from '../../../state/sagas/sagaTypes';
 import {
@@ -78,7 +78,7 @@ const ControlsBox = () => {
     if (!multicore) {
       dispatch({ type: SagaTypes.Resume });
     } else {
-      // not currently implemented: stop/resume in multicore rust mode
+      // not currently implemented: pause/resume in multicore rust mode
       // workers.forEach(({ worker }) => worker.postMessage({ type: RESUME }));
     }
   };
@@ -87,8 +87,8 @@ const ControlsBox = () => {
     if (!multicore) {
       dispatch({ type: SagaTypes.Stop });
     } else {
-      // not currently implemented: stop/resume in multicore rust mode
       // workers.forEach(({ worker }) => worker.postMessage({ type: STOP }));
+      stopCalculation(dispatch);
     }
   };
 
@@ -145,7 +145,7 @@ const ControlsBox = () => {
         </Button>
       </Box>
       <Box sx={{ flexGrow: 1 }}>
-        {status === STOPPED ? (
+        {status === STOPPED && !multicore ? (
           <Button
             variant="outlined"
             color="primary"

--- a/src/pages/index/index.jsx
+++ b/src/pages/index/index.jsx
@@ -120,8 +120,7 @@ const IndexPage = () => {
 
             <Typography variant="body2" component="ul" sx={{ '& > li': { mb: 1 } }}>
               <li>
-                <b>Pausing / Resuming a calculation.</b> Once started, the only way to prematurely
-                terminate a calculation is to refresh the tab.
+                <b>Resuming a paused calculation.</b>
               </li>
               <li>
                 <b>Infusions.</b> They are not yet supported and are ignored in the calculation.

--- a/src/state/optimizer-parallel/calculate.ts
+++ b/src/state/optimizer-parallel/calculate.ts
@@ -32,7 +32,7 @@ const terminateActiveWorkers = () => {
   });
 };
 
-export default function calculate(reduxState: RootState, dispatch: AppDispatch): WorkerWrapper[] {
+export function calculateParallel(reduxState: RootState, dispatch: AppDispatch): WorkerWrapper[] {
   const selectedMaxThreads = reduxState.optimizer.control.hwThreads;
 
   dispatch(changeStatus(RUNNING));
@@ -91,7 +91,7 @@ export default function calculate(reduxState: RootState, dispatch: AppDispatch):
   return workers;
 }
 
-export function stopCalculation(dispatch: AppDispatch) {
+export function stopCalculationParallel(dispatch: AppDispatch) {
   terminateActiveWorkers();
   dispatch(changeStatus(STOPPED));
 }

--- a/src/state/optimizer-parallel/calculate.ts
+++ b/src/state/optimizer-parallel/calculate.ts
@@ -1,4 +1,4 @@
-import { RUNNING } from '../optimizer/status';
+import { RUNNING, STOPPED } from '../optimizer/status';
 import {
   changeFilteredLists,
   changeList,
@@ -23,6 +23,15 @@ const createWorker = (): WorkerWrapper => ({
   worker: new Worker(new URL('./worker/worker.ts', import.meta.url), { type: 'module' }),
 });
 
+const terminateActiveWorkers = () => {
+  createdWorkers.forEach((workerObj, i) => {
+    if (workerObj.status !== 'idle') {
+      workerObj.worker.terminate();
+      createdWorkers[i] = createWorker();
+    }
+  });
+};
+
 export default function calculate(reduxState: RootState, dispatch: AppDispatch): WorkerWrapper[] {
   const selectedMaxThreads = reduxState.optimizer.control.hwThreads;
 
@@ -45,6 +54,8 @@ export default function calculate(reduxState: RootState, dispatch: AppDispatch):
 
   const withHeuristics = getHeuristics(reduxState);
   const settings = createSettings(reduxState);
+
+  terminateActiveWorkers();
 
   console.log(`Creating ${selectedMaxThreads} threads`);
   // create all threads. later on we may or may not use them depending on the presented problem
@@ -78,4 +89,9 @@ export default function calculate(reduxState: RootState, dispatch: AppDispatch):
   }
 
   return workers;
+}
+
+export function stopCalculation(dispatch: AppDispatch) {
+  terminateActiveWorkers();
+  dispatch(changeStatus(STOPPED));
 }


### PR DESCRIPTION
This implements the stop calculation button, but not the resume button, in the multicore rust mode.

It stops the calculation by terminating the active workers from the main thread and creating new ones. This obviously isn't as elegant as having the Rust code actually pause and let handlers run to check if it's received a message every so often (probably doable with `wasm_bindgen_futures` or whatever), but I don't know how to do that and this is at least better than having to refresh the page and lose your whole state.