### PR TITLE
refactor: Convert preset data to YAML; improve typecheck

### DIFF
--- a/src/assets/presetdata/metadata.ts
+++ b/src/assets/presetdata/metadata.ts
@@ -1,5 +1,6 @@
 import type { BuffsSlice } from '../../state/slices/buffs';
 import type { Distribution } from '../../state/slices/distribution';
+import type { ExtrasSlice } from '../../state/slices/extras';
 import type { PrioritiesSlice } from '../../state/slices/priorities';
 import type {
   InfusionName,
@@ -72,7 +73,7 @@ export interface PresetDistribution {
 }
 
 export type PresetExtrasEntry = PresetEntry & {
-  value: JSON;
+  value: Partial<ExtrasSlice>;
 };
 export interface PresetExtras {
   'GraphQL ID': string;

--- a/src/assets/presetdata/metadata.ts
+++ b/src/assets/presetdata/metadata.ts
@@ -1,3 +1,4 @@
+import type { PrioritiesSlice } from '../../state/slices/priorities';
 import type {
   InfusionName,
   ProfessionName,
@@ -46,7 +47,7 @@ export interface PresetBuffs {
 }
 
 export type PresetAffixesEntry = Exclude<PresetEntry, 'profession'> & {
-  value: JSON;
+  value: Partial<PrioritiesSlice>;
 };
 export interface PresetAffixes {
   'GraphQL ID': string;

--- a/src/assets/presetdata/metadata.ts
+++ b/src/assets/presetdata/metadata.ts
@@ -1,4 +1,5 @@
 import type { BuffsSlice } from '../../state/slices/buffs';
+import type { Distribution } from '../../state/slices/distribution';
 import type { PrioritiesSlice } from '../../state/slices/priorities';
 import type {
   InfusionName,
@@ -61,7 +62,7 @@ export interface Credit {
   log?: string;
 }
 export type PresetDistributionEntry = PresetEntry & {
-  value: JSON;
+  value: { values2: Distribution };
   noCreditOkay?: true;
   credit?: Credit[];
 };

--- a/src/assets/presetdata/metadata.ts
+++ b/src/assets/presetdata/metadata.ts
@@ -1,3 +1,4 @@
+import type { BuffsSlice } from '../../state/slices/buffs';
 import type { PrioritiesSlice } from '../../state/slices/priorities';
 import type {
   InfusionName,
@@ -39,7 +40,7 @@ export interface PresetEntry {
 }
 
 export type PresetBuffsEntry = PresetEntry & {
-  value: JSON;
+  value: Partial<BuffsSlice['buffs']>;
 };
 export interface PresetBuffs {
   'GraphQL ID': string;

--- a/src/assets/presetdata/metadata.ts
+++ b/src/assets/presetdata/metadata.ts
@@ -11,8 +11,6 @@ import type {
   WeaponHandednessType,
 } from '../../utils/gw2-data';
 
-type JSON = string;
-
 interface TemplateEntryBase {
   name: string;
   id: string;

--- a/src/assets/presetdata/metadata.ts
+++ b/src/assets/presetdata/metadata.ts
@@ -2,6 +2,8 @@ import type { BuffsSlice } from '../../state/slices/buffs';
 import type { Distribution } from '../../state/slices/distribution';
 import type { ExtrasSlice } from '../../state/slices/extras';
 import type { PrioritiesSlice } from '../../state/slices/priorities';
+import type { SkillsSlice } from '../../state/slices/skills';
+import type { TraitsSlice } from '../../state/slices/traits';
 import type {
   InfusionName,
   ProfessionName,
@@ -89,8 +91,8 @@ export interface PresetInfusions {
 }
 
 export type PresetTraitsEntry = PresetEntry & {
-  traits: JSON;
-  skills: JSON;
+  traits: Partial<TraitsSlice>;
+  skills: Partial<SkillsSlice>;
 };
 export interface PresetTraits {
   'GraphQL ID': string;

--- a/src/assets/presetdata/preset-affixes.yaml
+++ b/src/assets/presetdata/preset-affixes.yaml
@@ -1,384 +1,384 @@
 GraphQL ID: presetAffixes
 list:
   - name: Power DPS
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Dragon"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Power DPS (no dragon)
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi DPS
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Sinister"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi DPS Rampager
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Sinister", "Rampager"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Hybrid DPS
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Sinister", "Grieving"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Power Boon
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Diviner"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 84.5,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "84.5",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Boon
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Sinister", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 79,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "79",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Boon/Support
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Seraph", "Celestial"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 79,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "79",
+        "minQuicknessDuration": "0"
       }
 
   - name: Heal (Raid)
-    value: >-
+    value:
       {
         "affixes": ["Harrier", "Minstrel", "Magi"],
         "optimizeFor": "Healing",
-        "minBoonDuration": 100,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "100",
+        "minQuicknessDuration": "0"
       }
 
   - name: Heal (Fractal)
-    value: >-
+    value:
       {
         "affixes": ["Harrier", "Minstrel", "Cleric"],
         "optimizeFor": "Healing",
-        "minBoonDuration": 100,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "100",
+        "minQuicknessDuration": "0"
       }
 
   # -------------------------------------------------------------------------------------------- #
 
   - name: Viper Only
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Barrier Specter
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Ritualist", "Carrion"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Power Alacrity Willbender 14%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Diviner"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 14,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "14",
+        "minQuicknessDuration": "0"
       }
 
   - name: Power Quickbrand 25%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Diviner"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 25
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "25"
       }
 
   - name: Condi Quickness Scrapper 28.7%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 28.78
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "28.78"
       }
 
   # Math on SC Help Desk says 8.3 bare minimum, Arcane is baseline 12%
   # https://discord.com/channels/380901000200060929/471364822496444416/964202302791647283
   - name: Power Quickness Catalyst 8.3%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Diviner"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 8.33
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "8.33"
       }
 
   - name: Power Alacrity Mechanist 55%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Diviner"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 55,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "55",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Quickness Herald 0%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Sinister", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Power Boon Daredevil 99.7%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Diviner"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 99.7
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "99.7"
       }
 
   - name: Condi Hybrid Firebrand 40%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Seraph", "Celestial"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 40
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "40"
       }
 
   - name: Condi Hybrid Firebrand 78%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Seraph", "Celestial"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 78
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "78"
       }
 
   - name: Boon Condi Chrono 10%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 10.3
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "10.3"
       }
 
   - name: Condi Alacrity Scourge 28.8%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 28.8,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "28.8",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Quickness Harbinger 12.8%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 12.8
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "12.8"
       }
 
   - name: Condi Alacrity Mirage 0%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Quickness Berserker 44.7%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Sinister", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 44.7
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "44.7"
       }
 
   - name: Condi Quickness Untamed 30%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 30
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "30"
       }
 
   - name: Condi Boon Daredevil 62%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Sinister", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 92
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "92"
       }
 
   - name: Power Alacrity Renegade 37.5%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Diviner", "Dragon"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 37.5,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "37.5",
+        "minQuicknessDuration": "0"
       }
 
   - name: Alacrity Condi Renegade 42%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 42,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "42",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Quickbrand 40%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist", "Sinister"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 40
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "40"
       }
 
   - name: Condi Alacrity Specter 57%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 56.7,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "56.7",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Alacrity Specter 42%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 42,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "42",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Alacrity Willbender 14%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Grieving", "Celestial"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 14,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "14",
+        "minQuicknessDuration": "0"
       }
 
   - name: Alacrity Power Tempest 28%
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Diviner"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 28,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "28",
+        "minQuicknessDuration": "0"
       }
 
   - name: Alacrity Condi Tempest 40%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Ritualist", "Sinister"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 40,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "40",
+        "minQuicknessDuration": "0"
       }
 
   - name: Condi Tempest
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Viper", "Grieving", "Sinister"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "0"
       }
 
   - name: Heal Specter 88%
     hidden: true
-    value: >-
+    value:
       {
         "affixes": ["Plaguedoctor", "Minstrel", "Giver"],
         "optimizeFor": "Healing",
-        "minBoonDuration": 88,
-        "minQuicknessDuration": 0
+        "minBoonDuration": "88",
+        "minQuicknessDuration": "0"
       }
 
   - name: Power Quickness Untamed 40%
-    value: >-
+    value:
       {
         "affixes": ["Berserker", "Assassin", "Diviner"],
         "optimizeFor": "Damage",
-        "minBoonDuration": 0,
-        "minQuicknessDuration": 40
+        "minBoonDuration": "0",
+        "minQuicknessDuration": "40"
       }

--- a/src/assets/presetdata/preset-buffs.yaml
+++ b/src/assets/presetdata/preset-buffs.yaml
@@ -1,12 +1,12 @@
 GraphQL ID: presetBuffs
 list:
   - name: None
-    value: >-
+    value:
       {
       }
 
   - name: Realistic
