### PR TITLE
export gw2-data and presetdata/metadata subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     "enable-hooks": "husky",
     "disable-hooks": "git config --unset core.hooksPath"
   },
+  "exports": {
+    "./gw2-data": "./src/utils/gw2-data.ts",
+    "./presetdata/metadata": "./src/assets/presetdata/metadata.ts"
+  },
   "dependencies": {
     "@discretize/gw2-ui-new": "^3.6.1",
     "@discretize/object-compression": "^1.0.3",


### PR DESCRIPTION
Expose specific source modules so external packages (the authoring tool) can import them as named subpath entries
- discretize-gear-optimizer/gw2-data
- discretize-gear-optimizer/presetdata/metadata 
