### PR TITLE
Fix template helper's detection of Clone damage

### DIFF
--- a/src/components/sections/results/TemplateHelper.jsx
+++ b/src/components/sections/results/TemplateHelper.jsx
@@ -172,7 +172,7 @@ const TemplateHelper = ({ character }) => {
 
           for (const { name, totalTargetDamage, targetDamageDist } of minions) {
             let type = 'Minion';
-            if (name === 'Clone') type = 'Clone';
+            if (name.includes('Clone')) type = 'Clone';
             if (name?.startsWith('Illusionary')) type = 'Phantasm';
 
             for (const skill of targetDamageDist?.[0]?.[0] ?? []) {


### PR DESCRIPTION
Arc now differentiates between the weapon type of each Clone, leading to names like Axe Clone instead of just Clone. Fix clone detection for this new naming scheme.