### PR TITLE
feat: Utilize multiple CPU cores in all modes

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -76,7 +76,7 @@
   "Distribution Template": "Distribution Template",
   "Dual wielded": "Dual wielded",
   "Effective Power": "Effective Power",
-  "Enable experimental multicore processing": "Enable experimental multicore processing",
+  "Enable experimental Rust/WebAssembly mode": "Enable experimental Rust/WebAssembly mode",
   "Enable free WvW stat infusions": "Enable free WvW stat infusions",
   "Enable heuristics": "Enable heuristics",
   "Enhancement": "Enhancement",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -126,6 +126,7 @@
   "No Filtering": "No Filtering",
   "None": "None",
   "Note: Not cost optimized for >1 weapon set.": "Note: Not cost optimized for >1 weapon set.",
+  "Note: Some large calculations may take longer in Firefox for reasons that are currently unclear.": "Note: Some large calculations may take longer in Firefox for reasons that are currently unclear.",
   "Nourishment": "Nourishment",
   "Number of threads to use for calculations": "Number of threads to use for calculations",
   "Okay": "Okay",

--- a/src/components/nav/NavSettings.tsx
+++ b/src/components/nav/NavSettings.tsx
@@ -22,7 +22,7 @@ import {
   changeHeuristics,
   changeHwThreads,
   changeMulticore,
-  defaultHwThreads,
+  getDefaultHwThreads,
   getHeuristics,
   getHwThreadsString,
   getMulticore,
@@ -82,6 +82,7 @@ export default function NavSettings({
   const gameMode = useSelector(getGameMode);
   const selectedTemplate = useSelector(getSelectedTemplate);
   const hwThreadsString = useSelector(getHwThreadsString);
+  const defaultHwThreads = useSelector(getDefaultHwThreads);
   const enableMulticore = useSelector(getMulticore);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -175,6 +176,11 @@ export default function NavSettings({
             onChange={(e) => dispatch(changeHwThreads(e.target.value))}
             slotProps={{
               htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
+              input: {
+                // used to always display the placeholder value instead of the label
+                // eslint-disable-next-line react/jsx-no-useless-fragment
+                startAdornment: <></>,
+              },
             }}
           />
 

--- a/src/components/nav/NavSettings.tsx
+++ b/src/components/nav/NavSettings.tsx
@@ -164,6 +164,22 @@ export default function NavSettings({
       {!threadingDisabled && (
         <>
           <Divider className={classes.divider} />
+
+          <TextField
+            label={t('Threads')}
+            helperText={t('Number of threads to use for calculations')}
+            placeholder={String(defaultHwThreads)}
+            size="small"
+            value={hwThreadsString}
+            error={hwThreadsError}
+            onChange={(e) => dispatch(changeHwThreads(e.target.value))}
+            slotProps={{
+              htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
+            }}
+          />
+
+          <Divider className={classes.divider} />
+
           <FormControlLabel
             control={
               <Checkbox
@@ -180,23 +196,10 @@ export default function NavSettings({
                 }}
               />
             }
-            label={t('Enable experimental multicore processing')}
-            sx={{ mb: 3 }}
+            label={t('Enable experimental Rust/WebAssembly mode')}
             checked={enableMulticore}
           />
 
-          <TextField
-            label={t('Threads')}
-            helperText={t('Number of threads to use for calculations')}
-            placeholder={String(defaultHwThreads)}
-            size="small"
-            value={hwThreadsString}
-            error={hwThreadsError}
-            onChange={(e) => dispatch(changeHwThreads(e.target.value))}
-            slotProps={{
-              htmlInput: { inputMode: 'numeric', pattern: '[0-9]*' },
-            }}
-          />
           <FormControlLabel
             control={
               <Checkbox
@@ -207,7 +210,7 @@ export default function NavSettings({
               />
             }
             label={t('Enable heuristics')}
-            sx={{ mb: 3, display: 'none' }}
+            sx={{ display: 'none' }}
             checked={enableHeuristics}
           />
         </>

--- a/src/pages/index/index.jsx
+++ b/src/pages/index/index.jsx
@@ -11,6 +11,7 @@ import BackgroundImage from '../../components/baseComponents/BackgroundImage';
 import ErrorBoundary from '../../components/baseComponents/ErrorBoundary';
 import Layout from '../../components/baseComponents/Layout';
 import URLStateImport from '../../components/url-state/URLStateImport';
+import { isFirefox } from '../../state/optimizer/detectFirefox';
 import SagaTypes from '../../state/sagas/sagaTypes';
 import { getMulticore } from '../../state/slices/controlsSlice';
 import { getGameMode } from '../../state/slices/userSettings';
@@ -22,7 +23,7 @@ const IndexPage = () => {
   const gameMode = useSelector(getGameMode);
   const multicore = useSelector(getMulticore);
 
-  const [alertOpen, setAlertOpen] = React.useState([true, true]);
+  const [alertOpen, setAlertOpen] = React.useState([true, true, true]);
 
   const ALERTS = [
     <Trans>
@@ -53,6 +54,14 @@ const IndexPage = () => {
       </Link>
       .
     </Trans>,
+    ...(isFirefox
+      ? [
+          <Trans>
+            Note: Some large calculations may take longer in Firefox for reasons that are currently
+            unclear.
+          </Trans>,
+        ]
+      : []),
   ];
 
   return (

--- a/src/pages/index/index.jsx
+++ b/src/pages/index/index.jsx
@@ -100,8 +100,8 @@ const IndexPage = () => {
         {multicore && (
           <Alert severity="error" sx={{ marginBottom: 2 }}>
             <Typography variant="body2" sx={{ marginBottom: '16px' }}>
-              You have selected the experimental multicore mode. This mode is still in development
-              and may cause issues. Please report any issues in the Discretize{' '}
+              You have selected the experimental Rust/WebAssembly mode. This mode is still in
+              development and may cause issues. Please report any issues in the Discretize{' '}
               <Link href="https://discord.gg/Qdt7nFY" target="_blank" rel="noopener">
                 Discord
               </Link>

--- a/src/state/optimizer-parallel/calculate.ts
+++ b/src/state/optimizer-parallel/calculate.ts
@@ -21,7 +21,7 @@ const createdWorkers: WorkerWrapper[] = [];
 
 const createWorker = (): WorkerWrapper => ({
   status: 'idle',
-  worker: new Worker(new URL('./worker/worker.ts', import.meta.url), { type: 'module' }),
+  worker: new Worker(new URL('./worker/worker.ts', import.meta.url)),
 });
 
 const terminateActiveWorkers = () => {

--- a/src/state/optimizer/detectFirefox.ts
+++ b/src/state/optimizer/detectFirefox.ts
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -138,7 +138,9 @@ export async function* calculate(
             const {
               value: { isChanged, calculationRuns, newList },
             } = result;
-            combination.list = newList;
+            if (newList) {
+              combination.list = newList;
+            }
 
             combination.calculationRuns = calculationRuns ?? 0;
             // console.log(`option ${index} progress: ${calculationRuns} / ${calculationTotal}`);
@@ -295,8 +297,10 @@ export async function* calculateHeuristic(
             const {
               value: { isChanged, calculationRuns, newList },
             } = result;
-            // eslint-disable-next-line prefer-destructuring
-            combination.heuristicBestResult = newList[0];
+            if (newList) {
+              // eslint-disable-next-line prefer-destructuring
+              combination.heuristicBestResult = newList[0];
+            }
 
             combination.heuristicCalculationRuns = calculationRuns ?? 0;
             // console.log(`option ${index} heuristics progress: ${calculationRuns} / ${calculationTotal}`);

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -61,9 +61,7 @@ const findExtraBestResults = (
 };
 
 const createWorker = () =>
-  new ComlinkWorker<typeof import('./worker')>(new URL('./worker.ts', import.meta.url), {
-    type: 'module',
-  });
+  new ComlinkWorker<typeof import('./worker')>(new URL('./worker.ts', import.meta.url));
 
 const createdWorkers: ReturnType<typeof createWorker>[] = [];
 

--- a/src/state/optimizer/optimizerCore.ts
+++ b/src/state/optimizer/optimizerCore.ts
@@ -399,7 +399,7 @@ export class OptimizerCore {
     }
 
     this.list.forEach(this.calcResults, this);
-    return {
+    yield {
       isChanged: this.isChanged,
       calculationRuns,
       newList: this.list,
@@ -424,11 +424,12 @@ export class OptimizerCore {
     const { affixes, jsHeuristicsData } = settings;
 
     if (!jsHeuristicsData) {
-      return {
+      yield {
         isChanged: true,
         calculationRuns: 0,
         newList: [],
       };
+      return;
     }
 
     let calculationRuns = 0;
@@ -476,7 +477,7 @@ export class OptimizerCore {
     }
 
     this.list.forEach(this.calcResults, this);
-    return {
+    yield {
       isChanged: this.isChanged,
       calculationRuns,
       newList: this.list,

--- a/src/state/optimizer/optimizerCore.ts
+++ b/src/state/optimizer/optimizerCore.ts
@@ -326,7 +326,7 @@ export class OptimizerCore {
         yield {
           isChanged: this.isChanged,
           calculationRuns,
-          newList: this.list,
+          newList: this.isChanged ? this.list : undefined,
         };
         this.isChanged = false;
         iterationTimer = Date.now();
@@ -402,7 +402,7 @@ export class OptimizerCore {
     yield {
       isChanged: this.isChanged,
       calculationRuns,
-      newList: this.list,
+      newList: this.isChanged ? this.list : undefined,
     };
   }
 
@@ -447,7 +447,7 @@ export class OptimizerCore {
         yield {
           isChanged: this.isChanged,
           calculationRuns,
-          newList: this.list,
+          newList: this.isChanged ? this.list : undefined,
         };
         this.isChanged = false;
         iterationTimer = Date.now();
@@ -480,7 +480,7 @@ export class OptimizerCore {
     yield {
       isChanged: this.isChanged,
       calculationRuns,
-      newList: this.list,
+      newList: this.isChanged ? this.list : undefined,
     };
   }
 

--- a/src/state/optimizer/worker.ts
+++ b/src/state/optimizer/worker.ts
@@ -1,29 +1,36 @@
 import type { Combination } from './optimizer';
+import type { CalculateGenerator } from './optimizerCore';
 import { OptimizerCore } from './optimizerCore';
 
+type WorkerCombination = Combination & {
+  calculation: CalculateGenerator;
+};
+
 let i = 0;
-let combinations: Combination[] = [];
+let combinations: WorkerCombination[] = [];
 
 export const setup = (input: Combination[]) => {
   i = 0;
-  combinations = input;
-
-  combinations.forEach((combination) => {
+  combinations = input.map((combination) => {
     const core = new OptimizerCore(combination.settings);
-    combination.calculation = core.calculate();
+    return {
+      ...combination,
+      calculation: core.calculate(),
+    };
   });
 };
 
 export const setupHeuristic = (input: Combination[], split: number) => {
   i = 0;
-  combinations = input;
-
-  combinations.forEach((combination) => {
+  combinations = input.map((combination) => {
     const core = new OptimizerCore({
       ...combination.settings,
       maxResults: 1,
     });
-    combination.calculation = core.calculateHeuristic(split);
+    return {
+      ...combination,
+      calculation: core.calculateHeuristic(split),
+    };
   });
 };
 

--- a/src/state/optimizer/worker.ts
+++ b/src/state/optimizer/worker.ts
@@ -1,0 +1,50 @@
+import type { Combination } from './optimizer';
+import { OptimizerCore } from './optimizerCore';
+
+let i = 0;
+let combinations: Combination[] = [];
+
+let nextPromise: ReturnType<typeof iterate>;
+
+export const setup = (input: Combination[]) => {
+  i = 0;
+  combinations = input;
+
+  combinations.forEach((combination) => {
+    const core = new OptimizerCore(combination.settings);
+    combination.calculation = core.calculate();
+  });
+
+  nextPromise = iterate();
+};
+
+export const setupHeuristic = (input: Combination[], split: number) => {
+  i = 0;
+  combinations = input;
+
+  combinations.forEach((combination) => {
+    const core = new OptimizerCore({
+      ...combination.settings,
+      maxResults: 1,
+    });
+    combination.calculation = core.calculateHeuristic(split);
+  });
+
+  nextPromise = iterate();
+};
+
+const iterate = async () => {
+  await new Promise((resolve) => {
+    setTimeout(resolve);
+  });
+  const combination = combinations[i];
+  i = (i + 1) % combinations.length;
+
+  return { combinationIndex: combination.index, result: combination.calculation!.next() };
+};
+
+export const next = async () => {
+  const current = nextPromise;
+  nextPromise = iterate();
+  return current;
+};

--- a/src/state/optimizer/worker.ts
+++ b/src/state/optimizer/worker.ts
@@ -4,8 +4,6 @@ import { OptimizerCore } from './optimizerCore';
 let i = 0;
 let combinations: Combination[] = [];
 
-let nextPromise: ReturnType<typeof iterate>;
-
 export const setup = (input: Combination[]) => {
   i = 0;
   combinations = input;
@@ -14,8 +12,6 @@ export const setup = (input: Combination[]) => {
     const core = new OptimizerCore(combination.settings);
     combination.calculation = core.calculate();
   });
-
-  nextPromise = iterate();
 };
 
 export const setupHeuristic = (input: Combination[], split: number) => {
@@ -29,22 +25,11 @@ export const setupHeuristic = (input: Combination[], split: number) => {
     });
     combination.calculation = core.calculateHeuristic(split);
   });
-
-  nextPromise = iterate();
 };
 
-const iterate = async () => {
-  await new Promise((resolve) => {
-    setTimeout(resolve);
-  });
+export const next = async () => {
   const combination = combinations[i];
   i = (i + 1) % combinations.length;
 
   return { combinationIndex: combination.index, result: combination.calculation!.next() };
-};
-
-export const next = async () => {
-  const current = nextPromise;
-  nextPromise = iterate();
-  return current;
 };

--- a/src/state/sagas/calculationSaga.ts
+++ b/src/state/sagas/calculationSaga.ts
@@ -21,9 +21,6 @@ import SagaTypes from './sagaTypes';
 
 const worker = new ComlinkWorker<typeof import('../optimizer/optimizer')>(
   new URL('../optimizer/optimizer.ts', import.meta.url),
-  {
-    type: 'module',
-  },
 );
 
 function* runCalc() {

--- a/src/state/sagas/calculationSaga.ts
+++ b/src/state/sagas/calculationSaga.ts
@@ -9,6 +9,7 @@ import {
   changeProgress,
   changeSelectedCharacter,
   changeStatus,
+  getHwThreads,
   getJsHeuristicsEnabled,
   getSelectedCharacter,
   getStatus,
@@ -46,11 +47,12 @@ function* runCalc() {
     const originalSelectedCharacter = yield* select(getSelectedCharacter);
     const jsHeuristicsEnabled = getJsHeuristicsEnabled(reduxState);
     const { value: jsHeuristicsTarget } = getParsedJsHeuristicsTarget(reduxState);
+    const threads = getHwThreads(reduxState);
 
     let elapsed = 0;
     let timer = performance.now();
 
-    yield worker.setup(reduxState, jsHeuristicsEnabled, jsHeuristicsTarget);
+    yield worker.setup(reduxState, jsHeuristicsEnabled, jsHeuristicsTarget, threads);
 
     let nextPromise = worker.next();
 

--- a/src/state/slices/controlsSlice.ts
+++ b/src/state/slices/controlsSlice.ts
@@ -10,6 +10,7 @@ import type { Character } from '../optimizer/optimizerCore';
 import type { OptimizerStatus } from '../optimizer/status';
 import { RUNNING, RUNNING_HEURISTICS, WAITING } from '../optimizer/status';
 import type { RootState } from '../store';
+import { reduxSideEffect } from '../redux-hooks';
 
 const roundThree = (num: number) => Math.round(num * 1000) / 1000;
 
@@ -91,6 +92,10 @@ export const emptyFilteredLists = {
   Enhancement: [],
 };
 
+const THREADS_SETTINGS_STORAGE_KEY = 'hwThreads-1';
+const savedHwThreads =
+  (typeof localStorage !== 'undefined' && localStorage.getItem(THREADS_SETTINGS_STORAGE_KEY)) || '';
+
 const initialState: {
   list: Character[];
   filteredLists: Record<ExtraFilterMode, Character[]>;
@@ -134,7 +139,7 @@ const initialState: {
   jsHeuristicsEnabled: false,
   jsHeuristicsTarget: '',
   multicore: false,
-  hwThreads: '',
+  hwThreads: savedHwThreads,
   heuristics: false,
   error: '',
 };
@@ -297,6 +302,10 @@ export const getHwThreads = createSelector(
   getDefaultHwThreads,
   (hwThreadsString, defaultHwThreads) =>
     Math.max(parseHwThreads(hwThreadsString).value ?? defaultHwThreads, 1),
+);
+
+reduxSideEffect(getHwThreadsString, (hwThreads) =>
+  localStorage.setItem(THREADS_SETTINGS_STORAGE_KEY, hwThreads),
 );
 
 export const getPageTitle = createSelector(getStatus, getProgress, (status, progress) => {

--- a/src/state/slices/controlsSlice.ts
+++ b/src/state/slices/controlsSlice.ts
@@ -5,6 +5,7 @@ import type { getBuildTemplateData } from '../../assets/presetdata/templateTrans
 import type { ProfessionName, ProfessionOrSpecializationName } from '../../utils/gw2-data';
 import type { ParseFunction } from '../../utils/usefulFunctions';
 import { parseNumber } from '../../utils/usefulFunctions';
+import { isFirefox } from '../optimizer/detectFirefox';
 import type { Character } from '../optimizer/optimizerCore';
 import type { OptimizerStatus } from '../optimizer/status';
 import { RUNNING, RUNNING_HEURISTICS, WAITING } from '../optimizer/status';
@@ -90,7 +91,9 @@ export const emptyFilteredLists = {
   Enhancement: [],
 };
 
-export const defaultHwThreads = navigator.hardwareConcurrency || 4; // 4 seems to be a sensible default
+export const defaultHwThreads = isFirefox
+  ? 4 // to investigate: high thread count performance degradation in firefox
+  : navigator.hardwareConcurrency || 4; // 4 seems to be a sensible default
 
 export const parseHwThreads: ParseFunction<number> = (text) =>
   parseNumber(text, defaultHwThreads, true);


### PR DESCRIPTION
Enables multithreading in the regular (javascript) mode.

This is, in certain circumstances, as fast as (or even slightly faster than) the Rust/Webassembly mode. Not all the time, though. Notably, thread counts more than four or five in javascript mode show no additional speedup in Firefox, even when adjusting browser flags; I'm not currently sure why this is but it seems to have to do with memory allocation issues. Chrome/Edge/Safari (and the Rust/Webassembly mode in Firefox) don't suffer from this.

<img src="https://github.com/user-attachments/assets/c39db863-aea6-4203-91a3-1b7f6d5c64c3">


