### PR TITLE
refactor: Avoid sending settings from worker threads

### DIFF
--- a/src/state/async/calculationThunks.ts
+++ b/src/state/async/calculationThunks.ts
@@ -2,7 +2,6 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-console */
 import { freeze } from '@reduxjs/toolkit';
-import { next, setup } from '../optimizer/optimizer';
 import type { Character } from '../optimizer/optimizerCore';
 import { ERROR, RUNNING, STOPPED, SUCCESS, WAITING } from '../optimizer/status';
 import type { AppThunk } from '../redux-hooks';
@@ -21,6 +20,10 @@ import {
 import { getParsedJsHeuristicsTarget } from '../slices/extras';
 
 let resume: (() => void) | undefined;
+
+const worker = new ComlinkWorker<typeof import('../optimizer/optimizer')>(
+  new URL('../optimizer/optimizer.ts', import.meta.url),
+);
 
 export const startCalc: AppThunk = async (dispatch, getState) => {
   const reduxState = getState();
@@ -51,11 +54,13 @@ export const startCalc: AppThunk = async (dispatch, getState) => {
     let elapsed = 0;
     let timer = performance.now();
 
-    await setup(reduxState, jsHeuristicsEnabled, jsHeuristicsTarget, threads);
+    await worker.setup(reduxState, jsHeuristicsEnabled, jsHeuristicsTarget, threads);
+
+    let nextPromise = worker.next();
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const result = await next();
+      const result = await nextPromise;
 
       const { percent, heuristicsPercent, isChanged, list, filteredLists } = result.value;
       currentPercent = percent;
@@ -80,6 +85,9 @@ export const startCalc: AppThunk = async (dispatch, getState) => {
         );
         break;
       }
+
+      // concurrency: send next request to worker thread before rendering current on main thread
+      nextPromise = worker.next();
 
       dispatch(
         updateResults({

--- a/src/state/optimizer/optimizer.ts
+++ b/src/state/optimizer/optimizer.ts
@@ -6,7 +6,11 @@ import { defaultJsThreads } from '../slices/controlsSlice';
 import type { ExtrasType } from '../slices/extras';
 import type { RootState } from '../store';
 import { iteratePartitionCount } from './combinatorics';
-import type { Character, OptimizerCoreSettings } from './optimizerCore';
+import type {
+  Character,
+  OptimizerCoreMinimalSettings,
+  OptimizerCoreSettings,
+} from './optimizerCore';
 import { characterLT, UPDATE_MS } from './optimizerCore';
 import type { ExtrasCombinationEntry } from './optimizerSetup';
 import { setupCombinations } from './optimizerSetup';
@@ -15,6 +19,7 @@ export interface Combination extends ExtrasCombinationEntry {
   index: number;
 
   settings: OptimizerCoreSettings;
+  minimalSettings: OptimizerCoreMinimalSettings;
   done: boolean;
   list: Character[];
   calculationRuns: number;
@@ -97,6 +102,18 @@ export async function* calculate(
       ({ extrasCombinationEntry, settings }, index): Combination => ({
         ...extrasCombinationEntry,
         settings,
+        minimalSettings: {
+          cachedFormState: settings.cachedFormState,
+          profession: settings.profession,
+          specialization: settings.specialization,
+          weaponType: settings.weaponType,
+          appliedModifiers: settings.appliedModifiers,
+          rankby: settings.rankby,
+          shouldDisplayExtras: settings.shouldDisplayExtras,
+          extrasCombination: settings.extrasCombination,
+          modifiers: settings.modifiers,
+          gameMode: settings.gameMode,
+        },
         done: false,
         list: [],
         calculationRuns: 0,
@@ -151,7 +168,12 @@ export async function* calculate(
       } else {
         const { value } = result;
         if (value.newList) {
-          combination.list = value.newList;
+          const newList: Character[] = value.newList.map((character) => ({
+            ...character,
+            settings: combination.minimalSettings,
+          }));
+
+          combination.list = newList;
         }
         if (value.isChanged) {
           isChanged = true;
@@ -241,6 +263,18 @@ export async function* calculateHeuristic(
     ({ extrasCombinationEntry, settings }, index) => ({
       ...extrasCombinationEntry,
       settings,
+      minimalSettings: {
+        cachedFormState: settings.cachedFormState,
+        profession: settings.profession,
+        specialization: settings.specialization,
+        weaponType: settings.weaponType,
+        appliedModifiers: settings.appliedModifiers,
+        rankby: settings.rankby,
+        shouldDisplayExtras: settings.shouldDisplayExtras,
+        extrasCombination: settings.extrasCombination,
+        modifiers: settings.modifiers,
+        gameMode: settings.gameMode,
+      },
       done: false,
       list: [],
       calculationRuns: 0,
@@ -307,8 +341,12 @@ export async function* calculateHeuristic(
       } else {
         const { value } = result;
         if (value.newList) {
+          const newList: Character[] = value.newList.map((character) => ({
+            ...character,
+            settings: combination.minimalSettings,
+          }));
           // eslint-disable-next-line prefer-destructuring
-          combination.heuristicBestResult = value.newList[0];
+          combination.heuristicBestResult = newList[0];
         }
         if (value.isChanged) {
           isChanged = true;


### PR DESCRIPTION
Each time the worker threads communicate results back to the main thread, they currently include the `settings` object on every character in the list of (up to) 50 character results, even though those settings will be the same for every result from a certain combination.

Back when the calculation was not run in a worker, this just meant that every character object had a pointer to the same settings object. But data sent via postMessage is cloned, meaning that every character object includes its own fresh copy of the identical settings object once it's sent back from a worker thread.

This moves the "attach settings object" behavior out of optimizercore, which is definitely run in a worker thread, and into optimizer.ts (the coordinator that manages state between workers and sorts results), which doesn't have to be in a worker (I'm currently undecided on whether it's better to or not).

This should save some postMessage traffic and memory/garbage collection, but it seems to have no meaningful effect on performance so far.

[draft previews]