### PR TITLE
compression experiments

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "axios@0.26.1": "^0.28.1"
   },
   "dependencies": {
+    "@bokuweb/zstd-wasm": "0.0.21-alpha.5",
     "@discretize/globals": "^0.0.4",
     "@discretize/gw2-ui-new": "^0.1.7",
     "@discretize/object-compression": "^1.0.3",
@@ -60,6 +61,7 @@
     "@mui/material": "^6.1.5",
     "@reduxjs/toolkit": "^2.3.0",
     "axios": "^1.7.7",
+    "brotli-wasm": "^3.0.1",
     "comlink": "^4.4.1",
     "i18next": "^23.16.4",
     "js-yaml": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@bokuweb/zstd-wasm':
+        specifier: 0.0.21-alpha.5
+        version: 0.0.21-alpha.5
       '@discretize/globals':
         specifier: ^0.0.4
         version: 0.0.4(@mui/material@6.1.5(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/styles@6.1.4(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)(tss-react@4.9.13(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@mui/material@6.1.5(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1))
@@ -44,6 +47,9 @@ importers:
       axios:
         specifier: ^1.7.7
         version: 1.7.7
+      brotli-wasm:
+        specifier: ^3.0.1
+        version: 3.0.1
       comlink:
         specifier: ^4.4.1
         version: 4.4.1
@@ -422,6 +428,9 @@ packages:
   '@babel/types@7.26.0':
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
+
+  '@bokuweb/zstd-wasm@0.0.21-alpha.5':
+    resolution: {integrity: sha512-HydRNavt4rlQH3sbAG1iksR9V9+AsxfAXSzG5zRoksFn0f+yq8VqJ/BFp5MdcGt6lzNdELDiCOjKvJ3NpSc+Qw==}
 
   '@cloudflare/kv-asset-handler@0.3.4':
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
@@ -1570,6 +1579,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brotli-wasm@3.0.1:
+    resolution: {integrity: sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==}
+    engines: {node: '>=v18.0.0'}
 
   browserslist@4.24.2:
     resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
@@ -3818,6 +3831,8 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@bokuweb/zstd-wasm@0.0.21-alpha.5': {}
+
   '@cloudflare/kv-asset-handler@0.3.4':
     dependencies:
       mime: 3.0.0
@@ -4820,6 +4835,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brotli-wasm@3.0.1: {}
 
   browserslist@4.24.2:
     dependencies:

--- a/src/state/async/formStateThunks.ts
+++ b/src/state/async/formStateThunks.ts
@@ -1,7 +1,10 @@
+import { compress, init } from '@bokuweb/zstd-wasm';
 import axios from 'axios';
+import brotliInit from 'brotli-wasm';
 import type { TFunction } from 'i18next';
 import JsonUrl from 'json-url';
 import pako from 'pako';
+import { uint8ArrayToBase64 } from 'uint8array-extras';
 import { PARAMS } from '../../utils/queryParam';
 import type { AppThunk } from '../redux-hooks';
 // import { changeBuildPage } from '../slices/buildPage';
@@ -9,6 +12,8 @@ import { changeAll, emptyFilteredLists } from '../slices/controlsSlice';
 import type { RootState } from '../store';
 
 const lib = JsonUrl('lzma');
+const zstdInit = init();
+const textEncoder = new TextEncoder();
 
 // hard coded temporarily!
 const version = 0;
@@ -113,13 +118,57 @@ const getLongUrl = async (
   onFailure: (msg: string) => void,
   t: TFunction,
 ): Promise<string> => {
+  const jsonString = JSON.stringify(exportData);
+  console.log(`jsonString.length`, jsonString.length);
+
+  /*
   console.time('Compressed json-url data in:');
   const jsonUrlData = await lib.compress(exportData);
+  // console.log('json-url string', jsonUrlData);
+  console.log('json-url length', jsonUrlData.length);
   console.timeEnd('Compressed json-url data in:');
+  */
+
+  console.time(`Compressed pakoData data in:`);
+  const pakoData = uint8ArrayToBase64(pako.deflate(JSON.stringify(exportData)), {
+    urlSafe: true,
+  });
+  // console.log(`pakoData string`, pakoData);
+  console.log(`pakoData length`, pakoData.length);
+  console.timeEnd(`Compressed pakoData data in:`);
+
+  const brotli = await brotliInit;
+
+  for (const quality of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) {
+    console.time(`Compressed brotli ${quality} data in:`);
+    const brotliData = uint8ArrayToBase64(
+      brotli.compress(textEncoder.encode(jsonString), { quality }),
+      {
+        urlSafe: true,
+      },
+    );
+    // console.log(`brotliData ${quality} string`, brotliData);
+    console.log(`brotliData ${quality} length`, brotliData.length);
+    console.timeEnd(`Compressed brotli ${quality} data in:`);
+  }
+
+  await zstdInit;
+
+  for (const quality of Array(22)
+    .fill(0)
+    .map((_, i) => i)) {
+    console.time(`Compressed zstd ${quality} data in:`);
+    const zstdData = uint8ArrayToBase64(compress(textEncoder.encode(jsonString), quality), {
+      urlSafe: true,
+    });
+    // console.log(`zstd ${quality} string`, zstdData);
+    console.log(`zstd ${quality} length`, zstdData.length);
+    console.timeEnd(`Compressed zstd ${quality} data in:`);
+  }
 
   const urlObject = new URL(window.location.href);
-  urlObject.searchParams.set(PARAMS.VERSION, String(version));
-  urlObject.searchParams.set(PARAMS.DATA, jsonUrlData);
+  // urlObject.searchParams.set(PARAMS.VERSION, String(version));
+  // urlObject.searchParams.set(PARAMS.DATA, );
   const longUrl = urlObject.href;
 
   if (longUrl.length > 8000) {
@@ -150,7 +199,7 @@ export const exportFormState =
     try {
       const reduxState = getState();
 
-      const exportData = modifyState(reduxState.optimizer);
+      const exportData = reduxState.optimizer;
       console.log(exportData);
 
       let successMessage = import.meta.env.VITE_HAS_CF

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,4 +26,10 @@ export default defineConfig({
     format: 'iife',
     plugins: () => [comlink(), yamlImporter(), wasm()],
   },
+  optimizeDeps: {
+    exclude: ['brotli-wasm', '@bokuweb/zstd-wasm'],
+    esbuildOptions: {
+      target: 'es2020',
+    },
+  },
 });


### PR DESCRIPTION
Currently our unshortened URLs are compressed via LZMA (json-url library), which is unusably slow if we store all of the results. Our short URLs, before being sent to the server to be shortened, are compressed using deflate (pako), which has a bit worse than half its compression ratio if we do so.

Experimenting here with some brotli/zstd libraries. Brotli 8 and zstd 8 seem like reasonable levels, yielding similar compression ratios as json-url LZMA and similar performance to pako's deflate.

zstd is faster in this particular setup, but seems to break when reloaded by vite's hot module reloading in dev mode.

Important considerations include bundle size (brotli usually ships a large dictionary with its compressor; I think this includes it; would like to see the results without it) and future compatibility (`"Content-Encoding", "br"` exists; `node:zlib` supports brotli and cloudflare workers ships it with `nodejs_compat_v2` if we ever needed to decode on the server side; none of these are _currently_ true of zstd).

```
jsonString.length 2341796
json-url length 34586
Compressed json-url data in:: 15717.1650390625 ms
pakoData length 97403
Compressed pakoData data in:: 51.894775390625 ms
brotliData 0 length 1147510
Compressed brotli 0 data in:: 167.887939453125 ms
brotliData 1 length 1118283
Compressed brotli 1 data in:: 159.541015625 ms
brotliData 2 length 66170
Compressed brotli 2 data in:: 79.85107421875 ms
brotliData 3 length 57203
Compressed brotli 3 data in:: 82.751220703125 ms
brotliData 4 length 51322
Compressed brotli 4 data in:: 96.630126953125 ms
brotliData 5 length 42127
Compressed brotli 5 data in:: 57.64013671875 ms
brotliData 6 length 41082
Compressed brotli 6 data in:: 69.693115234375 ms
brotliData 7 length 40336
Compressed brotli 7 data in:: 80.15087890625 ms
brotliData 8 length 39956
Compressed brotli 8 data in:: 85.27099609375 ms
brotliData 9 length 39471
Compressed brotli 9 data in:: 106.369140625 ms
brotliData 10 length 36894
Compressed brotli 10 data in:: 533.053955078125 ms
brotliData 11 length 35382
Compressed brotli 11 data in:: 2325.001953125 ms
zstd 0 length 55255
Compressed zstd 0 data in:: 7.204833984375 ms
zstd 1 length 67679
Compressed zstd 1 data in:: 7.087158203125 ms
zstd 2 length 57788
Compressed zstd 2 data in:: 5.81884765625 ms
zstd 3 length 55255
Compressed zstd 3 data in:: 6.541015625 ms
zstd 4 length 54687
Compressed zstd 4 data in:: 7.327880859375 ms
zstd 5 length 47556
Compressed zstd 5 data in:: 15.64501953125 ms
zstd 6 length 44647
Compressed zstd 6 data in:: 20.198974609375 ms
zstd 7 length 43686
Compressed zstd 7 data in:: 23.38818359375 ms
zstd 8 length 42258
Compressed zstd 8 data in:: 21.94384765625 ms
zstd 9 length 41852
Compressed zstd 9 data in:: 28.1669921875 ms
zstd 10 length 41287
Compressed zstd 10 data in:: 39.4228515625 ms
zstd 11 length 40823
Compressed zstd 11 data in:: 42.204833984375 ms
zstd 12 length 40822
Compressed zstd 12 data in:: 57.587890625 ms
zstd 13 length 41243
Compressed zstd 13 data in:: 115.190185546875 ms
zstd 14 length 40599
Compressed zstd 14 data in:: 183.5478515625 ms
zstd 15 length 40108
Compressed zstd 15 data in:: 276.432861328125 ms
zstd 16 length 38955
Compressed zstd 16 data in:: 179.58203125 ms
zstd 17 length 38562
Compressed zstd 17 data in:: 208.568115234375 ms
zstd 18 length 38892
Compressed zstd 18 data in:: 252.544189453125 ms
zstd 19 length 37714
Compressed zstd 19 data in:: 516.73388671875 ms
zstd 20 length 37714
Compressed zstd 20 data in:: 524.890869140625 ms
zstd 21 length 37490
Compressed zstd 21 data in:: 1162.782958984375 ms
```

[draft previews]