### PR TITLE
chore(deps): Remove @discretize/globals dependency

### DIFF
--- a/build/main.jsx
+++ b/build/main.jsx
@@ -1,4 +1,3 @@
-import { globals } from '@discretize/globals';
 import '@discretize/gw2-ui-new/dist/default_style.css';
 import '@discretize/gw2-ui-new/dist/index.css';
 import '@discretize/react-discretize-components/dist/index.css';
@@ -7,6 +6,7 @@ import { CssBaseline, ThemeProvider } from '@mui/material';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
+import { globals } from '../src/utils/globals';
 import IndexPage from '../src/pages/build/index';
 import store from '../src/state/store';
 import muiTheme from '../src/utils/placeholder-unused-theme';

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "axios@0.26.1": "^0.29.0"
   },
   "dependencies": {
-    "@discretize/globals": "^0.0.4",
     "@discretize/gw2-ui-new": "^0.1.7",
     "@discretize/object-compression": "^1.0.3",
     "@discretize/react-discretize-components": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
 
   .:
     dependencies:
-      '@discretize/globals':
-        specifier: ^0.0.4
-        version: 0.0.4(@mui/material@6.3.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/styles@6.3.0(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)(tss-react@4.9.14(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@mui/material@6.3.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))
       '@discretize/gw2-ui-new':
         specifier: ^0.1.7
         version: 0.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -442,14 +439,6 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
-
-  '@discretize/globals@0.0.4':
-    resolution: {integrity: sha512-b0efhmvAhjp3OzRCqGVgF+7ujRfOfgLJtohXayNsPSAf5f00qzAKPaiiyUrPzl3VrJqNYZYP8V4MiVNvptox5Q==}
-    peerDependencies:
-      '@mui/material': ^5.0.0 || ^6.0.0
-      '@mui/styles': ^5.0.0 || ^6.0.0
-      react: ^18.0.0
-      tss-react: ^4.0.0
 
   '@discretize/gw2-ui-new@0.1.7':
     resolution: {integrity: sha512-FTCGhWz+52SCxgRUVwT6KVridPXVkXRQBnZoxIGTXE83hiqty4IFQb9R4af7ynjK8P0LlQ9SeX+jsNIBmvWxuA==}
@@ -1091,16 +1080,6 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/styles@6.3.0':
-    resolution: {integrity: sha512-IG7U0TV1KAtiZUQALoABaVoe5/bK5+ZlngUJXdPlp1v8clPCPlid2M/Nd8Gnv10gyKm5HWmoJ4qLN8/DELM/wA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@mui/system@6.3.0':
     resolution: {integrity: sha512-L+8hUHMNlfReKSqcnVslFrVhoNfz/jw7Fe9NfDE85R3KarvZ4O3MU9daF/lZeqEAvnYxEilkkTfDwQ7qCgJdFg==}
     engines: {node: '>=14.0.0'}
@@ -1703,9 +1682,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-vendor@2.0.8:
-    resolution: {integrity: sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==}
-
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
@@ -2210,9 +2186,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  hyphenate-style-name@1.1.0:
-    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
-
   i18next@24.2.0:
     resolution: {integrity: sha512-ArJJTS1lV6lgKH7yEf4EpgNZ7+THl7bsGxxougPYiXRTJ/Fe1j08/TBpV9QsXCIYVfdE/HWG/xLezJ5DOlfBOA==}
     peerDependencies:
@@ -2324,9 +2297,6 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
-
-  is-in-browser@1.1.3:
-    resolution: {integrity: sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g==}
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -2454,30 +2424,6 @@ packages:
 
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
-
-  jss-plugin-camel-case@10.10.0:
-    resolution: {integrity: sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==}
-
-  jss-plugin-default-unit@10.10.0:
-    resolution: {integrity: sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==}
-
-  jss-plugin-global@10.10.0:
-    resolution: {integrity: sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==}
-
-  jss-plugin-nested@10.10.0:
-    resolution: {integrity: sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==}
-
-  jss-plugin-props-sort@10.10.0:
-    resolution: {integrity: sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==}
-
-  jss-plugin-rule-value-function@10.10.0:
-    resolution: {integrity: sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==}
-
-  jss-plugin-vendor-prefixer@10.10.0:
-    resolution: {integrity: sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==}
-
-  jss@10.10.0:
-    resolution: {integrity: sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -3241,9 +3187,6 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
-  tiny-warning@1.0.3:
-    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
-
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -3839,13 +3782,6 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@discretize/globals@0.0.4(@mui/material@6.3.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/styles@6.3.0(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)(tss-react@4.9.14(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@mui/material@6.3.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))':
-    dependencies:
-      '@mui/material': 6.3.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mui/styles': 6.3.0(@types/react@18.3.18)(react@18.3.1)
-      react: 18.3.1
-      tss-react: 4.9.14(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@mui/material@6.3.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
-
   '@discretize/gw2-ui-new@0.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@discretize/typeface-menomonia': 0.1.3
@@ -4311,29 +4247,6 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.18)(react@18.3.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
-
-  '@mui/styles@6.3.0(@types/react@18.3.18)(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@emotion/hash': 0.9.2
-      '@mui/private-theming': 6.3.0(@types/react@18.3.18)(react@18.3.1)
-      '@mui/types': 7.2.20(@types/react@18.3.18)
-      '@mui/utils': 6.3.0(@types/react@18.3.18)(react@18.3.1)
-      clsx: 2.1.1
-      csstype: 3.1.3
-      hoist-non-react-statics: 3.3.2
-      jss: 10.10.0
-      jss-plugin-camel-case: 10.10.0
-      jss-plugin-default-unit: 10.10.0
-      jss-plugin-global: 10.10.0
-      jss-plugin-nested: 10.10.0
-      jss-plugin-props-sort: 10.10.0
-      jss-plugin-rule-value-function: 10.10.0
-      jss-plugin-vendor-prefixer: 10.10.0
-      prop-types: 15.8.1
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.18
 
   '@mui/system@6.3.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
@@ -4974,11 +4887,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  css-vendor@2.0.8:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      is-in-browser: 1.1.3
 
   csstype@3.1.3: {}
 
@@ -5676,8 +5584,6 @@ snapshots:
 
   husky@9.1.7: {}
 
-  hyphenate-style-name@1.1.0: {}
-
   i18next@24.2.0(typescript@5.7.2):
     dependencies:
       '@babel/runtime': 7.26.0
@@ -5797,8 +5703,6 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-in-browser@1.1.3: {}
-
   is-interactive@1.0.0: {}
 
   is-map@2.0.3: {}
@@ -5915,52 +5819,6 @@ snapshots:
   json5@2.2.3: {}
 
   jsonify@0.0.1: {}
-
-  jss-plugin-camel-case@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      hyphenate-style-name: 1.1.0
-      jss: 10.10.0
-
-  jss-plugin-default-unit@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      jss: 10.10.0
-
-  jss-plugin-global@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      jss: 10.10.0
-
-  jss-plugin-nested@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      jss: 10.10.0
-      tiny-warning: 1.0.3
-
-  jss-plugin-props-sort@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      jss: 10.10.0
-
-  jss-plugin-rule-value-function@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      jss: 10.10.0
-      tiny-warning: 1.0.3
-
-  jss-plugin-vendor-prefixer@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      css-vendor: 2.0.8
-      jss: 10.10.0
-
-  jss@10.10.0:
-    dependencies:
-      '@babel/runtime': 7.26.0
-      csstype: 3.1.3
-      is-in-browser: 1.1.3
-      tiny-warning: 1.0.3
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -6769,8 +6627,6 @@ snapshots:
   text-table@0.2.0: {}
 
   through@2.3.8: {}
-
-  tiny-warning@1.0.3: {}
 
   tmp@0.0.33:
     dependencies:

--- a/src/pages/build/index.jsx
+++ b/src/pages/build/index.jsx
@@ -1,8 +1,8 @@
-import { Layout } from '@discretize/globals';
 import { APILanguageProvider } from '@discretize/gw2-ui-new';
 import { Box, Chip, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
+import { Layout } from '../../utils/globals';
 import BuildPage from '../../components/BuildPage';
 import BackgroundImage from '../../components/baseComponents/BackgroundImage';
 import ErrorBoundary from '../../components/baseComponents/ErrorBoundary';

--- a/src/pages/index/main.jsx
+++ b/src/pages/index/main.jsx
@@ -1,4 +1,3 @@
-import { globals } from '@discretize/globals';
 import '@discretize/gw2-ui-new/dist/default_style.css';
 import '@discretize/gw2-ui-new/dist/index.css';
 import '@discretize/react-discretize-components/dist/index.css';
@@ -8,6 +7,7 @@ import { CssBaseline, ThemeProvider } from '@mui/material';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
+import { globals } from '../../utils/globals';
 import 'typeface-fira-mono';
 import 'typeface-muli';
 import 'typeface-raleway';

--- a/src/utils/globals/index.ts
+++ b/src/utils/globals/index.ts
@@ -1,0 +1,4 @@
+import globals from './styles/globals';
+import Layout from './styles/Layout';
+
+export { globals, Layout };

--- a/src/utils/globals/styles/Layout.jsx
+++ b/src/utils/globals/styles/Layout.jsx
@@ -1,0 +1,23 @@
+import { Box, Container, useMediaQuery, useTheme } from '@mui/material';
+
+const Layout = ({ children, ContainerProps, disableContainer = false }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('lg'));
+  return (
+    (!disableContainer && !isMobile && (
+      <Container maxWidth="lg" {...ContainerProps}>
+        <Box
+          sx={{
+            padding: 2,
+            backgroundColor: 'background.default',
+            boxShadow: 5,
+          }}
+        >
+          {children}
+        </Box>
+      </Container>
+    )) || <Box sx={{ p: 2 }}>{children}</Box>
+  );
+};
+
+export default Layout;

--- a/src/utils/globals/styles/globals.js
+++ b/src/utils/globals/styles/globals.js
@@ -1,0 +1,83 @@
+import theme from './muiTheme';
+
+export default {
+  body: {
+    cursor: `url('/images/cursors/default.png'), default`,
+  },
+  'a, button, input, .MuiMenuItem-root, .MuiInput-root, .MuiSelect-root, .MuiFormControlLabel-label, .MuiButtonBase-root, .noUi-handle, .MuiSlider-root, .MuiChip-root, .MuiSvgIcon-root, .MuiAutocomplete-option':
+    {
+      cursor: `url('/images/cursors/green.png'), pointer !important`,
+    },
+
+  '::selection': {
+    backgroundColor: theme.palette.primary.dark,
+    color: theme.palette.common.white,
+  },
+
+  'code, pre, samp': {
+    fontFamily: 'Fira Mono',
+    lineHeight: 1,
+    fontSize: '0.875rem',
+  },
+
+  'code, samp': {
+    color: theme.palette.common.white,
+    backgroundColor: theme.palette.background.embossed,
+    padding: `${theme.spacing(0.25)} ${theme.spacing(0.75)}`,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    boxShadow: theme.shadows[1],
+  },
+
+  pre: {
+    margin: `0 ${theme.spacing(2)} ${theme.spacing(2)}`,
+    [theme.breakpoints.up('sm')]: {
+      marginLeft: theme.spacing(3),
+      marginRight: theme.spacing(3),
+    },
+    whiteSpace: 'pre',
+    '& > code': {
+      padding: theme.spacing(2),
+      display: 'block',
+      width: '100%',
+      boxShadow: theme.shadows[2],
+      wordWrap: 'normal',
+      wordBreak: 'normal',
+      whiteSpace: 'pre',
+      overflowX: 'auto',
+    },
+  },
+
+  blockquote: {
+    borderLeft: `2px solid ${theme.palette.primary.main}`,
+    padding: theme.spacing(2),
+    margin: `${theme.spacing(2)} ${theme.spacing(2)}`,
+    [theme.breakpoints.up('sm')]: {
+      marginLeft: theme.spacing(3),
+      marginRight: theme.spacing(3),
+    },
+  },
+
+  '::-webkit-scrollbar': {
+    width: theme.spacing(1),
+    height: theme.spacing(1),
+  },
+  '::-webkit-scrollbar-track': {
+    background: '#1e2124',
+  },
+  '::-webkit-scrollbar-thumb': {
+    background: '#484b51',
+    borderRadius: theme.shape.borderRadius,
+  },
+  '::-webkit-scrollbar-thumb:hover': {
+    background: '#b1b1b5',
+  },
+  '::-webkit-scrollbar-corner': {
+    background: '#1e2124',
+  },
+
+  '#nprogress .bar': {
+    zIndex: 1501,
+    height: 3,
+  },
+};

--- a/src/utils/globals/styles/muiTheme.jsx
+++ b/src/utils/globals/styles/muiTheme.jsx
@@ -1,0 +1,241 @@
+import { Paper } from '@mui/material';
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#00cccc',
+      light: '#64ffff',
+      dark: '#009a9b',
+    },
+    secondary: {
+      main: '#ff6e40',
+      light: '#FF8B66',
+      dark: '#B24D2C',
+    },
+    embossed: '#2a2c31',
+
+    background: {
+      default: '#2f3136',
+      paper: '#26292e',
+    },
+    text: {
+      primary: '#ddd',
+      secondary: '#b1b1b5',
+    },
+    divider: '#1e2124',
+    star: '#FFDF00',
+  },
+  typography: {
+    fontFamily: 'Muli',
+    fontSize: 16,
+    h1: {
+      fontFamily: 'Raleway',
+    },
+    h2: {
+      fontFamily: 'Raleway',
+    },
+    h3: {
+      fontFamily: 'Raleway',
+    },
+    h4: {
+      fontFamily: 'Raleway',
+    },
+    h5: {
+      fontFamily: 'Raleway',
+    },
+    h6: {
+      fontFamily: 'Raleway',
+    },
+  },
+});
+export default createTheme(theme, {
+  components: {
+    MuiSvgIcon: {
+      styleOverrides: {
+        root: {
+          marginBottom: '-2px !important',
+        },
+      },
+    },
+    MuiTable: {
+      styleOverrides: {
+        root: {
+          marginBottom: theme.spacing(2),
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          [theme.breakpoints.down('md')]: {
+            display: 'block',
+            width: 'auto',
+          },
+        },
+      },
+    },
+    MuiTableBody: {
+      styleOverrides: {
+        root: {
+          [theme.breakpoints.down('md')]: {
+            display: 'block',
+            width: 'auto',
+          },
+          '&> tr:last-child': {
+            '&> th, td': {
+              borderBottom: 'none',
+            },
+          },
+        },
+      },
+    },
+    MuiTableRow: {
+      styleOverrides: {
+        root: {
+          [theme.breakpoints.down('md')]: {
+            paddingTop: theme.spacing(1),
+            paddingBottom: theme.spacing(1),
+            display: 'block',
+            width: 'auto',
+            height: 'auto',
+            '&:not(:last-child)': {
+              borderBottom: `1px solid ${theme.palette.divider}`,
+            },
+          },
+        },
+        head: {
+          [theme.breakpoints.down('md')]: {
+            height: 'auto',
+            borderBottom: `1px solid ${theme.palette.divider}`,
+          },
+        },
+      },
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          borderBottom: `1px solid ${theme.palette.divider}`,
+          [theme.breakpoints.down('md')]: {
+            display: 'block',
+            width: 'auto',
+            borderBottom: 'none',
+            padding: '4px 24px 4px 24px',
+          },
+          'th&': {
+            fontWeight: 700,
+          },
+          '& > *:last-child': {
+            marginBottom: 0,
+          },
+        },
+        head: {
+          fontSize: '0.8571428571428571rem',
+          color: theme.palette.text.secondary,
+          lineHeight: 'inherit',
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        contained: {
+          fontWeight: 600,
+          transition: theme.transitions.create(
+            ['background-color', 'box-shadow', 'border', 'color'],
+            {
+              duration: theme.transitions.duration.short,
+            },
+          ),
+          '&:hover': {
+            color: 'white !important',
+          },
+        },
+      },
+    },
+    MuiButtonBase: { defaultProps: { disableRipple: true } },
+    MuiGridList: {
+      styleOverrides: {
+        root: {
+          overflowY: 'initial',
+        },
+      },
+    },
+    MuiGridListTile: {
+      styleOverrides: {
+        tile: {
+          overflow: 'initial',
+        },
+      },
+    },
+    MuiList: {
+      styleOverrides: {
+        root: {
+          '& > hr': {
+            marginBottom: 0,
+          },
+        },
+      },
+    },
+    MuiListItem: {
+      styleOverrides: {
+        root: {
+          paddingTop: '11px',
+          paddingBottom: '11px',
+          '& > *:first-child': {
+            paddingLeft: 0,
+          },
+        },
+        dense: {
+          paddingTop: '8px',
+          paddingBottom: '8px',
+        },
+      },
+    },
+    MuiListItemText: {
+      styleOverrides: {
+        root: {
+          marginTop: 0,
+          marginBottom: 0,
+          padding: '0 16px',
+        },
+      },
+    },
+    MuiAccordion: {
+      styleOverrides: {
+        root: { background: theme.palette.background.paper },
+      },
+    },
+    MuiMenu: {
+      defaultProps: {
+        elevation: 0,
+      },
+    },
+    MuiPaper: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: {
+          boxShadow: theme.shadows[1],
+        },
+      },
+    },
+    MuiDivider: {
+      styleOverrides: {
+        root: {
+          marginBottom: theme.spacing(2),
+        },
+      },
+    },
+    MuiAutocomplete: {
+      defaultProps: {
+        PaperComponent: ({ children }) => (
+          <Paper elevation={3} sx={{ background: theme.palette.background.paper }}>
+            {children}
+          </Paper>
+        ),
+      },
+    },
+  },
+});


### PR DESCRIPTION
As mentioned in https://github.com/discretize/discretize-ui/pull/57, the `@discretize/globals` package doesn't need to be shared, and legacy code in it and in its tooling is getting in the way of Typescript and React updates. This includes the referenced files in this repo and removes the dependency.