### PR TITLE
feat: Implement frost aura buff

### DIFF
--- a/docs/Contributing/Data Format/Modifiers.md
+++ b/docs/Contributing/Data Format/Modifiers.md
@@ -296,9 +296,15 @@ Array of numerical GW2 ids to select the cheapest price from if "show prices" is
 
 > source: [src/components/sections/buffs/Buffs.jsx](../../../src/components/sections/buffs/Buffs.jsx)
 
-`Boon`, `Skill`, `Trait`, `CommonEffect`, `Condition`, or `Text`; used to specify what kind of component to use to render buffs.
+`Boon`, `Skill`, `Trait`, `CommonEffect`, `Condition`, `Aura`, or `Text`; used to specify what kind of component to use to render buffs.
 
 (Food, utilities, runes, and sigils are always items; skills are always skills; traits are always traits. This can be changed if needed.)
+
+#### componentNameProp (buffs only)
+
+> source: [src/components/sections/buffs/Buffs.jsx](../../../src/components/sections/buffs/Buffs.jsx)
+
+String used to set the "name" property passed to gw2-ui to render buffs.
 
 #### defaultEnabled (traits only)
 

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -319,6 +319,7 @@
   "buffSection_Effects": "Effects",
   "buffSection_Other buffs": "Other buffs",
   "buffText_Exposed": "Exposed",
+  "buffText_Frost Aura": "Frost Aura",
   "buffText_Fury": "Fury",
   "buffText_Jade Bot": "Jade Bot",
   "buffText_Jade Bot Tier": "Jade Bot Tier",

--- a/src/assets/modifierdata/buffs.yaml
+++ b/src/assets/modifierdata/buffs.yaml
@@ -44,6 +44,14 @@
           Outgoing Phantasm Damage: [1%, target]
       type: Condition
 
+    - id: frost-aura
+      text: Frost Aura
+      componentNameProp: Frost
+      modifiers:
+        damage:
+          Damage Reduction: [10%, mult]
+      type: Aura
+
 - section: Other buffs
   items:
     - id: jade-bot-base

--- a/src/assets/modifierdata/metadata.ts
+++ b/src/assets/modifierdata/metadata.ts
@@ -308,7 +308,9 @@ export interface ModifierItem {
     | 'Condition'
     | 'Text'
     | 'Item'
-    | 'Augmentation';
+    | 'Augmentation'
+    | 'Aura';
+  componentNameProp?: string;
   temporaryBuff?: true | false | 'activeOutOfCombat';
 }
 

--- a/src/assets/testData.js
+++ b/src/assets/testData.js
@@ -123,6 +123,8 @@ const testModifiers = async () => {
           wvwModifiers,
           gw2id,
           type,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          componentNameProp,
           minor,
           amountData,
           defaultEnabled,

--- a/src/components/sections/buffs/Buffs.jsx
+++ b/src/components/sections/buffs/Buffs.jsx
@@ -1,5 +1,6 @@
 import {
   Augmentation,
+  Aura,
   Boon,
   CommonEffect,
   Condition,
@@ -64,6 +65,7 @@ const Buffs = () => {
     Condition,
     Item,
     Augmentation,
+    Aura,
   };
 
   return (
@@ -79,12 +81,14 @@ const Buffs = () => {
             </FormLabel>
             <FormGroup>
               {section.items.map((buff) => {
-                const { type, text, id, gw2id, subText, amountData } = buff;
+                const { type, componentNameProp, text, id, gw2id, subText, amountData } = buff;
 
                 const Component = components[type];
-                const name = ['Boon', 'Condition', 'CommonEffect', 'Augmentation'].includes(type)
-                  ? firstUppercase(id)
-                  : undefined;
+                const name =
+                  componentNameProp ??
+                  (['Boon', 'Condition', 'CommonEffect', 'Augmentation', 'Aura'].includes(type)
+                    ? firstUppercase(id)
+                    : undefined);
 
                 const label =
                   type === 'Text' ? (
@@ -104,7 +108,15 @@ const Buffs = () => {
                       </Typography>
                     </>
                   ) : (
-                    <Component id={gw2id} name={name} disableLink className={classes.boon} />
+                    <>
+                      <Component id={gw2id} name={name} disableLink className={classes.boon} />
+                      {subText && (
+                        <Typography variant="caption" className={classes.tinyNote}>
+                          {' '}
+                          {subText}
+                        </Typography>
+                      )}
+                    </>
                   );
 
                 return (

--- a/src/components/url-state/schema/SchemaDicts.js
+++ b/src/components/url-state/schema/SchemaDicts.js
@@ -442,4 +442,5 @@ export const buffsDict = [
   'lightArmor2',
   'lightArmor3',
   'reinforced-armor',
+  'frost-aura',
 ];

--- a/src/state/slices/buffs.ts
+++ b/src/state/slices/buffs.ts
@@ -40,6 +40,7 @@ const initialState: BuffsSlice = {
     riteDwarf: false,
     exposed: false,
     lightArmor: false,
+    'frost-aura': false,
   },
   amounts: {},
 };

--- a/src/utils/assumedBuffs.ts
+++ b/src/utils/assumedBuffs.ts
@@ -14,6 +14,7 @@ export function createAssumedBuffs({
 }): AssumedBuff[] {
   const assumedBuffs = buffsRaw
     .filter((buff) => !buff.id.includes('jade-bot-'))
+    .filter((buff) => buff.type !== 'Aura') // would have to implement this in react-discretize-components
     .map(({ id, gw2id, type }) => ({ id, gw2id, type }));
 
   const jadeBotModifier = character.settings.appliedModifiers.find(


### PR DESCRIPTION
Implements frost aura as a buff. This required some plumbing since we didn't have "aura" as an option to render a buff.

Annoyingly, our gw2-ui library displays this as "Frost" with no way to override the text. I can implement the override, but I'm not going to do it now.