### PR TITLE
Fix: Inconsistent combination ids in heuristics mode

### DIFF
--- a/wasm_module/src/lib.rs
+++ b/wasm_module/src/lib.rs
@@ -48,7 +48,7 @@ pub fn calculate(
     // workerglobal.set_onmessage(Some(on_message_callback.as_ref().unchecked_ref()));
 
     // calculate the result (maxResult best characters) for the given chunks
-    let mut result = start(&chunks, &settings, &combinations, Some(&workerglobal));
+    let mut result = start(&chunks, &settings, &combinations, None, Some(&workerglobal));
     result.on_complete(&settings, &combinations);
 
     // parse to string
@@ -79,16 +79,12 @@ pub fn calculate_with_heuristics(
 
     // receive list of combinationIds
     let picked_combination_ids = start_with_heuristics(&settings, &combinations);
-    // transform into combination structs
-    let mut picked_combinations = vec![];
-    for id in picked_combination_ids {
-        picked_combinations.push(combinations.get(id as usize).unwrap().clone());
-    }
 
     let mut result = start(
         &chunks,
         &settings,
-        &picked_combinations,
+        &combinations,
+        Some(&picked_combination_ids),
         Some(&workerglobal),
     );
     result.on_complete(&settings, &combinations);

--- a/wasm_module/src/optimizer_core.rs
+++ b/wasm_module/src/optimizer_core.rs
@@ -26,6 +26,7 @@ pub fn start(
     chunks: &Vec<Vec<Affix>>,
     settings: &Settings,
     combinations: &Vec<Combination>,
+    picked_combination_ids: Option<&Vec<u32>>,
     workerglobal: Option<&DedicatedWorkerGlobalScope>,
 ) -> Result {
     let rankby = settings.rankby;
@@ -48,6 +49,10 @@ pub fn start(
 
         // iterate over all combinations
         for i in 0..combinations.len() {
+            if picked_combination_ids.is_some_and(|ids| ids.contains(&(i as u32)) == false) {
+                continue;
+            }
+
             let combination = &combinations[i];
             character.clear();
             character.combination_id = i as u32;


### PR DESCRIPTION
Baby's first nontrivial Rust code; yes I will get around to learning the language for real some time, no today is not that day. Not AI-assisted—I hate using AI for code in its current state—but I was copy-pasting out of docs examples, so it arguably may as well be.

Anyway: this, for compatibility with #796, ensures that `character.combination_id` will refer to the index of the relevant combination relative to the entire combination list, not to the list picked by heuristics, by using `picked_combination_ids` as a whitelist instead of filtering the array with it beforehand.

Resolves #798.