### PR TITLE
Performance experiment: no megamorphic attributes

### DIFF
--- a/src/state/optimizer/optimizerSetup.ts
+++ b/src/state/optimizer/optimizerSetup.ts
@@ -638,15 +638,82 @@ export function createSettingsPerCombination(
     'Health': Classes[profession].health,
     'Armor': Classes[profession].defense,
 
-    'Power Coefficient': distribution.Power,
-    'Power2 Coefficient': distribution.Power2,
-    'Burning Coefficient': distribution.Burning,
+    'Aegis Duration': 0,
+    'Fury Duration': 0,
+    'Might Duration': 0,
+    'Protection Duration': 0,
+    'Quickness Duration': 0,
+    'Alacrity Duration': 0,
+    'Regeneration Duration': 0,
+    'Resistance Duration': 0,
+    'Resolution Duration': 0,
+    'Stability Duration': 0,
+    'Swiftness Duration': 0,
+    'Vigor Duration': 0,
+
+    'Bleeding Duration': 0,
+    'Burning Duration': 0,
+    'Confusion Duration': 0,
+    'Poison Duration': 0,
+    'Torment Duration': 0,
+
     'Bleeding Coefficient': distribution.Bleeding,
+    'Burning Coefficient': distribution.Burning,
     'Poison Coefficient': distribution.Poisoned, // renamed
     'Torment Coefficient': distribution.Torment,
     'Confusion Coefficient': distribution.Confusion,
 
+    'Bleeding Damage Tick': 0,
+    'Burning Damage Tick': 0,
+    'Confusion Damage Tick': 0,
+    'Poison Damage Tick': 0,
+    'Torment Damage Tick': 0,
+
+    'Effective Power': 0,
+    'Effective Health': 0,
+    'Effective Healing': 0,
+
+    'Damage': 0,
+    'Survivability': 0,
+    'Healing': 0,
+
+    'Bleeding Stacks': 0,
+    'Burning Stacks': 0,
+    'Confusion Stacks': 0,
+    'Poison Stacks': 0,
+    'Torment Stacks': 0,
+
+    'Bleeding DPS': 0,
+    'Burning DPS': 0,
+    'Confusion DPS': 0,
+    'Poison DPS': 0,
+    'Torment DPS': 0,
+
+    'Alternative Power': 0,
+    'Alternative Precision': 0,
+    'Alternative Ferocity': 0,
+    'Alternative Critical Chance': 0,
+    'Alternative Effective Power': 0,
+    'Alternative Critical Damage': 0,
+
+    'Clone Critical Chance': 0,
+    'Phantasm Critical Chance': 0,
+    'Phantasm Critical Damage': 0,
+    'Phantasm Effective Power': 0,
+
+    'Siphon Coefficient': 0,
+    'Siphon Base Coefficient': 0,
+    'Siphon DPS': 0,
+
+    'Maximum Health': 0,
+    'Outgoing Healing': 0,
+    'Power Coefficient': distribution.Power,
+    'NonCrit Power Coefficient': 0,
+    'Power2 DPS': 0,
+    'Power2 Coefficient': distribution.Power2,
     'Flat DPS': 0,
+    'Power DPS': 0,
+    'Player Critical Damage': 0,
   };
 
   if (profession === 'Mesmer') {


### PR DESCRIPTION
Sadly, this is not faster. Well, interestingly, it is in some circumstances, like at lower thread counts, but I think the additional memory allocation kills it when I use as many threads as I have CPU cores.

My guess is that having a non-megamorphic object for the commonly used attributes like primary, secondary, etc and another for dynamic stuff would be a win. I already knew that years ago when we first started the rewrite and never got around to it before we set up this whole ecosystem of saved character objects, though. It's probably possible to do internally-only, so this one is a to-investigate, for sure.

[draft previews]