### PR TITLE
Improve template helper phantasm/minion loading

### DIFF
--- a/src/components/sections/results/TemplateHelper.jsx
+++ b/src/components/sections/results/TemplateHelper.jsx
@@ -423,6 +423,7 @@ const TemplateHelper = ({ character }) => {
           {Object.entries(inputOptions).map(([label, newInput]) => (
             <Button onClick={() => setInput(newInput)}>{label}</Button>
           ))}
+          <Button disabled>something else (i.e. mechanist)</Button>
         </ButtonGroup>
       ) : undefined}
 

--- a/src/components/sections/results/TemplateHelper.jsx
+++ b/src/components/sections/results/TemplateHelper.jsx
@@ -278,7 +278,7 @@ const TemplateHelper = ({ character }) => {
             .join('\n');
 
           setInput({
-            Power: roundTwo(powerDPSWithoutLifesteal - clonePhantasmDamageSum),
+            Power: roundTwo(powerDPSWithoutLifesteal - clonePhantasmDamageSum - minionDamageSum),
             Power2: roundTwo(clonePhantasmDamageSum),
             ...conditionData,
           });

--- a/src/components/sections/results/TemplateHelper.jsx
+++ b/src/components/sections/results/TemplateHelper.jsx
@@ -230,9 +230,6 @@ const TemplateHelper = ({ character }) => {
               return [`${type} DPS`, dps];
             });
 
-          clonePhantasmDamageSum = roundTwo(clonePhantasmDamageSum);
-          minionDamageSum = roundTwo(minionDamageSum);
-
           const result = [
             ['Duration (sec)', duration],
             '\n',
@@ -281,21 +278,23 @@ const TemplateHelper = ({ character }) => {
             .join('\n');
 
           setInput({
-            Power: powerDPSWithoutLifesteal - clonePhantasmDamageSum,
-            Power2: clonePhantasmDamageSum,
+            Power: roundTwo(powerDPSWithoutLifesteal - clonePhantasmDamageSum),
+            Power2: roundTwo(clonePhantasmDamageSum),
             ...conditionData,
           });
 
           if (minionDamageSum) {
             setInputOptions({
               'minions: use player power stats': {
-                Power: powerDPSWithoutLifesteal - clonePhantasmDamageSum,
-                Power2: clonePhantasmDamageSum,
+                Power: roundTwo(powerDPSWithoutLifesteal - clonePhantasmDamageSum),
+                Power2: roundTwo(clonePhantasmDamageSum),
                 ...conditionData,
               },
               'minions: unaffected by stats': {
-                Power: powerDPSWithoutLifesteal - clonePhantasmDamageSum - minionDamageSum,
-                Power2: clonePhantasmDamageSum,
+                Power: roundTwo(
+                  powerDPSWithoutLifesteal - clonePhantasmDamageSum - minionDamageSum,
+                ),
+                Power2: roundTwo(clonePhantasmDamageSum),
                 ...conditionData,
               },
             });

--- a/src/components/sections/results/TemplateHelper.jsx
+++ b/src/components/sections/results/TemplateHelper.jsx
@@ -277,26 +277,23 @@ const TemplateHelper = ({ character }) => {
             })
             .join('\n');
 
-          setInput({
+          const inputWithoutMinion = {
             Power: roundTwo(powerDPSWithoutLifesteal - clonePhantasmDamageSum - minionDamageSum),
             Power2: roundTwo(clonePhantasmDamageSum),
             ...conditionData,
-          });
+          };
+          const inputWithMinionPlayerDamage = {
+            Power: roundTwo(powerDPSWithoutLifesteal - clonePhantasmDamageSum),
+            Power2: roundTwo(clonePhantasmDamageSum),
+            ...conditionData,
+          };
+
+          setInput(inputWithoutMinion);
 
           if (minionDamageSum) {
             setInputOptions({
-              'minions: use player power stats': {
-                Power: roundTwo(powerDPSWithoutLifesteal - clonePhantasmDamageSum),
-                Power2: roundTwo(clonePhantasmDamageSum),
-                ...conditionData,
-              },
-              'minions: unaffected by stats': {
-                Power: roundTwo(
-                  powerDPSWithoutLifesteal - clonePhantasmDamageSum - minionDamageSum,
-                ),
-                Power2: roundTwo(clonePhantasmDamageSum),
-                ...conditionData,
-              },
+              'minions: unaffected by stats': inputWithoutMinion,
+              'minions: use player power stats': inputWithMinionPlayerDamage,
             });
           }
 


### PR DESCRIPTION
When using the template helper to load data from a log URL, this:

- automatically and unconditionally moves the phantasm+clone damage to the "power2" box, if present
- makes a set of buttons appear if there are non-phantasm-or-clone minions that include/don't include them in the "power" box, defaulting to "don't include" (as it's more obvious something should be changed if the wrong setting is selected that way)