### PR TITLE
fix: Omnipotion always appearing in results

### DIFF
--- a/src/components/sections/results/ResultDetails.tsx
+++ b/src/components/sections/results/ResultDetails.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { buffModifiers } from '../../../assets/modifierdata';
 import { getSelectedCharacter } from '../../../state/slices/controlsSlice';
-import { getGameMode } from '../../../state/slices/userSettings';
 import { createAssumedBuffs } from '../../../utils/assumedBuffs';
 import { objectEntries } from '../../../utils/usefulFunctions';
 import ErrorBoundary from '../../baseComponents/ErrorBoundary';

--- a/src/components/sections/results/ResultDetails.tsx
+++ b/src/components/sections/results/ResultDetails.tsx
@@ -29,7 +29,6 @@ const ResultDetails = () => {
   const { t } = useTranslation();
 
   const character = useSelector(getSelectedCharacter);
-  const gameMode = useSelector(getGameMode);
 
   if (!character) {
     return null;
@@ -38,8 +37,8 @@ const ResultDetails = () => {
   const buffsRaw = buffModifiers
     .flatMap((buff) => buff.items)
     .filter((buff) => character.settings.cachedFormState.buffs.buffs[buff.id]);
-  // gamemode is technically not correct since the gamemode is not tied to a character at the moment.
-  const assumedBuffs = createAssumedBuffs({ buffsRaw, character, gameMode });
+
+  const assumedBuffs = createAssumedBuffs({ buffsRaw, character });
 
   const bonuses: Record<string, string> = {};
   objectEntries({

--- a/src/components/sections/results/TemplateHelperSections.jsx
+++ b/src/components/sections/results/TemplateHelperSections.jsx
@@ -7,7 +7,6 @@ import { useSelector } from 'react-redux';
 import { allExtrasModifiersById, buffModifiers } from '../../../assets/modifierdata';
 import { getSkills, getWeapons } from '../../../state/slices/buildPage';
 import { getTraitLines, getTraits } from '../../../state/slices/traits';
-import { getGameMode } from '../../../state/slices/userSettings';
 import { createAssumedBuffs } from '../../../utils/assumedBuffs';
 import { MAX_INFUSIONS, WEAPONS, getWeight, statInfusionIds } from '../../../utils/gw2-data';
 import Section from '../../baseComponents/Section';
@@ -24,7 +23,6 @@ const TemplateHelperSections = ({ character }) => {
   const { t } = useTranslation();
   const weapons = useSelector(getWeapons);
   const skills = useSelector(getSkills);
-  const gameMode = useSelector(getGameMode);
   const traitSelection = useSelector(getTraits);
   const traitLines = useSelector(getTraitLines);
 
@@ -168,8 +166,8 @@ const TemplateHelperSections = ({ character }) => {
     };
 
     const buffsRaw = buffModifiers.flatMap((buff) => buff.items).filter((buff) => buffs[buff.id]);
-    // gamemode is technically not correct since the gamemode is not tied to a character at the moment.
-    const assumedBuffs = createAssumedBuffs({ buffsRaw, gameMode, character });
+
+    const assumedBuffs = createAssumedBuffs({ buffsRaw, character });
 
     const template = {
       attributes: {

--- a/src/utils/assumedBuffs.ts
+++ b/src/utils/assumedBuffs.ts
@@ -1,6 +1,5 @@
 import type { ModifierItem } from '../assets/modifierdata/metadata';
 import type { Character } from '../state/optimizer/types/optimizerTypes';
-import type { GameMode } from '../state/slices/userSettings';
 import { JADE_BOT_CORE_IDS } from './gw2-data';
 
 type AssumedBuff = Pick<ModifierItem, 'id' | 'gw2id' | 'type'>;

--- a/src/utils/assumedBuffs.ts
+++ b/src/utils/assumedBuffs.ts
@@ -9,11 +9,9 @@ type AssumedBuff = Pick<ModifierItem, 'id' | 'gw2id' | 'type'>;
 export function createAssumedBuffs({
   buffsRaw,
   character,
-  gameMode,
 }: {
   buffsRaw: ModifierItem[];
   character: Character;
-  gameMode: GameMode;
 }): AssumedBuff[] {
   const assumedBuffs = buffsRaw.map(({ id, gw2id, type }) => ({ id, gw2id, type }));
 
@@ -38,7 +36,7 @@ export function createAssumedBuffs({
       gw2id: JADE_BOT_CORE_IDS[jadeBotTier - 1],
     });
 
-  if (gameMode === 'fractals') {
+  if (character.settings.appliedModifiers.find(({ id }) => id === 'omnipotion')) {
     assumedBuffs.push({ type: 'Item', id: 'omnipotion', gw2id: 79722 });
   }
 


### PR DESCRIPTION

Resolves #884.

This only applies to the results section at the bottom of the main optimizer page; the build page has a bunch of missing/inaccurate buffs, omnipotion being only one of them.

[no previews]