-    value: >-
+    value:
       {
         "might": true,
         "fury": true,
@@ -19,7 +19,7 @@ list:
 
   - name: Condi
     hidden: true
-    value: >-
+    value:
       {
         "might": true,
         "fury": true,
@@ -33,7 +33,7 @@ list:
 
   - name: Power (no spotter)
     hidden: true
-    value: >-
+    value:
       {
         "might": true,
         "fury": true,
@@ -48,7 +48,7 @@ list:
 
   - name: Power (spotter)
     hidden: true
-    value: >-
+    value:
       {
         "might": true,
         "fury": true,
@@ -64,7 +64,7 @@ list:
 
   - name: Benchmark
     hidden: true
-    value: >-
+    value:
       {
         "might": true,
         "fury": true,

--- a/src/assets/presetdata/preset-distribution.yaml
+++ b/src/assets/presetdata/preset-distribution.yaml
@@ -2,14 +2,14 @@ GraphQL ID: presetDistribution
 list:
   # button not shown; used for no-op templates
   - name: None
-    value: >-
+    value:
       {
         "values2": { "Power": 0, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
     noCreditOkay: true
 
   - name: 100% Power
-    value: >-
+    value:
       {
         "values2": { "Power": 3000, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -17,7 +17,7 @@ list:
 
   - name: No Simulation
     hidden: true
-    value: >-
+    value:
       {
         "values2": { "Power": 1, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -27,7 +27,7 @@ list:
   # proc rate high enough to match air+hydro damage
   - name: Power Berserker GS A/A
     profession: Berserker
-    value: >-
+    value:
       {
         "values2": { "Power": 3871, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -40,7 +40,7 @@ list:
   # proc rate high enough to match air+hydro damage
   - name: Quickness Power Berserker GS A/A
     profession: Berserker
-    value: >-
+    value:
       {
         "values2": { "Power": 3829, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -51,7 +51,7 @@ list:
 
   - name: Power Spellbreaker GS
     profession: Spellbreaker
-    value: >-
+    value:
       {
         "values2": { "Power": 2909, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -62,7 +62,7 @@ list:
 
   - name: Power Spellbreaker Hammer
     profession: Spellbreaker
-    value: >-
+    value:
       {
         "values2": { "Power": 2329, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -74,7 +74,7 @@ list:
   # includes sigils
   - name: Condi Quickness Bers
     profession: Berserker
-    value: >-
+    value:
       {
         "values2": { "Power": 2438, "Power2": 0, "Burning": 8.82, "Bleeding": 14.13, "Poisoned": 2.1, "Torment": 3.64, "Confusion": 0 }
       }
@@ -86,7 +86,7 @@ list:
   # includes sigils
   - name: Condi Berserker
     profession: Berserker
-    value: >-
+    value:
       {
         "values2": { "Power": 2470, "Power2": 0, "Burning": 8.29, "Bleeding": 13.67, "Poisoned": 2.15, "Torment": 5.11, "Confusion": 0 }
       }
@@ -97,7 +97,7 @@ list:
 
   - name: Power Alacrity Bladesworn
     profession: Bladesworn
-    value: >-
+    value:
       {
         "values2": { "Power": 3916, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -108,7 +108,7 @@ list:
 
   - name: DPS Bladesworn Tactics
     profession: Bladesworn
-    value: >-
+    value:
       {
         "values2": { "Power": 4548, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -119,7 +119,7 @@ list:
 
   - name: DH Radiance
     profession: Dragonhunter
-    value: >-
+    value:
       {
         "values2": { "Power": 4085, "Power2": 0, "Burning": 2.59, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -130,7 +130,7 @@ list:
 
   - name: DH Virtues
     profession: Dragonhunter
-    value: >-
+    value:
       {
         "values2": { "Power": 3967, "Power2": 0, "Burning": 2.8, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -144,7 +144,7 @@ list:
   # 12 boons
   - name: Core Guardian
     profession: Guardian
-    value: >-
+    value:
       {
         "values2": { "Power": 3340, "Power2": 0, "Burning": 1.1, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -153,7 +153,7 @@ list:
   # (this is actually an old core guardian distribution iirc)
   - name: Power Quickbrand (approx.)
     profession: Firebrand
-    value: >-
+    value:
       {
         "values2": { "Power": 3390, "Power2": 0, "Burning": 1.1, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -161,7 +161,7 @@ list:
 
   - name: Condi Willbender P/T P/P
     profession: Willbender
-    value: >-
+    value:
       {
         "values2": { "Power": 2202, "Power2": 0, "Burning": 16.4, "Bleeding": 6.46, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -172,7 +172,7 @@ list:
 
   - name: Condi Willbender Sword
     profession: Willbender
-    value: >-
+    value:
       {
         "values2": { "Power": 2871, "Power2": 0, "Burning": 14.05, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -186,7 +186,7 @@ list:
   # NO JADE BOT (in arc log, probably - seems bugged)
   - name: Condi Willbender GS
     profession: Willbender
-    value: >-
+    value:
       {
         "values2": { "Power": 3010, "Power2": 0, "Burning": 13.38, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -197,7 +197,7 @@ list:
 
   - name: Quickess Condi Firebrand P/T P/P
     profession: Firebrand
-    value: >-
+    value:
       {
         "values2": { "Power": 1548, "Power2": 0, "Burning": 16.88, "Bleeding": 8.17, "Poisoned": 0, "Torment": 0.11, "Confusion": 0 }
       }
@@ -208,7 +208,7 @@ list:
 
   - name: Condi Firebrand A/T P/P
     profession: Firebrand
-    value: >-
+    value:
       {
         "values2": { "Power": 1784, "Power2": 0, "Burning": 14.49, "Bleeding": 12.08, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -219,7 +219,7 @@ list:
 
   - name: Condi Firebrand A/T
     profession: Firebrand
-    value: >-
+    value:
       {
         "values2": { "Power": 2219, "Power2": 0, "Burning": 13.98, "Bleeding": 14.64, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -230,7 +230,7 @@ list:
 
   - name: Condi Firebrand A/T P/P (No Allies)
     profession: Firebrand
-    value: >-
+    value:
       {
         "values2": { "Power": 1775, "Power2": 0, "Burning": 13.39, "Bleeding": 12.05, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -241,7 +241,7 @@ list:
 
   # - name: Condi Quickbrand (WT, Allies)
   #   profession: Firebrand
-  #   value: >-
+  #   value:
   #     {
   #       "values2": { "Power": 1397, "Power2": 0, "Burning": 14.23, "Bleeding": 6.07, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
   #     }
@@ -252,7 +252,7 @@ list:
 
   # - name: Condi Quickbrand (WT, No Allies)
   #   profession: Firebrand
-  #   value: >-
+  #   value:
   #     {
   #       "values2": { "Power": 1391, "Power2": 0, "Burning": 13.51, "Bleeding": 5.83, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
   #     }
@@ -264,7 +264,7 @@ list:
   # Solo log adjusted upwards to match with-allies dps (no log for the with allies bench)
   # - name: Condi Quickbrand (LL, Allies, Approx.)
   #   profession: Firebrand
-  #   value: >-
+  #   value:
   #     {
   #       "values2": { "Power": 2023, "Power2": 0, "Burning": 16.65, "Bleeding": 3.51, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
   #     }
@@ -275,7 +275,7 @@ list:
 
   # - name: Condi Quickbrand (LL, No Allies)
   #   profession: Firebrand
-  #   value: >-
+  #   value:
   #     {
   #       "values2": { "Power": 2023, "Power2": 0, "Burning": 13.95, "Bleeding": 3.34, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
   #     }
@@ -286,7 +286,7 @@ list:
 
   # - name: Hybrid FB (Virtues, no allies)
   #   profession: Firebrand
-  #   value: >-
+  #   value:
   #     {
   #       "values2": { "Power": 1942, "Power2": 0, "Burning": 12.1, "Bleeding": 3.0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
   #     }
@@ -295,7 +295,7 @@ list:
 
   - name: Hybrid FB Virtues
     profession: Firebrand
-    value: >-
+    value:
       {
         "values2": { "Power": 1864, "Power2": 0, "Burning": 13.8, "Bleeding": 3.0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -303,7 +303,7 @@ list:
 
   - name: Hybrid FB (Honor, No Allies)
     profession: Firebrand
-    value: >-
+    value:
       {
         "values2": { "Power": 2203, "Power2": 0, "Burning": 9.05, "Bleeding": 16.22, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -314,7 +314,7 @@ list:
 
   - name: Hybrid FB (Honor, Allies)
     profession: Firebrand
-    value: >-
+    value:
       {
         "values2": { "Power": 2014, "Power2": 0, "Burning": 10.92, "Bleeding": 16.16, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -328,7 +328,7 @@ list:
   # RHS
   - name: Power Willbender Radiance
     profession: Willbender
-    value: >-
+    value:
       {
         "values2": { "Power": 3289, "Power2": 0, "Burning": 2.9, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -336,7 +336,7 @@ list:
 
   - name: Power Willbender Virtues
     profession: Willbender
-    value: >-
+    value:
       {
         "values2": { "Power": 4387, "Power2": 0, "Burning": 5.59, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -348,7 +348,7 @@ list:
   # 12 boons, celefood toxiccrystal, 14%
   - name: Condi Alacrity Willbender
     profession: Willbender
-    value: >-
+    value:
       {
         "values2": { "Power": 2711, "Power2": 0, "Burning": 9.8, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -362,7 +362,7 @@ list:
   # 12 boons, thief accuracy, 14%
   - name: Power Alacrity Willbender
     profession: Willbender
-    value: >-
+    value:
       {
         "values2": { "Power": 3506, "Power2": 0, "Burning": 2.49, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -370,7 +370,7 @@ list:
 
   - name: Power Weaver (BTTH, small)
     profession: Weaver
-    value: >-
+    value:
       {
         "values2": { "Power": 3844, "Power2": 0, "Burning": 6.58, "Bleeding": 4.02, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -381,7 +381,7 @@ list:
 
   - name: Condi Weaver Pistol
     profession: Weaver
-    value: >-
+    value:
       {
         "values2": { "Power": 1442, "Power2": 0, "Burning": 9.53, "Bleeding": 29.79, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -393,7 +393,7 @@ list:
   # no jade bot
   - name: Condi Weaver Sword
     profession: Weaver
-    value: >-
+    value:
       {
         "values2": { "Power": 2626, "Power2": 0, "Burning": 11.78, "Bleeding": 14.92, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -405,7 +405,7 @@ list:
   # no jade bot
   - name: Condi Weaver (Dagger)
     profession: Weaver
-    value: >-
+    value:
       {
         "values2": { "Power": 2091, "Power2": 0, "Burning": 12.01, "Bleeding": 17.55, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -416,7 +416,7 @@ list:
 
   - name: Condi Weaver Staff (Large)
     profession: Weaver
-    value: >-
+    value:
       {
         "values2": { "Power": 3096, "Power2": 0, "Burning": 10.35, "Bleeding": 16.51, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -428,7 +428,7 @@ list:
   # Without eles (distribution still comparable, lower rng)
   - name: Condi Weaver Scepter
     profession: Weaver
-    value: >-
+    value:
       {
         "values2": { "Power": 2226, "Power2": 0, "Burning": 13.49, "Bleeding": 12.29, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -439,7 +439,7 @@ list:
 
   - name: Hybrid Weaver
     profession: Weaver
-    value: >-
+    value:
       {
         "values2": { "Power": 3328, "Power2": 0, "Burning": 11.76, "Bleeding": 1.88, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -450,7 +450,7 @@ list:
 
   - name: Alacrity Condi Tempest Pistol
     profession: Tempest
-    value: >-
+    value:
       {
         "values2": { "Power": 2452, "Power2": 0, "Burning": 9.13, "Bleeding": 29.37, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -461,7 +461,7 @@ list:
 
   - name: Condi Tempest Pistol
     profession: Tempest
-    value: >-
+    value:
       {
         "values2": { "Power": 2616, "Power2": 0, "Burning": 11.04, "Bleeding": 25.97, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -472,7 +472,7 @@ list:
 
   - name: Condi Tempest Hammer
     profession: Tempest
-    value: >-
+    value:
       {
         "values2": { "Power": 2506, "Power2": 0, "Burning": 10.73, "Bleeding": 16.73, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -483,7 +483,7 @@ list:
 
   - name: Power Tempest Scepter
     profession: Tempest
-    value: >-
+    value:
       {
         "values2": { "Power": 5121, "Power2": 0, "Burning": 3.21, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -494,7 +494,7 @@ list:
 
   - name: Power Catalyst
     profession: Catalyst
-    value: >-
+    value:
       {
         "values2": { "Power": 3294, "Power2": 0, "Burning": 4.07, "Bleeding": 5.49, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -505,7 +505,7 @@ list:
 
   - name: Power Quickness Catalyst
     profession: Catalyst
-    value: >-
+    value:
       {
         "values2": { "Power": 3417, "Power2": 0, "Burning": 3.65, "Bleeding": 6.71, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -516,7 +516,7 @@ list:
 
   - name: Alacrity Renegade
     profession: Renegade
-    value: >-
+    value:
       {
         "values2": { "Power": 3532, "Power2": 0, "Burning": 0.78, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -527,7 +527,7 @@ list:
 
   - name: Alacrity Condi Renegade
     profession: Renegade
-    value: >-
+    value:
       {
         "values2": { "Power": 2139, "Power2": 0, "Burning": 3.97, "Bleeding": 12.36, "Poisoned": 4.42, "Torment": 17.24, "Confusion": 0 }
       }
@@ -538,7 +538,7 @@ list:
 
   - name: Condi Alac Invocation (no allies)
     profession: Renegade
-    value: >-
+    value:
       {
         "values2": { "Power": 1903, "Power2": 0, "Burning": 4.14, "Bleeding": 9.37, "Poisoned": 4, "Torment": 16.09, "Confusion": 0 }
       }
@@ -551,7 +551,7 @@ list:
   # 4 players * 10 pulses * 2 seconds / 20 sec = 4.00 avg bleed
   - name: Condi Renegade Devastation
     profession: Renegade
-    value: >-
+    value:
       {
         "values2": { "Power": 2092, "Power2": 0, "Burning": 4.21, "Bleeding": 14.13, "Poisoned": 2.23, "Torment": 16.34, "Confusion": 0 }
       }
@@ -563,7 +563,7 @@ list:
   # AP, full viper, asparagus food
   - name: Condi Renegade Devastation (no allies)
     profession: Renegade
-    value: >-
+    value:
       {
         "values2": { "Power": 2092, "Power2": 0, "Burning": 4.21, "Bleeding": 10.13, "Poisoned": 2.23, "Torment": 16.34, "Confusion": 0 }
       }
@@ -576,7 +576,7 @@ list:
   # 4 players * 10 pulses * 2 seconds / 20 sec = 4.00 avg bleed
   - name: Condi Renegade Invocation
     profession: Renegade
-    value: >-
+    value:
       {
         "values2": { "Power": 2011, "Power2": 0, "Burning": 4.48, "Bleeding": 14.48, "Poisoned": 4.07, "Torment": 18.32, "Confusion": 0 }
       }
@@ -587,7 +587,7 @@ list:
 
   - name: Condi Renegade Invocation (no allies)
     profession: Renegade
-    value: >-
+    value:
       {
         "values2": { "Power": 2011, "Power2": 0, "Burning": 4.48, "Bleeding": 10.48, "Poisoned": 4.07, "Torment": 18.32, "Confusion": 0 }
       }
@@ -600,7 +600,7 @@ list:
   # todo: convert 122dps to self lifesteal
   - name: Power Quickness Herald
     profession: Herald
-    value: >-
+    value:
       {
         "values2": { "Power": 3056, "Power2": 0, "Burning": 0.72, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -613,7 +613,7 @@ list:
   # todo: convert 268dps to self lifesteal
   - name: Power Herald FP
     profession: Herald
-    value: >-
+    value:
       {
         "values2": { "Power": 2838, "Power2": 0, "Burning": 1.43, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0 }
       }
@@ -624,7 +624,7 @@ list:
 
   - name: Condi Quickness Herald
     profession: Herald
-    value: >-
+    value:
       {
         "values2": { "Power": 2148, "Power2": 0, "Burning": 4.75, "Bleeding": 6.5, "Poisoned": 4.9, "Torment": 15.63, "Confusion": 0 }
       }
@@ -636,7 +636,7 @@ list:
   # force air force air
   - name: DPS Vindicator
     profession: Vindicator
-    value: >-
+    value:
       {
         "values2": { "Power": 3673, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 2.96, "Confusion": 0 }
       }
@@ -647,7 +647,7 @@ list:
 
   - name: Condi Quickness Untamed
     profession: Untamed
-    value: >-
+    value:
       {
         "values2": { "Power": 2104, "Power2": 0, "Burning": 3.46, "Bleeding": 21.84, "Poisoned": 13.23, "Torment": 0, "Confusion": 0 }
       }
@@ -658,7 +658,7 @@ list:
 
   - name: Power Soulbeast
     profession: Soulbeast
-    value: >-
+    value:
       {
         "values2": { "Power": 3480, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0.39, "Torment": 0, "Confusion": 0 }
       }
@@ -678,7 +678,7 @@ list:
   # (does not match well because of higher than average TaV on OWP, but whatever)
   - name: Condi Slb (D/T SB)
     profession: Soulbeast
-    value: >-
+    value:
       {
         "values2": { "Power": 1366, "Power2": 0, "Burning": 2.42, "Bleeding": 21.7, "Poisoned": 16.26, "Torment": 0, "Confusion": 0 }
       }
@@ -696,7 +696,7 @@ list:
   # (does not match well because of higher than average TaV on OWP, but whatever)
   - name: Condi Slb (D/T A/D)
     profession: Soulbeast
-    value: >-
+    value:
       {
         "values2": { "Power": 1442, "Power2": 0, "Burning": 3.54, "Bleeding": 19.95, "Poisoned": 13.86, "Torment": 0, "Confusion": 0 }
       }
@@ -707,7 +707,7 @@ list:
   # Note: solo number, not with allies
   - name: Condi Slb D/D SB
     profession: Soulbeast
-    value: >-
+    value:
       {
         "values2": { "Power": 1729, "Power2": 0, "Burning": 0, "Bleeding": 23.59, "Poisoned": 12.53, "Torment": 0, "Confusion": 0 }
       }
@@ -718,7 +718,7 @@ list:
 
   # - name: Hybrid Slb OS (A/T D/A)
   #   profession: Soulbeast
-  #   value: >-
+  #   value:
   #     {
   #       "values2": { "Power": 2382, "Power2": 0, "Burning": 2.25, "Bleeding": 23.11, "Poisoned": 3.14, "Torment": 0.05, "Confusion": 0 }
   #     }
@@ -729,7 +729,7 @@ list:
 
   - name: Hybrid Slb A/T D/A
     profession: Soulbeast
-    value: >-
+    value:
       {
         "values2": { "Power": 2531, "Power2": 0, "Burning": 2.12, "Bleeding": 19.45, "Poisoned": 2.56, "Torment": 0.04, "Confusion": 0 }
       }
@@ -742,7 +742,7 @@ list:
   # koi cake
   # - name: Pure Shortbow Slb BM
   #   profession: Soulbeast
-  #   value: >-
+  #   value:
   #     {
   #       "values2": { "Power": 1661, "Power2": 0, "Burning": 0.54, "Bleeding": 25.48, "Poisoned": 11.45, "Torment": 0, "Confusion": 0 }
   #     }
@@ -753,7 +753,7 @@ list:
 
   - name: Condi Druid
     profession: Druid
-    value: >-
+    value:
       {
         "values2": { "Power": 1594, "Power2": 0, "Burning": 4.33, "Bleeding": 30.01, "Poisoned": 15.04, "Torment": 0.05, "Confusion": 0 }
       }
@@ -764,7 +764,7 @@ list:
 
   - name: Power Holo PBM
     profession: Holosmith
-    value: >-
+    value:
       {
         "values2": { "Power": 3974, "Power2": 0, "Burning": 5.27, "Bleeding": 5.1, "Poisoned": 2.95, "Torment": 0, "Confusion": 0 }
       }
@@ -775,7 +775,7 @@ list:
 
   - name: Power Holo ECSU
     profession: Holosmith
-    value: >-
+    value:
       {
         "values2": { "Power": 3890, "Power2": 0, "Burning": 5.41, "Bleeding": 9.82, "Poisoned": 2.39, "Torment": 0, "Confusion": 0 }
       }
@@ -786,7 +786,7 @@ list:
 
   - name: Condi Holo
     profession: Holosmith
-    value: >-
+    value:
       {
         "values2": { "Power": 3072, "Power2": 0, "Burning": 16.89, "Bleeding": 8.12, "Poisoned": 3.67, "Torment": 0, "Confusion": 2.54 }
       }
@@ -799,7 +799,7 @@ list:
   # mech does burning (???) - import tool breaks
   - name: Power Alacrity Mechanist (inaccurate)
     profession: Mechanist
-    value: >-
+    value:
       {
         "values2": { "Power": 2745, "Power2": 0, "Burning": 4.38, "Bleeding": 5.45, "Poisoned": 3.45, "Torment": 0, "Confusion": 10.45 }
       }
@@ -810,7 +810,7 @@ list:
 
   - name: Condi Mechanist J-Drive (approx.)
     profession: Mechanist
-    value: >-
+    value:
       {
         "values2": { "Power": 3622, "Power2": 0, "Burning": 6.17, "Bleeding": 18.34, "Poisoned": 9.03, "Torment": 0, "Confusion": 3.83 }
       }
@@ -822,7 +822,7 @@ list:
   # icicle
   - name: Condi Mechanist Jade Dynamo Pistol (approx.)
     profession: Mechanist
-    value: >-
+    value:
       {
         "values2": { "Power": 3566, "Power2": 0, "Burning": 7.42, "Bleeding": 17.54, "Poisoned": 10.05, "Torment": 0, "Confusion": 9.18 }
       }
@@ -833,7 +833,7 @@ list:
 
   - name: Condi Alac Mechanist (inaccurate)
     profession: Mechanist
-    value: >-
+    value:
       {
         "values2": { "Power": 3124, "Power2": 0, "Burning": 8.81, "Bleeding": 9.98, "Poisoned": 9.25, "Torment": 0, "Confusion": 5.02 }
       }
@@ -844,7 +844,7 @@ list:
 
   - name: Power Scrapper
     profession: Scrapper
-    value: >-
+    value:
       {
         "values2": { "Power": 3662, "Power2": 0, "Burning": 0, "Bleeding": 4.98, "Poisoned": 4.78, "Torment": 0, "Confusion": 0 }
       }
@@ -855,7 +855,7 @@ list:
 
   - name: Quickness Condi Scrapper
     profession: Scrapper
-    value: >-
+    value:
       {
         "values2": { "Power": 1952, "Power2": 0, "Burning": 8.91, "Bleeding": 11.34, "Poisoned": 11.87, "Torment": 0, "Confusion": 4.66 }
       }
@@ -866,7 +866,7 @@ list:
 
   - name: Power Chrono IA GS
     profession: Chronomancer
-    value: >-
+    value:
       {
         "values2": { "Power": 3541, "Power2": 1419, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0.93 }
       }
@@ -878,7 +878,7 @@ list:
   # impact
   - name: Boon Power Chrono Spear
     profession: Chronomancer
-    value: >-
+    value:
       {
         "values2": { "Power": 4691, "Power2": 0, "Burning": 0, "Bleeding": 0.63, "Poisoned": 0, "Torment": 0, "Confusion": 1.12 }
       }
@@ -890,7 +890,7 @@ list:
   # impact
   - name: Boon Power Chrono GS
     profession: Chronomancer
-    value: >-
+    value:
       {
         "values2": { "Power": 3640, "Power2": 1118, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 1.24 }
       }
@@ -901,7 +901,7 @@ list:
 
   - name: Alacrity Staff Mirage
     profession: Mirage
-    value: >-
+    value:
       {
         "values2": { "Power": 1162, "Power2": 175, "Burning": 0.01, "Bleeding": 9.75, "Poisoned": 0.2, "Torment": 12.12, "Confusion": 18.48 }
       }
@@ -912,7 +912,7 @@ list:
 
   - name: Condi Staff / Axe Mirage
     profession: Mirage
-    value: >-
+    value:
       {
         "values2": { "Power": 1717, "Power2": 468, "Burning": 0, "Bleeding": 9.27, "Poisoned": 0.57, "Torment": 28.87, "Confusion": 15.05 }
       }
@@ -923,7 +923,7 @@ list:
 
   - name: Axe Mirage (Deception Torch)
     profession: Mirage
-    value: >-
+    value:
       {
         "values2": { "Power": 2050, "Power2": 453, "Burning": 1.08, "Bleeding": 7.88, "Poisoned": 0.46, "Torment": 22.88, "Confusion": 11.84 }
       }
@@ -935,7 +935,7 @@ list:
   # rit: shoulders coat gloves leggings, domi midnight, mischief, rendang icicle
   - name: Boon Condi Chrono
     profession: Chronomancer
-    value: >-
+    value:
       {
         "values2": { "Power": 1894, "Power2": 426, "Burning": 1.57, "Bleeding": 4.99, "Poisoned": 0, "Torment": 6.75, "Confusion": 16.42 }
       }
@@ -949,7 +949,7 @@ list:
   # 2 expertise 4 malign 12 precise infusions
   - name: Condi Virtuoso Dueling
     profession: Virtuoso
-    value: >-
+    value:
       {
         "values2": { "Power": 3200, "Power2": 930, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 8.98, "Confusion": 3.39 }
       }
@@ -961,7 +961,7 @@ list:
   # https://optimizer.discretize.eu/?s=tC0aBKlpv1
   - name: Condi Virtuoso Chaos
     profession: Virtuoso
-    value: >-
+    value:
       {
         "values2": { "Power": 3146, "Power2": 9, "Burning": 0.52, "Bleeding": 3.08, "Poisoned": 0.27, "Torment": 7.58, "Confusion": 3.03 }
       }
@@ -972,7 +972,7 @@ list:
 
   - name: Power Virtuoso Spear
     profession: Virtuoso
-    value: >-
+    value:
       {
         "values2": { "Power": 4886, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0.52 }
       }
@@ -984,7 +984,7 @@ list:
   # accuracy, assassin legs, 4 precise (2007 prec)
   - name: Power Virtuoso GS
     profession: Virtuoso
-    value: >-
+    value:
       {
         "values2": { "Power": 3508, "Power2": 1106, "Burning": 0, "Bleeding": 0, "Poisoned": 0, "Torment": 0, "Confusion": 0.56 }
       }
@@ -995,7 +995,7 @@ list:
 
   - name: Condi Alacrity Scourge
     profession: Scourge
-    value: >-
+    value:
       {
         "values2": { "Power": 1656, "Power2": 0, "Burning": 1.77, "Bleeding": 13.54, "Poisoned": 5.16, "Torment": 13.25, "Confusion": 0 }
       }
@@ -1006,7 +1006,7 @@ list:
 
   - name: Condi Scourge
     profession: Scourge
-    value: >-
+    value:
       {
         "values2": { "Power": 1799, "Power2": 0, "Burning": 2.94, "Bleeding": 12.77, "Poisoned": 4.91, "Torment": 13.37, "Confusion": 0 }
       }
@@ -1020,7 +1020,7 @@ list:
   # uses https://github.com/hobinjk/optimizer-scripts/blob/main/reaper.js for shroud power damage split
   - name: Power Reaper
     profession: Reaper
-    value: >-
+    value:
       {
         "values2": { "Power": 1580, "Power2": 2795, "Burning": 0, "Bleeding": 0.42, "Poisoned": 1.23, "Torment": 0, "Confusion": 0 }
       }
@@ -1032,7 +1032,7 @@ list:
   # uses https://github.com/hobinjk/optimizer-scripts/blob/main/reaper.js for shroud power damage split
   - name: Condi Reaper Spear
     profession: Reaper
-    value: >-
+    value:
       {
         "values2": { "Power": 3109, "Power2": 666, "Burning": 0.32, "Bleeding": 39.17, "Poisoned": 1.73, "Torment": 2.06, "Confusion": 0 }
       }
@@ -1044,7 +1044,7 @@ list:
   # uses https://github.com/hobinjk/optimizer-scripts/blob/main/reaper.js for shroud power damage split
   - name: Condi Reaper Scepter
     profession: Reaper
-    value: >-
+    value:
       {
         "values2": { "Power": 1637, "Power2": 1288, "Burning": 0.31, "Bleeding": 47.83, "Poisoned": 2.69, "Torment": 3.76, "Confusion": 0 }
       }
@@ -1055,7 +1055,7 @@ list:
 
   - name: DPS Harbinger
     profession: Harbinger
-    value: >-
+    value:
       {
         "values2": { "Power": 2314, "Power2": 0, "Burning": 2, "Bleeding": 7.93, "Poisoned": 6.36, "Torment": 20.8, "Confusion": 0.65 }
       }
@@ -1066,7 +1066,7 @@ list:
 
   - name: Quickness Condi Harbinger
     profession: Harbinger
-    value: >-
+    value:
       {
         "values2": { "Power": 2252, "Power2": 0, "Burning": 1.93, "Bleeding": 9.28, "Poisoned": 6.08, "Torment": 17.58, "Confusion": 0.64 }
       }
@@ -1077,7 +1077,7 @@ list:
 
   - name: Quickness Power Harbinger
     profession: Harbinger
-    value: >-
+    value:
       {
         "values2": { "Power": 1656, "Power2": 1965, "Burning": 0.55, "Bleeding": 0.55, "Poisoned": 0.55, "Torment": 10.11, "Confusion": 0.55 }
       }
@@ -1089,7 +1089,7 @@ list:
   # uses https://github.com/hobinjk/optimizer-scripts/blob/main/reaper.js for shroud power damage split
   - name: Power Harbinger
     profession: Harbinger
-    value: >-
+    value:
       {
         "values2": { "Power": 1756, "Power2": 2122, "Burning": 0.67, "Bleeding": 0.67, "Poisoned": 1.48, "Torment": 9.89, "Confusion": 0.66 }
       }
@@ -1100,7 +1100,7 @@ list:
 
   - name: Condi Deadeye A/D
     profession: Deadeye
-    value: >-
+    value:
       {
         "values2": { "Power": 3552, "Power2": 0, "Burning": 0, "Bleeding": 7.43, "Poisoned": 25.79, "Torment": 4.95, "Confusion": 0 }
       }
@@ -1111,7 +1111,7 @@ list:
 
   - name: Condi Deadeye A/D (no allies)
     profession: Deadeye
-    value: >-
+    value:
       {
         "values2": { "Power": 3554, "Power2": 0, "Burning": 0, "Bleeding": 7.24, "Poisoned": 21.34, "Torment": 6.47, "Confusion": 0 }
       }
@@ -1122,7 +1122,7 @@ list:
 
   - name: Quickness Condi Deadeye Spear
     profession: Deadeye
-    value: >-
+    value:
       {
         "values2": { "Power": 3173, "Power2": 0, "Burning": 0, "Bleeding": 14.14, "Poisoned": 20.49, "Torment": 0.51, "Confusion": 0 }
       }
@@ -1133,7 +1133,7 @@ list:
 
   - name: Power Staff Daredevil
     profession: Daredevil
-    value: >-
+    value:
       {
         "values2": { "Power": 3401, "Power2": 0, "Burning": 0, "Bleeding": 0.65, "Poisoned": 3.3, "Torment": 0, "Confusion": 0 }
       }
@@ -1144,7 +1144,7 @@ list:
 
   - name: Condi Daredevil (No Allies)
     profession: Daredevil
-    value: >-
+    value:
       {
         "values2": { "Power": 1348, "Power2": 0, "Burning": 0, "Bleeding": 25.72, "Poisoned": 10.39, "Torment": 1.66, "Confusion": 0 }
       }
@@ -1157,7 +1157,7 @@ list:
   # scuffed approximation by taking total damage and dividing by approximate duration (99.143)
   - name: Condi Daredevil
     profession: Daredevil
-    value: >-
+    value:
       {
         "values2": { "Power": 1513, "Power2": 0, "Burning": 0, "Bleeding": 25.8, "Poisoned": 16.09, "Torment": 1.74, "Confusion": 0 }
       }
@@ -1168,7 +1168,7 @@ list:
 
   - name: Power Deadeye Rifle
     profession: Deadeye
-    value: >-
+    value:
       {
         "values2": { "Power": 4065, "Power2": 0, "Burning": 0, "Bleeding": 0.98, "Poisoned": 2.17, "Torment": 0.27, "Confusion": 0 }
       }
@@ -1179,7 +1179,7 @@ list:
 
   - name: Power Deadeye Spear
     profession: Deadeye
-    value: >-
+    value:
       {
         "values2": { "Power": 3705, "Power2": 0, "Burning": 0, "Bleeding": 10.41, "Poisoned": 8.77, "Torment": 1.37, "Confusion": 0 }
       }
@@ -1190,7 +1190,7 @@ list:
 
   - name: Quickness Power Deadeye Spear
     profession: Deadeye
-    value: >-
+    value:
       {
         "values2": { "Power": 3670, "Power2": 0, "Burning": 0, "Bleeding": 8.39, "Poisoned": 9, "Torment": 0.41, "Confusion": 0 }
       }
@@ -1201,7 +1201,7 @@ list:
 
   - name: Power Deadeye Daggers BQoBK
     profession: Deadeye
-    value: >-
+    value:
       {
         "values2": { "Power": 3192, "Power2": 0, "Burning": 0, "Bleeding": 3.86, "Poisoned": 6.7, "Torment": 0, "Confusion": 0 }
       }
@@ -1212,7 +1212,7 @@ list:
 
   - name: Power Deadeye Rifle Silent Scope
     profession: Deadeye
-    value: >-
+    value:
       {
         "values2": { "Power": 3907, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 0.95, "Torment": 0.24, "Confusion": 0 }
       }
@@ -1223,7 +1223,7 @@ list:
 
   - name: Condi Specter Spear (Allies)
     profession: Specter
-    value: >-
+    value:
       {
         "values2": { "Power": 3206, "Power2": 0, "Burning": 0.24, "Bleeding": 12.24, "Poisoned": 21.26, "Torment": 6.69, "Confusion": 0 }
       }
@@ -1235,7 +1235,7 @@ list:
   # 1.72 torment proc rate (from evtc tool applied to previous log)
   - name: Condi Specter SC/D (Allies)
     profession: Specter
-    value: >-
+    value:
       {
         "values2": { "Power": 2437, "Power2": 0, "Burning": 0, "Bleeding": 2.53, "Poisoned": 14.31, "Torment": 16.75, "Confusion": 0 }
       }
@@ -1249,7 +1249,7 @@ list:
   # 1.52 torment proc rate (from evtc tool)
   - name: DPS Barrier Specter SC/D (Allies)
     profession: Specter
-    value: >-
+    value:
       {
         "values2": { "Power": 2163, "Power2": 0, "Burning": 0, "Bleeding": 2.55, "Poisoned": 15.94, "Torment": 20.03, "Confusion": 0 }
       }
@@ -1261,7 +1261,7 @@ list:
   # 1.52 torment proc rate (from evtc tool on carrion spec, which has the same critchance)
   - name: Alacrity Specter SC/D (allies)
     profession: Specter
-    value: >-
+    value:
       {
         "values2": { "Power": 1903, "Power2": 0, "Burning": 0, "Bleeding": 0, "Poisoned": 14.33, "Torment": 18.23, "Confusion": 0 }
       }
@@ -1272,7 +1272,7 @@ list:
 
   - name: Alacrity Specter D/D (allies)
     profession: Specter
-    value: >-
+    value:
       {
         "values2": { "Power": 2467, "Power2": 0, "Burning": 0, "Bleeding": 21.02, "Poisoned": 13.38, "Torment": 6.37, "Confusion": 0 }
       }

--- a/src/assets/presetdata/preset-extras.yaml
+++ b/src/assets/presetdata/preset-extras.yaml
@@ -2,7 +2,7 @@ GraphQL ID: presetExtras
 list:
 
   - name: Power (Fractal)
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -35,7 +35,7 @@ list:
       }
 
   - name: Power (Raid)
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -70,7 +70,7 @@ list:
       }
 
   - name: Power (Raid, fireworks)
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -108,7 +108,7 @@ list:
       }
 
   - name: Power (Raid, claw)
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -146,7 +146,7 @@ list:
       }
 
   - name: Power (Raid, furious)
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -182,7 +182,7 @@ list:
       }
 
   - name: Power (Raid, air)
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -220,7 +220,7 @@ list:
 
   # just reduced lifesteal frequency
   - name: Bladesworn
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -257,7 +257,7 @@ list:
 
   # air-only approximation of air/hydro split
   - name: Power Berserker
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -294,7 +294,7 @@ list:
       }
 
   - name: Power Boon (Raid)
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -338,7 +338,7 @@ list:
       }
 
   - name: Power Boon (Fractal)
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -380,7 +380,7 @@ list:
 
   # no item sigil represents use of water sigil
   - name: Heal
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -406,7 +406,7 @@ list:
 
   - name: Alacrity Staff Mirage
     profession: Mirage
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -439,7 +439,7 @@ list:
 
   - name: DPS Mirage (Raid)
     profession: Mirage
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -473,7 +473,7 @@ list:
 
   - name: Boon Condi Chrono
     profession: Chronomancer
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -502,7 +502,7 @@ list:
 
   - name: Condi Chrono DPS
     profession: Chronomancer
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -529,7 +529,7 @@ list:
 
   - name: Condi Virtuoso Dueling
     profession: Virtuoso
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -561,7 +561,7 @@ list:
 
   - name: Condi Virtuoso Chaos
     profession: Virtuoso
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -590,7 +590,7 @@ list:
 
   - name: Power Quickbrand (Raid)
     profession: Firebrand
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -628,7 +628,7 @@ list:
 
   - name: DH Virtues (Raid)
     profession: Dragonhunter
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -668,7 +668,7 @@ list:
 
   - name: DH Virtues (Fractal)
     profession: Dragonhunter
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -703,7 +703,7 @@ list:
 
   - name: Power Willbender Virtues (Fractal)
     profession: Willbender
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -733,7 +733,7 @@ list:
 
   - name: Power Alacrity Willbender (Raid)
     profession: Willbender
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -768,7 +768,7 @@ list:
 
   - name: Condi Willbender
     profession: Willbender
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -805,7 +805,7 @@ list:
 
   - name: Condi Alacrity Willbender
     profession: Willbender
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -843,7 +843,7 @@ list:
 
   - name: Condi Firebrand
     profession: Firebrand
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -884,7 +884,7 @@ list:
 
   - name: Quickess Condi Firebrand
     profession: Firebrand
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -923,7 +923,7 @@ list:
 
   - name: Hybrid FB Traveler
     profession: Firebrand
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {},
@@ -949,7 +949,7 @@ list:
 
   - name: Condi Berserker
     profession: Berserker
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -985,7 +985,7 @@ list:
 
   - name: Condi Quickness Bers
     profession: Berserker
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1013,7 +1013,7 @@ list:
 
   - name: Alacrity Power Tempest (Fractal)
     profession: Tempest
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1052,7 +1052,7 @@ list:
 
   - name: Alacrity Power Tempest (Raid)
     profession: Tempest
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1092,7 +1092,7 @@ list:
 
   - name: Condi Weaver Sword
     profession: Weaver
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1121,7 +1121,7 @@ list:
 
   - name: Condi Weaver Dagger
     profession: Weaver
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -1155,7 +1155,7 @@ list:
   # Torment procs chosen to make log get 0 stacks
   - name: Condi Weaver Scepter
     profession: Weaver
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1192,7 +1192,7 @@ list:
 
   - name: Condi Weaver
     profession: Weaver
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1229,7 +1229,7 @@ list:
 
   - name: Hybrid Weaver (Fractal)
     profession: Weaver
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1262,7 +1262,7 @@ list:
 
   - name: Hybrid Weaver (Raid)
     profession: Weaver
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1295,7 +1295,7 @@ list:
 
   - name: Alacrity Hybrid Tempest
     profession: Tempest
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1340,7 +1340,7 @@ list:
 
   - name: Condi Tempest
     profession: Tempest
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1382,7 +1382,7 @@ list:
 
   - name: Power Quickness Catalyst (Raid)
     profession: Catalyst
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1419,7 +1419,7 @@ list:
 
   - name: Condi Quickness Untamed
     profession: Untamed
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -1461,7 +1461,7 @@ list:
 
   - name: Power Quickness Untamed (Raid)
     profession: Untamed
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1504,7 +1504,7 @@ list:
 
   - name: Condi Slb
     profession: Soulbeast
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -1546,7 +1546,7 @@ list:
 
   - name: Hybrid Slb
     profession: Soulbeast
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -1584,7 +1584,7 @@ list:
 
   - name: Condi Druid
     profession: Druid
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -1619,7 +1619,7 @@ list:
 
   - name: Power Holo (Raid)
     profession: Holosmith
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1656,7 +1656,7 @@ list:
 
   - name: Condi Holo
     profession: Holosmith
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1693,7 +1693,7 @@ list:
 
   - name: Condi Quickness Scrapper
     profession: Scrapper
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1730,7 +1730,7 @@ list:
 
   - name: Alacrity Condi Renegade
     profession: Renegade
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {},
@@ -1766,7 +1766,7 @@ list:
 
   - name: Condi Ren
     profession: Renegade
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {},
@@ -1794,7 +1794,7 @@ list:
 
   - name: Power Quickness Herald (Raid)
     profession: Herald
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1837,7 +1837,7 @@ list:
 
   - name: Power Quickness Herald (Fractal)
     profession: Herald
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1872,7 +1872,7 @@ list:
 
   - name: Power Alac Ren (Raid)
     profession: Renegade
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1911,7 +1911,7 @@ list:
 
   - name: Condi Quickness Herald
     profession: Herald
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1944,7 +1944,7 @@ list:
 
   - name: DPS Vindicator (Fractal)
     profession: Vindicator
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1975,7 +1975,7 @@ list:
 
   - name: DPS Vindicator (Raid)
     profession: Vindicator
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -1995,7 +1995,7 @@ list:
           },
           "Sigil2": {
             "air": {
-              "amount": 3.1
+              "amount": "3.1"
             }
           },
           "Enhancement": {
@@ -2011,7 +2011,7 @@ list:
   - name: Power Alacrity Mechanist (Fractal, inaccurate)
     hidden: true
     profession: Mechanist
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2034,7 +2034,7 @@ list:
 
   - name: Power Alacrity Mechanist (Raid, air, inaccurate)
     profession: Mechanist
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2059,7 +2059,7 @@ list:
 
   - name: Power Alacrity Mechanist (Raid, concentration, inaccurate)
     profession: Mechanist
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2086,7 +2086,7 @@ list:
 
   - name: Condi Mechanist
     profession: Mechanist
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2122,7 +2122,7 @@ list:
 
   - name: DPS Scourge
     profession: Scourge
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2158,7 +2158,7 @@ list:
 
   - name: Condi Reaper Spear
     profession: Reaper
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2189,7 +2189,7 @@ list:
 
   - name: Condi Reaper Scepter
     profession: Reaper
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2213,7 +2213,7 @@ list:
 
   - name: DPS Harbinger
     profession: Harbinger
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -2254,7 +2254,7 @@ list:
 
   - name: Quickness Condi Harbinger
     profession: Harbinger
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -2296,7 +2296,7 @@ list:
 
   - name: Condi Deadeye A/D
     profession: Deadeye
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2336,7 +2336,7 @@ list:
 
   - name: Quickness Condi Deadeye Spear
     profession: Deadeye
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2376,7 +2376,7 @@ list:
 
   - name: Power Deadeye (Raid)
     profession: Deadeye
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2414,7 +2414,7 @@ list:
 
   - name: Power Staff Daredevil
     profession: Daredevil
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2450,7 +2450,7 @@ list:
 
   - name: Power Boon Daredevil
     profession: Daredevil
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2487,7 +2487,7 @@ list:
 
   - name: Condi Daredevil
     profession: Daredevil
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -2531,7 +2531,7 @@ list:
 
   - name: Condi Boon Daredevil
     profession: Daredevil
-    value: |-
+    value:
       {
         "extras": {
           "Runes": {
@@ -2565,7 +2565,7 @@ list:
 
   - name: Condi Specter Spear
     profession: Specter
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -2608,7 +2608,7 @@ list:
 
   - name: Condi Specter SC/D
     profession: Specter
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -2654,7 +2654,7 @@ list:
 
   - name: Condi Barrier Specter SC/D
     profession: Specter
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {
@@ -2694,7 +2694,7 @@ list:
 
   - name: Alacrity Specter
     profession: Specter
-    value: |-
+    value:
       {
         "extras": {
           "Sigil1": {

--- a/src/assets/presetdata/preset-traits.yaml
+++ b/src/assets/presetdata/preset-traits.yaml
@@ -3,7 +3,7 @@ list:
 
   - name: Power Chrono IA GS
     profession: Chronomancer
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -64,14 +64,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Boon Power Chrono Spear
     profession: Chronomancer
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -132,14 +132,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Boon Power Chrono GS
     profession: Chronomancer
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -200,14 +200,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Heal Chrono
     profession: Chronomancer
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -250,7 +250,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
@@ -258,7 +258,7 @@ list:
 
   - name: Axe Mirage
     profession: Mirage
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -316,7 +316,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-domination": {},
@@ -326,7 +326,7 @@ list:
 
   - name: Alacrity Staff Mirage
     profession: Mirage
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -388,7 +388,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-domination": {},
@@ -398,7 +398,7 @@ list:
 
   - name: Condi Staff / Axe Mirage
     profession: Mirage
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -460,7 +460,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-domination": {},
@@ -470,7 +470,7 @@ list:
 
   - name: Boon Condi Chrono
     profession: Chronomancer
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -523,7 +523,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-domination": {},
@@ -533,7 +533,7 @@ list:
 
   - name: Condi Virtuoso Dueling
     profession: Virtuoso
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -597,7 +597,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-domination": {},
@@ -607,7 +607,7 @@ list:
 
   - name: Condi Virtuoso Chaos
     profession: Virtuoso
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -668,7 +668,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-domination": {},
@@ -678,7 +678,7 @@ list:
 
   - name: Power Virtuoso Spear
     profession: Virtuoso
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -743,14 +743,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Virtuoso GS
     profession: Virtuoso
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -814,14 +814,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: DH Radiance
     profession: Dragonhunter
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -884,7 +884,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "bane-signet": {
@@ -895,7 +895,7 @@ list:
 
   - name: DH Virtues
     profession: Dragonhunter
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -961,7 +961,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "bane-signet": {
@@ -972,7 +972,7 @@ list:
 
   - name: Core Guardian
     profession: Guardian
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1036,7 +1036,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "bane-signet": {
@@ -1047,7 +1047,7 @@ list:
 
   - name: Power Quickbrand
     profession: Firebrand
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1103,7 +1103,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "bane-signet": {
@@ -1114,7 +1114,7 @@ list:
 
   - name: Condi Willbender
     profession: Willbender
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1177,7 +1177,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-wrath": {
@@ -1188,7 +1188,7 @@ list:
 
   - name: Quickess Condi Firebrand P/T P/P
     profession: Firebrand
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1247,14 +1247,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Firebrand Zeal
     profession: Firebrand
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1310,7 +1310,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-wrath": {
@@ -1321,7 +1321,7 @@ list:
 
   - name: Condi Firebrand Virtues
     profession: Firebrand
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1380,7 +1380,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-wrath": {
@@ -1391,7 +1391,7 @@ list:
 
   - name: Hybrid FB Virtues
     profession: Firebrand
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1450,14 +1450,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Hybrid FB Honor
     profession: Firebrand
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1510,14 +1510,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Healbrand
     profession: Firebrand
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1570,14 +1570,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Heal Alacrity Willbender
     profession: Willbender
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1639,14 +1639,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Willbender Radiance
     profession: Willbender
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1706,7 +1706,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "bane-signet": {
@@ -1717,7 +1717,7 @@ list:
 
   - name: Power Willbender Virtues
     profession: Willbender
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1780,7 +1780,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "bane-signet": {
@@ -1791,7 +1791,7 @@ list:
 
   - name: Condi Alacrity Willbender
     profession: Willbender
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1855,7 +1855,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-wrath": {
@@ -1866,7 +1866,7 @@ list:
 
   - name: Power Alacrity Willbender
     profession: Willbender
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -1926,7 +1926,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "bane-signet": {
@@ -1937,7 +1937,7 @@ list:
 
   - name: Power Berserker GS A/A
     profession: Berserker
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2003,7 +2003,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-might": {},
@@ -2013,7 +2013,7 @@ list:
 
   - name: Quickness Power Berserker GS A/A
     profession: Berserker
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2079,7 +2079,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-might": {},
@@ -2089,7 +2089,7 @@ list:
 
   - name: Condi Quickness Berserker
     profession: Berserker
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2166,14 +2166,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Berserker
     profession: Berserker
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2250,7 +2250,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
@@ -2258,7 +2258,7 @@ list:
   # Tether uptime can be calculated from Damage Modifiers tab
   - name: Power Spellbreaker GS
     profession: Spellbreaker
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2329,7 +2329,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-might": {},
@@ -2341,7 +2341,7 @@ list:
   # gear may be calculated properly for crit cap
   - name: Power Spellbreaker Hammer
     profession: Spellbreaker
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2411,7 +2411,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-might": {},
@@ -2421,7 +2421,7 @@ list:
 
   - name: Alacrity Bladesworn
     profession: Bladesworn
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2482,14 +2482,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: DPS Bladesworn Tactics
     profession: Bladesworn
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2553,14 +2553,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Heal Quickness Berserker
     profession: Berserker
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2625,14 +2625,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Weaver Stormsoul Fractal
     profession: Weaver
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2714,14 +2714,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Weaver Raid
     profession: Weaver
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2803,7 +2803,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "woven-fire": {
@@ -2817,7 +2817,7 @@ list:
 
   - name: Condi Weaver Pistol
     profession: Weaver
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2881,7 +2881,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "woven-fire": {
@@ -2899,7 +2899,7 @@ list:
 
   - name: Condi Weaver Sword
     profession: Weaver
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -2966,7 +2966,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "woven-fire": {
@@ -2977,7 +2977,7 @@ list:
 
   - name: Condi Weaver Dagger
     profession: Weaver
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3044,7 +3044,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "woven-fire": {
@@ -3055,7 +3055,7 @@ list:
 
   - name: Condi Weaver Staff
     profession: Weaver
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3122,7 +3122,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "woven-fire": {
@@ -3136,7 +3136,7 @@ list:
 
   - name: Condi Weaver Scepter
     profession: Weaver
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3203,7 +3203,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "woven-fire": {
@@ -3218,7 +3218,7 @@ list:
 
   - name: Hybrid Weaver
     profession: Weaver
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3300,7 +3300,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "woven-fire": {
@@ -3314,7 +3314,7 @@ list:
 
   - name: Alacrity Hybrid Tempest
     profession: Tempest
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3377,14 +3377,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Alacrity Condi Tempest Pistol
     profession: Tempest
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3443,7 +3443,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-fire": {},
@@ -3453,7 +3453,7 @@ list:
 
   - name: Condi Tempest Pistol
     profession: Tempest
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3512,7 +3512,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-fire": {}
@@ -3521,7 +3521,7 @@ list:
 
   - name: Condi Tempest Hammer
     profession: Tempest
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3580,7 +3580,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "crescent-wind": {},
@@ -3594,7 +3594,7 @@ list:
 
   - name: Power Tempest Water
     profession: Tempest
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3660,7 +3660,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-fire": {}
@@ -3669,7 +3669,7 @@ list:
 
   - name: Alacrity Power Tempest Arcane
     profession: Tempest
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3736,7 +3736,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-fire": {}
@@ -3745,7 +3745,7 @@ list:
 
   - name: Power Catalyst
     profession: Catalyst
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3818,7 +3818,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "flame-wheel": {
@@ -3833,7 +3833,7 @@ list:
 
   - name: Power Quickness Catalyst
     profession: Catalyst
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3901,7 +3901,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "flame-wheel": {
@@ -3916,7 +3916,7 @@ list:
 
   - name: Heal Tempest
     profession: Tempest
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -3968,14 +3968,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Quickness Untamed
     profession: Untamed
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4029,7 +4029,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "pet-dps": {
@@ -4040,7 +4040,7 @@ list:
 
   - name: Power Soulbeast
     profession: Soulbeast
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4100,7 +4100,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-the-wild": {},
@@ -4112,7 +4112,7 @@ list:
 
   - name: Quickness Power Untamed
     profession: Untamed
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4168,7 +4168,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-the-wild": {}
@@ -4177,7 +4177,7 @@ list:
 
   - name: Power Untamed
     profession: Untamed
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4232,7 +4232,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-the-wild": {}
@@ -4241,7 +4241,7 @@ list:
 
   - name: Condi Slb D/D SB
     profession: Soulbeast
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4296,7 +4296,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "one-wolf-pack-no-sic-em-sharpened": {
@@ -4310,7 +4310,7 @@ list:
 
   - name: Hybrid Slb OS
     profession: Soulbeast
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4366,7 +4366,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "one-wolf-pack-sic-em-sharpened": {
@@ -4380,7 +4380,7 @@ list:
 
   - name: Hybrid Slb
     profession: Soulbeast
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4436,7 +4436,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "one-wolf-pack-sic-em-sharpened": {
@@ -4450,7 +4450,7 @@ list:
 
   - name: Condi Druid
     profession: Druid
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4503,7 +4503,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "pet-dps": {
@@ -4514,7 +4514,7 @@ list:
 
   - name: Heal Druid
     profession: Druid
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4560,14 +4560,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Alac Ren
     profession: Renegade
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4633,14 +4633,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Alac Ren Invo
     profession: Renegade
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4695,14 +4695,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi DPS Ren Invo
     profession: Renegade
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4757,14 +4757,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Quickness Herald
     profession: Herald
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4833,7 +4833,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "burst-of-strength": {
@@ -4844,7 +4844,7 @@ list:
 
   - name: Power Herald FP
     profession: Herald
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4912,7 +4912,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "burst-of-strength": {
@@ -4923,7 +4923,7 @@ list:
 
   - name: Condi Quickness Herald
     profession: Herald
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -4981,7 +4981,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "burst-of-strength": {
@@ -4992,7 +4992,7 @@ list:
 
   - name: Heal Ren
     profession: Renegade
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5039,14 +5039,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Heal Herald
     profession: Herald
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5096,14 +5096,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: DPS Vindicator
     profession: Vindicator
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5172,14 +5172,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Holo ECSU
     profession: Holosmith
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5243,14 +5243,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Holo PBM
     profession: Holosmith
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5314,14 +5314,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Holo
     profession: Holosmith
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5385,14 +5385,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Alacrity Mechanist (inaccurate)
     profession: Mechanist
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5452,7 +5452,7 @@ list:
           {}
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "force-signet": {}
@@ -5461,7 +5461,7 @@ list:
 
   - name: Condi Mechanist J-Drive
     profession: Mechanist
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5519,7 +5519,7 @@ list:
           {}
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "superconducting-signet-traited": {}
@@ -5528,7 +5528,7 @@ list:
 
   - name: Condi Mechanist Jade Dynamo
     profession: Mechanist
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5588,14 +5588,14 @@ list:
           {}
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Alac Mechanist (inaccurate)
     profession: Mechanist
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5655,14 +5655,14 @@ list:
           {}
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Scrapper
     profession: Scrapper
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5731,14 +5731,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Quickness Power Scrapper
     profession: Scrapper
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5807,14 +5807,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Quickness Condi Scrapper
     profession: Scrapper
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5883,14 +5883,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Heal Scrapper
     profession: Scrapper
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5935,14 +5935,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Heal Mechanist
     profession: Mechanist
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -5978,14 +5978,14 @@ list:
           {}
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Alacrity Scourge
     profession: Scourge
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6038,7 +6038,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-spite": {
@@ -6049,7 +6049,7 @@ list:
 
   - name: DPS Scourge
     profession: Scourge
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6102,7 +6102,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-spite": {
@@ -6113,7 +6113,7 @@ list:
 
   - name: Power Reaper
     profession: Reaper
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6169,14 +6169,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Reaper Spear
     profession: Reaper
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6233,7 +6233,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "soul-shards": {
@@ -6247,7 +6247,7 @@ list:
 
   - name: Condi Reaper Scepter
     profession: Reaper
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6304,14 +6304,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Heal Scourge
     profession: Scourge
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6355,14 +6355,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: DPS Harbinger
     profession: Harbinger
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6422,7 +6422,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-spite": {
@@ -6433,7 +6433,7 @@ list:
 
   - name: Quickness Condi Harbinger
     profession: Harbinger
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6494,7 +6494,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-spite": {
@@ -6505,7 +6505,7 @@ list:
 
   - name: Quickness Power Harbinger
     profession: Harbinger
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6566,7 +6566,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "soul-shards": {
@@ -6580,7 +6580,7 @@ list:
 
   - name: Power Harbinger
     profession: Harbinger
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6641,7 +6641,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-spite": {
@@ -6658,7 +6658,7 @@ list:
 
   - name: Condi Deadeye A/D
     profession: Deadeye
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6715,14 +6715,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Quickness Condi Deadeye Spear
     profession: Deadeye
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6779,14 +6779,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Staff Daredevil
     profession: Daredevil
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6855,7 +6855,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "assassins-signet": {
@@ -6869,7 +6869,7 @@ list:
 
   - name: Power Boon Daredevil
     profession: Daredevil
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6929,7 +6929,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "signet-of-agility": {}
@@ -6938,7 +6938,7 @@ list:
 
   - name: Condi Daredevil
     profession: Daredevil
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -6996,14 +6996,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Boon Daredevil
     profession: Daredevil
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7061,14 +7061,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Power Deadeye Rifle
     profession: Deadeye
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7137,7 +7137,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "assassins-signet": {
@@ -7151,7 +7151,7 @@ list:
 
   - name: Power Deadeye Spear
     profession: Deadeye
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7217,7 +7217,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "assassins-signet": {
@@ -7231,7 +7231,7 @@ list:
 
   - name: Quickness Power Deadeye Spear
     profession: Deadeye
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7297,7 +7297,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "assassins-signet": {
@@ -7311,7 +7311,7 @@ list:
 
   - name: Power Deadeye Daggers BQoBK
     profession: Deadeye
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7378,7 +7378,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "assassins-signet": {
@@ -7392,7 +7392,7 @@ list:
 
   - name: Power Deadeye Rifle Silent Scope
     profession: Deadeye
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7458,7 +7458,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {
           "assassins-signet": {
@@ -7472,7 +7472,7 @@ list:
 
   - name: Condi Specter Spear
     profession: Specter
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7528,14 +7528,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Condi Specter SC/D
     profession: Specter
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7594,14 +7594,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Alacrity Specter SC/D
     profession: Specter
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7660,14 +7660,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Alacrity Specter D/D
     profession: Specter
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7723,14 +7723,14 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }
 
   - name: Heal Specter
     profession: Specter
-    traits: |-
+    traits:
       {
         "showAll": false,
         "selectedLines": [
@@ -7774,7 +7774,7 @@ list:
           }
         ]
       }
-    skills: |-
+    skills:
       {
         "skills": {}
       }

--- a/src/assets/presetdata/templateTransform.ts
+++ b/src/assets/presetdata/templateTransform.ts
@@ -64,11 +64,7 @@ export function getBuildTemplateData({
     prioritiesPreset:
       prioritiesPresets.list.find((pre) => pre.name === build.priority)?.value ?? 'undefined',
     extrasPreset: presetExtras.list.find((pre) => pre.name === build.extras)?.value ?? 'undefined',
-    traitsPreset: JSON.parse(
-      presetTraits.list.find((pre) => pre.name === build.traits)?.traits ?? 'undefined',
-    ),
-    skillsPreset: JSON.parse(
-      presetTraits.list.find((pre) => pre.name === build.traits)?.skills ?? 'undefined',
-    ),
+    traitsPreset: presetTraits.list.find((pre) => pre.name === build.traits)?.traits ?? 'undefined',
+    skillsPreset: presetTraits.list.find((pre) => pre.name === build.traits)?.skills ?? 'undefined',
   };
 }

--- a/src/assets/presetdata/templateTransform.ts
+++ b/src/assets/presetdata/templateTransform.ts
@@ -64,9 +64,8 @@ export function getBuildTemplateData({
     distributionPreset: JSON.parse(
       presetDistribution.list.find((pre) => pre.name === build.distribution)?.value || 'undefined',
     ),
-    prioritiesPreset: JSON.parse(
+    prioritiesPreset:
       prioritiesPresets.list.find((pre) => pre.name === build.priority)?.value ?? 'undefined',
-    ),
     extrasPreset: JSON.parse(
       presetExtras.list.find((pre) => pre.name === build.extras)?.value ?? 'undefined',
     ),

--- a/src/assets/presetdata/templateTransform.ts
+++ b/src/assets/presetdata/templateTransform.ts
@@ -57,14 +57,13 @@ export function getBuildTemplateData({
     build,
     specialization: build.specialization,
     profession,
-    buffPreset: presetBuffs.list.find((pre) => pre.name === build.boons)?.value ?? 'undefined',
+    buffPreset: presetBuffs.list.find((pre) => pre.name === build.boons)?.value,
     selectedDistribution: build.distribution,
-    distributionPreset:
-      presetDistribution.list.find((pre) => pre.name === build.distribution)?.value || 'undefined',
-    prioritiesPreset:
-      prioritiesPresets.list.find((pre) => pre.name === build.priority)?.value ?? 'undefined',
-    extrasPreset: presetExtras.list.find((pre) => pre.name === build.extras)?.value ?? 'undefined',
-    traitsPreset: presetTraits.list.find((pre) => pre.name === build.traits)?.traits ?? 'undefined',
-    skillsPreset: presetTraits.list.find((pre) => pre.name === build.traits)?.skills ?? 'undefined',
+    distributionPreset: presetDistribution.list.find((pre) => pre.name === build.distribution)
+      ?.value,
+    prioritiesPreset: prioritiesPresets.list.find((pre) => pre.name === build.priority)?.value,
+    extrasPreset: presetExtras.list.find((pre) => pre.name === build.extras)?.value,
+    traitsPreset: presetTraits.list.find((pre) => pre.name === build.traits)?.traits,
+    skillsPreset: presetTraits.list.find((pre) => pre.name === build.traits)?.skills,
   };
 }

--- a/src/assets/presetdata/templateTransform.ts
+++ b/src/assets/presetdata/templateTransform.ts
@@ -59,9 +59,8 @@ export function getBuildTemplateData({
     profession,
     buffPreset: presetBuffs.list.find((pre) => pre.name === build.boons)?.value ?? 'undefined',
     selectedDistribution: build.distribution,
-    distributionPreset: JSON.parse(
+    distributionPreset:
       presetDistribution.list.find((pre) => pre.name === build.distribution)?.value || 'undefined',
-    ),
     prioritiesPreset:
       prioritiesPresets.list.find((pre) => pre.name === build.priority)?.value ?? 'undefined',
     extrasPreset: JSON.parse(

--- a/src/assets/presetdata/templateTransform.ts
+++ b/src/assets/presetdata/templateTransform.ts
@@ -57,9 +57,7 @@ export function getBuildTemplateData({
     build,
     specialization: build.specialization,
     profession,
-    buffPreset: JSON.parse(
-      presetBuffs.list.find((pre) => pre.name === build.boons)?.value ?? 'undefined',
-    ),
+    buffPreset: presetBuffs.list.find((pre) => pre.name === build.boons)?.value ?? 'undefined',
     selectedDistribution: build.distribution,
     distributionPreset: JSON.parse(
       presetDistribution.list.find((pre) => pre.name === build.distribution)?.value || 'undefined',

--- a/src/assets/presetdata/templateTransform.ts
+++ b/src/assets/presetdata/templateTransform.ts
@@ -63,9 +63,7 @@ export function getBuildTemplateData({
       presetDistribution.list.find((pre) => pre.name === build.distribution)?.value || 'undefined',
     prioritiesPreset:
       prioritiesPresets.list.find((pre) => pre.name === build.priority)?.value ?? 'undefined',
-    extrasPreset: JSON.parse(
-      presetExtras.list.find((pre) => pre.name === build.extras)?.value ?? 'undefined',
-    ),
+    extrasPreset: presetExtras.list.find((pre) => pre.name === build.extras)?.value ?? 'undefined',
     traitsPreset: JSON.parse(
       presetTraits.list.find((pre) => pre.name === build.traits)?.traits ?? 'undefined',
     ),

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -554,11 +554,6 @@ const testPresets = async () => {
           Object.keys(entry.skills.skills).forEach((id) =>
             gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent skill id: ${id}`),
           );
-        } else if (['priority', 'boons', 'distribution', 'extras', 'infusions'].includes(type)) {
-          // values are not JSON; do nothing
-          // (values are validated in validateDataTypes script)
-        } else {
-          JSON.parse(entry.value);
         }
       } catch {
         gentleAssert(false, `err: the ${entry.name} ${type} entry is invalid JSON`);

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -544,19 +544,15 @@ const testPresets = async () => {
 
   for (const [type, entries] of Object.entries(data)) {
     for (const entry of entries) {
-      try {
-        if (type === 'traits') {
-          // entry.traits.items
-          //   .flatMap(Object.keys)
-          //   .forEach((id) =>
-          //     gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent trait id: ${id}`),
-          //   );
-          Object.keys(entry.skills.skills).forEach((id) =>
-            gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent skill id: ${id}`),
-          );
-        }
-      } catch {
-        gentleAssert(false, `err: the ${entry.name} ${type} entry is invalid JSON`);
+      if (type === 'traits') {
+        // entry.traits.items
+        //   .flatMap(Object.keys)
+        //   .forEach((id) =>
+        //     gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent trait id: ${id}`),
+        //   );
+        Object.keys(entry.skills.skills).forEach((id) =>
+          gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent skill id: ${id}`),
+        );
       }
       if (type === 'distribution') {
         if (!entry.noCreditOkay) {

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -557,7 +557,7 @@ const testPresets = async () => {
           Object.keys(skills.skills).forEach((id) =>
             gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent skill id: ${id}`),
           );
-        } else if (['priority', 'boons', 'infusions'].includes(type)) {
+        } else if (['priority', 'boons', 'distribution', 'infusions'].includes(type)) {
           // values are not JSON; do nothing
           // (values are validated in validateDataTypes script)
         } else {

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -546,15 +546,12 @@ const testPresets = async () => {
     for (const entry of entries) {
       try {
         if (type === 'traits') {
-          JSON.parse(entry.traits);
-          // const traits = JSON.parse(entry.traits);
-          // traits.items
+          // entry.traits.items
           //   .flatMap(Object.keys)
           //   .forEach((id) =>
           //     gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent trait id: ${id}`),
           //   );
-          const skills = JSON.parse(entry.skills);
-          Object.keys(skills.skills).forEach((id) =>
+          Object.keys(entry.skills.skills).forEach((id) =>
             gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent skill id: ${id}`),
           );
         } else if (['priority', 'boons', 'distribution', 'extras', 'infusions'].includes(type)) {

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -586,7 +586,7 @@ const testPresets = async () => {
 
     for (const entry of data[type]) {
       const { name, value, traits, skills } = entry;
-      const entryValue = value || traits + skills;
+      const entryValue = JSON.stringify(value) || JSON.stringify(traits) + JSON.stringify(skills);
 
       if (potentialDuplicates[entryValue]) {
         potentialDuplicates[entryValue].push(name);

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -557,7 +557,7 @@ const testPresets = async () => {
           Object.keys(skills.skills).forEach((id) =>
             gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent skill id: ${id}`),
           );
-        } else if (['priority', 'infusions'].includes(type)) {
+        } else if (['priority', 'boons', 'infusions'].includes(type)) {
           // values are not JSON; do nothing
           // (values are validated in validateDataTypes script)
         } else {

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -582,7 +582,9 @@ const testPresets = async () => {
 
     for (const entry of data[type]) {
       const { name, value, traits, skills } = entry;
-      const entryValue = JSON.stringify(value) || JSON.stringify(traits) + JSON.stringify(skills);
+      const entryValue = traits
+        ? JSON.stringify(traits) + JSON.stringify(skills)
+        : JSON.stringify(value);
 
       if (potentialDuplicates[entryValue]) {
         potentialDuplicates[entryValue].push(name);

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -557,7 +557,7 @@ const testPresets = async () => {
           Object.keys(skills.skills).forEach((id) =>
             gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent skill id: ${id}`),
           );
-        } else if (['priority', 'boons', 'distribution', 'infusions'].includes(type)) {
+        } else if (['priority', 'boons', 'distribution', 'extras', 'infusions'].includes(type)) {
           // values are not JSON; do nothing
           // (values are validated in validateDataTypes script)
         } else {
@@ -676,7 +676,7 @@ const testPresets = async () => {
             console.log(`❓ ${name}'s ${type}'s profession is wrong! (mode: ${mode})`);
 
           if (type === 'extras') {
-            const extrasData = JSON.parse(match.value);
+            const extrasData = match.value;
             ['Sigil1', 'Sigil2', 'Runes', 'Relics', 'Nourishment', 'Enhancement'].forEach(
               (extrasType) => {
                 gentleAssert(

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -557,7 +557,7 @@ const testPresets = async () => {
           Object.keys(skills.skills).forEach((id) =>
             gentleAssert(allTraitIds.has(id), `${entry.name} has nonexistent skill id: ${id}`),
           );
-        } else if (['infusions'].includes(type)) {
+        } else if (['priority', 'infusions'].includes(type)) {
           // values are not JSON; do nothing
           // (values are validated in validateDataTypes script)
         } else {

--- a/src/components/sections/affixes/AffixesSection.tsx
+++ b/src/components/sections/affixes/AffixesSection.tsx
@@ -28,11 +28,7 @@ const AffixesSection = () => {
   const exoticsEnabled = useSelector(getExoticsEnabled);
 
   const handleTemplateClickPriorities = React.useCallback(
-    (value: PresetAffixesEntry) => {
-      if (!value) return;
-      const state = JSON.parse(value.value);
-      dispatch(changePriorities(state));
-    },
+    (value: PresetAffixesEntry) => dispatch(changePriorities(value.value)),
     [dispatch],
   );
 

--- a/src/components/sections/buffs/BuffsSection.tsx
+++ b/src/components/sections/buffs/BuffsSection.tsx
@@ -13,12 +13,7 @@ const BuffsSection = () => {
   const { t } = useTranslation();
 
   const handleTemplateClickBuffs = React.useCallback(
-    (value: PresetBuffsEntry) => {
-      if (!value) return;
-
-      const state = JSON.parse(value.value);
-      dispatch(replaceBuffs(state as Record<string, boolean>));
-    },
+    (value: PresetBuffsEntry) => dispatch(replaceBuffs(value.value)),
     [dispatch],
   );
 

--- a/src/components/sections/distribution/DistributionSection.tsx
+++ b/src/components/sections/distribution/DistributionSection.tsx
@@ -31,11 +31,7 @@ const DistributionSection = () => {
   }
 
   const onTemplateClickDistribution = React.useCallback(
-    (value: PresetDistributionEntry) => {
-      if (!value) return;
-
-      dispatch(changeAllDistributions(value));
-    },
+    (value: PresetDistributionEntry) => dispatch(changeAllDistributions(value)),
     [dispatch],
   );
 

--- a/src/components/sections/extras/ExtrasSection.tsx
+++ b/src/components/sections/extras/ExtrasSection.tsx
@@ -58,12 +58,7 @@ const ExtrasSection = () => {
   }
 
   const onTemplateClickExtras = React.useCallback(
-    (value: PresetExtrasEntry) => {
-      if (!value) return;
-
-      const newExtras = JSON.parse(value.value);
-      dispatch(changeExtras(newExtras));
-    },
+    (value: PresetExtrasEntry) => dispatch(changeExtras(value.value)),
     [dispatch],
   );
 

--- a/src/components/sections/traits/TraitsSection.tsx
+++ b/src/components/sections/traits/TraitsSection.tsx
@@ -33,13 +33,8 @@ const TraitsSection = () => {
 
   const onTemplateClickTraits = React.useCallback(
     (value: PresetTraitsEntry) => {
-      if (!value) return;
-
-      const newTraits = JSON.parse(value.traits);
-      dispatch(changeTraits(newTraits));
-
-      const newSkills = JSON.parse(value.skills);
-      dispatch(changeSkills(newSkills));
+      dispatch(changeTraits(value.traits));
+      dispatch(changeSkills(value.skills));
     },
     [dispatch],
   );

--- a/src/state/slices/buffs.ts
+++ b/src/state/slices/buffs.ts
@@ -9,7 +9,12 @@ import { changeAll, setBuildTemplate } from './controlsSlice';
 type Buffs = Record<string, boolean>;
 type BuffAmounts = Record<string, string>;
 
-const initialState: { buffs: Buffs; amounts: BuffAmounts } = {
+export interface BuffsSlice {
+  buffs: Buffs;
+  amounts: BuffAmounts;
+}
+
+const initialState: BuffsSlice = {
   buffs: {
     might: false,
     fury: false,

--- a/src/state/slices/buffs.ts
+++ b/src/state/slices/buffs.ts
@@ -85,13 +85,15 @@ export const buffsSlice = createSlice({
     builder.addCase(setBuildTemplate, (state, action) => {
       const { buffPreset } = action.payload;
 
-      const buffs: Buffs = {};
-      [...Object.keys(state.buffs)].forEach((key) => {
-        buffs[key] = false;
-        if (key in buffPreset) buffs[key] = buffPreset[key];
-      });
+      if (buffPreset) {
+        const buffs: Buffs = {};
+        [...Object.keys(state.buffs)].forEach((key) => {
+          buffs[key] = false;
+          if (key in buffPreset) buffs[key] = buffPreset[key]!;
+        });
 
-      return { buffs, amounts: state.amounts };
+        return { buffs, amounts: state.amounts };
+      }
     });
   },
 });

--- a/src/state/slices/controlsSlice.ts
+++ b/src/state/slices/controlsSlice.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice, original } from '@reduxjs/toolkit';
+import type { getBuildTemplateData } from '../../assets/presetdata/templateTransform';
 import type { ProfessionName, ProfessionOrSpecializationName } from '../../utils/gw2-data';
 import type { Character } from '../optimizer/optimizerCore';
 import type { OptimizerStatus } from '../optimizer/status';
@@ -154,7 +155,7 @@ export const controlSlice = createSlice({
       }
       return state;
     },
-    setBuildTemplate: (state, action) => {
+    setBuildTemplate: (state, action: PayloadAction<ReturnType<typeof getBuildTemplateData>>) => {
       const { build, specialization, profession } = action.payload;
 
       return {

--- a/src/state/slices/distribution.ts
+++ b/src/state/slices/distribution.ts
@@ -8,7 +8,7 @@ const clone =
     ? (value: any) => structuredClone(value)
     : (value: any) => JSON.parse(JSON.stringify(value));
 
-interface Distribution {
+export interface Distribution {
   Power: number;
   Power2: number;
   Burning: number;
@@ -85,11 +85,12 @@ export const distributionSlice = createSlice({
         textBoxes: action.payload,
       };
     },
-    changeAllDistributions: (state, action: PayloadAction<{ name: string; value: string }>) => {
-      const { name, value } = action.payload;
+    changeAllDistributions: (
+      state,
+      action: PayloadAction<{ name: string; value: { values2: Distribution } }>,
+    ) => {
+      const { name, value: distributionPreset } = action.payload;
       try {
-        const distributionPreset = JSON.parse(value) as typeof initialState;
-
         return {
           ...state,
           selectedDistribution: name,

--- a/src/state/slices/distribution.ts
+++ b/src/state/slices/distribution.ts
@@ -116,7 +116,7 @@ export const distributionSlice = createSlice({
     });
 
     builder.addCase(setBuildTemplate, (state, action) => {
-      const { distributionPreset, selectedDistribution } = action.payload;
+      const { distributionPreset, selectedDistribution = '' } = action.payload;
 
       if (distributionPreset) {
         return {

--- a/src/state/slices/extras.ts
+++ b/src/state/slices/extras.ts
@@ -34,7 +34,7 @@ type ExtrasValues = Record<string, ExtraValue>;
 export type ExtrasCombination = Record<ExtrasType, string>;
 export type ShouldDisplayExtras = Record<ExtrasType, boolean>;
 
-const initialState: {
+export interface ExtrasSlice {
   extras: {
     Sigil1: ExtrasValues;
     Sigil2: ExtrasValues;
@@ -44,7 +44,9 @@ const initialState: {
     Enhancement: ExtrasValues;
   };
   lifestealAmount: string;
-} = {
+}
+
+const initialState: ExtrasSlice = {
   extras: {
     Sigil1: {},
     Sigil2: {},
@@ -81,7 +83,7 @@ export const extrasSlice = createSlice({
       const { type, id, amount } = action.payload;
       state.extras[type][id].amount = amount;
     },
-    changeExtras: (state, action) => {
+    changeExtras: (state, action: PayloadAction<Partial<ExtrasSlice>>) => {
       return { ...state, ...action.payload };
     },
     changeLifestealAmount: (state, action: PayloadAction<string>) => {

--- a/src/state/slices/priorities.ts
+++ b/src/state/slices/priorities.ts
@@ -16,7 +16,7 @@ const fillAffix = (data: Data, affix: AffixNameOrCustom, value = false) => {
   data[affix] = Array(14).fill(value);
 };
 
-const initialState: {
+export interface PrioritiesSlice {
   optimizeFor: IndicatorName;
   weaponType: WeaponHandednessType;
   minBoonDuration: string;
@@ -42,7 +42,9 @@ const initialState: {
   customAffix: Partial<AffixData>;
   customAffixTextBox: string;
   customAffixError: string;
-} = {
+}
+
+const initialState: PrioritiesSlice = {
   optimizeFor: 'Damage',
   weaponType: WeaponTypes.dualWield,
   minBoonDuration: '',
@@ -90,7 +92,7 @@ export const prioritiesSlice = createSlice({
     changeConstraint: (state, action: PayloadAction<{ key: ConstraintKey; value: string }>) => {
       state[action.payload.key] = action.payload.value;
     },
-    changePriorities: (state, action) => {
+    changePriorities: (state, action: PayloadAction<Partial<PrioritiesSlice>>) => {
       return { ...state, ...action.payload };
     },
     changeOptimizeFor: (state, action: PayloadAction<IndicatorName>) => {

--- a/src/state/slices/skills.ts
+++ b/src/state/slices/skills.ts
@@ -12,9 +12,11 @@ interface SkillValue {
 // todo: specify skills keys
 type SkillsValues = Record<string, SkillValue>;
 
-const initialState: {
+export interface SkillsSlice {
   skills: SkillsValues;
-} = {
+}
+
+const initialState: SkillsSlice = {
   skills: {},
 };
 

--- a/src/state/slices/traits.ts
+++ b/src/state/slices/traits.ts
@@ -31,12 +31,14 @@ const getInitialItems = (traitline: string): TraitsValues => {
   );
 };
 
-const initialState: {
+export interface TraitsSlice {
   showAll: boolean;
   selectedLines: string[];
   selectedTraits: number[][];
   items: TraitsValues[];
-} = {
+}
+
+const initialState: TraitsSlice = {
   showAll: false,
   selectedLines: ['', '', ''],
   selectedTraits: [


### PR DESCRIPTION
Fun fact: YAML is a superset of JSON, so pasting JSON into YAML is totally a thing you can do without defining it as a string and parsing it. Not sure how I had forgotten about this fact, honestly.