### PR TITLE
chore: Remove CI action Rust compilation workaround

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -44,8 +44,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Cache Rust Output
+        id: rust-output-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            wasm_module/pkg
+            wasm_module/target
+          key: rust-output-${{ env.NODE_VERSION }}-${{ hashFiles('wasm_module', '**/pnpm-lock.yaml') }}
+          restore-keys: rust-output-
+      - name: Cache Rust Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: wasm_module
+        if: steps.rust-output-cache.outputs.cache-hit != 'true'
       - name: Compile Rust
         run: pnpm wasm
+        if: steps.rust-output-cache.outputs.cache-hit != 'true'
 
       - name: Build
         run: pnpm build-all

--- a/.github/workflows/previews-cf-dependabot.yml
+++ b/.github/workflows/previews-cf-dependabot.yml
@@ -43,8 +43,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Cache Rust Output
+        id: rust-output-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            wasm_module/pkg
+            wasm_module/target
+          key: rust-output-${{ env.NODE_VERSION }}-${{ hashFiles('wasm_module', '**/pnpm-lock.yaml') }}
+          restore-keys: rust-output-
+      - name: Cache Rust Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: wasm_module
+        if: steps.rust-output-cache.outputs.cache-hit != 'true'
+
       - name: Compile Rust
         run: pnpm wasm
+        if: steps.rust-output-cache.outputs.cache-hit != 'true'
 
       - name: Build Cloudflare
         run: pnpm build-cf

--- a/.github/workflows/previews-cf.yml
+++ b/.github/workflows/previews-cf.yml
@@ -53,8 +53,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Cache Rust Output
+        id: rust-output-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            wasm_module/pkg
+            wasm_module/target
+          key: rust-output-${{ env.NODE_VERSION }}-${{ hashFiles('wasm_module', '**/pnpm-lock.yaml') }}
+          restore-keys: rust-output-
+      - name: Cache Rust Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: wasm_module
+        if: steps.rust-output-cache.outputs.cache-hit != 'true'
       - name: Compile Rust
         run: pnpm wasm
+        if: steps.rust-output-cache.outputs.cache-hit != 'true'
 
       - name: Build Cloudflare
         run: pnpm build-cf

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -34,8 +34,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Cache Rust Output
+        id: rust-output-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            wasm_module/pkg
+            wasm_module/target
+          key: rust-output-${{ env.NODE_VERSION }}-${{ hashFiles('wasm_module', '**/pnpm-lock.yaml') }}
+          restore-keys: rust-output-
+      - name: Cache Rust Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: wasm_module
+        if: steps.rust-output-cache.outputs.cache-hit != 'true'
       - name: Compile Rust
         run: pnpm wasm
+        if: steps.rust-output-cache.outputs.cache-hit != 'true'
 
       - name: Test modifier and preset data
         run: pnpm testData


### PR DESCRIPTION
Removes #939, as it no longer seems necessary. 